### PR TITLE
update thanos token secret required by slo-reporter

### DIFF
--- a/slo-reporter/base/cronjob.yaml
+++ b/slo-reporter/base/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
                 - name: THANOS_ACCESS_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: prometheus-reader
+                      name: slo-reporter
                       key: token
                 - name: EMAIL_RECIPIENTS
                   valueFrom:

--- a/slo-reporter/overlays/test/configmap.yaml
+++ b/slo-reporter/overlays/test/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: slo-reporter
 data:
-  thanos-endpoint: "https://prometheus-dh-prod-monitoring.cloud.datahub.psi.redhat.com"
+  thanos-endpoint: "https://thanos-query-dh-prod-monitoring.cloud.datahub.psi.redhat.com"
   smtp-server: "smtp.corp.redhat.com"
   sender-address: "aicoe-thoth@redhat.com"
   email-recipients: "aicoe@redhat.com"

--- a/slo-reporter/overlays/test/secrets.enc.yaml
+++ b/slo-reporter/overlays/test/secrets.enc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 items:
 -   apiVersion: v1
     data:
-        thanos-token: ENC[AES256_GCM,data:C0uDRHPmlxqN3GWw,iv:0aEjZAy59wo0wh6JmJ7WSPIZCuGOlj7dvWoS2psU59k=,tag:R9NkDgnZdkHZi4PkSjyKYA==,type:str]
+        token: ENC[AES256_GCM,data:pWhztGQCUZbmnQIKaMaYiBtMXJbdwpVTm2CtBWVRS5pLeNXmfe7PNktNsj+6dBGyXSz7SjrTKBYUlj1clsU2VxZ194JIi/YEiDRhZP97iwtSkYb+U+v1uUTbzC7XiwvEMhkWsqpfcj/YKDxP15pNpth3lRCAFWEpCzE2lpzVYNcNIyrsgf5nG4OSdWsfkxqpb4ftdYW4Qip3pPrRu6qIkDkIbDyxnVC8ykCHv6Y/U5F3RVuV7RKVHNjWUhM3wnM647GRbRL+qeNQ+VDlBMPdqNBKmhbsArgdQFed17JJXqG966xrD5EH44eZFunldAlIe1Bp6qtZXTRQBtDQqUDs6i2KKXl0vkwfgXeWQW/PVqUz1XPeEaO/rF9MgESc17RhsRyqI8HC2H3MS0kCYQfXKqxl5Hl7oXH3wV16UKK6ya5HihI7Z3lmQADPFmu7JzHBO4S9JinFdUSuZrUbFqaElmDPRKj8hDauGrNCh5ngko0bIU+bFYkbYjEuXKsxznhGSMNOCV6qZ+WwTlR73BjdK4PxHRp2c4Halm9jqVdDrdXAOSvYrSwuJ/jYdbc8LltaA6D+8q6ptfLIThkWytzLTJobiplUFbjcZOnAIth7vCO+hSbVtl6XctJL1EuLlytabKW7UF+iO8wek14sPin+Tah9Pn8jiljmGS8Gyua0zPExNqFoOdzh/sRkxS+dqwvv2qiwxx+ZHW4J6hrnEmEXMYO7r3LvWZjS3hrcK64o6tc0ap3rkh8Uj5XIw5b9o+b+eQcMV37efOZicwAtJbYHTfPe3v3Hud1239QU0AvMDpCUbuWi09551D3f9Um0bgpIA8NtNqmeAyaBJv0YeF5CvmW0cXma0m7V94hMzgHgmHGsMpgJ4xx8UtgSeqzsofQ5eEGkuM0Cl7oVQmOQCsE/uUwnNHbjqx1fnJQlNS7ARDqdZIkiZzUOnO8KX4DKAYrWsUFRrXBXxJBRm35ZvB9sGmo9b60gtxfGrGKCtWXwVxPRUE4vHe9Dnv0ByCxLEiKJ/a+AfjUfIeU11vZy0Po8V/xTRvn/QBtfpix0w6i+Q9uDd+mP1BdhfKwOJTfGsaUXRPgLCITzBzOerctdRC5u2ZP+UF6JnFcOddFH2xcAu743O5HF+/BPRcO7QI5uc1YD/voMMhR8FVDF3pCqeWvbALxWMY/cjgaiI87LqK8krdkqXJDVJo/OaoQjgzJYpFxTpKnaVoNdBlv4CTEnIpFB+8ALiYcuiPrL2kgpUM8to7WFOZKsPXuOGY/AlW6+ewewN6ECuVToRtdpSYiwcGrIfg4lMKDe8t/HI3LsXovv9gVGcffko58rwY/s4jOw/NxMDJyw5lh4u4dPBnbHPv/Ensmm4U7vfJWlsy57SnYqIhlXRKmhUlWclYP7Cldf8RvrXfDnnKc59iMhRDZfz5XfR45jpPUAq2eFy3+ar53iRnpS5Ub2MDAhiwm5YITcbwOGC62doIrRQU0bQytwVX2J93sizF2I8SHMzyZy16+iVrSuiQAkH4pQib5+9ugFUWLXyIe/Gk7LPXreYlA818Ux0Y9jbIzeOEppD5InzHb9b1vYv0yHik5L5h5yMB+l5xNdsEfeLE25yAfAveRuoSDL0A1wgQ8LfCr35FPm2cU5D8g6sJfh,iv:iobELpzGbNrXFZfLeZcQp1UO4qi399UnEG1Anj5TI8c=,tag:UHz4YvFfcxxMbmS+jVGr2w==,type:str]
     kind: Secret
     metadata:
         name: slo-reporter
@@ -15,58 +15,58 @@ sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2020-05-05T12:12:15Z'
-    mac: ENC[AES256_GCM,data:LFEAEd2RgMmoacgXk6eLdjfQm0QolFV3rGosgm81KlwUqVIIn3jwBBsil+MiL/eu7VNJkVHxMNilezQ93UQ35jXU7k4nVt43q0KJ+CWF98DPPzsdqKd+3s3m2hQvKujLf0mFQTfEn3CJnX9JFfHGlDY8/OvWll27mCJdtHYjEzE=,iv:jBzRu/ryHucaBXo1l+bqf84moRU8cXRF4aS01KxI9Mk=,tag:Xnc3bc7te1bC6vYjNQ8NXg==,type:str]
+    lastmodified: '2020-05-11T15:42:26Z'
+    mac: ENC[AES256_GCM,data:5AfocnWBRq+XoGGa0xiC4AUISOyDrtp45EWRpdiNhtqUCpSAuwVy5uvIePqh48ZwTSbky9AXznGxWzqXiY0Ue76lslLNYTJAcCYPhQurnx8tPleB8odyz+ze7vbIZdj+W3XT5y3oSjsLu5tKIuJ10zRBs3G7Ublg1U3SaTlXp14=,iv:e5+Y/HGoAkuuWhSGiyBZlswRMs+OmCRFR6zcV8PeleM=,tag:QoNBqtcVM7H/+PVGQK7cdw==,type:str]
     pgp:
-    -   created_at: '2020-05-05T12:12:13Z'
+    -   created_at: '2020-05-11T15:42:26Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA1gbAjViyxWYARAAc3RJHoquD2b5ctCNg6H0VrXjypEDqwYQLg43kPi+/1Mh
-            80Aw1JTmJ4A+XyEhu5XmgnA2pgwtFz+zbSZ45RwyhQ9jk9rNIbHNXmUqYqkDaBFo
-            wvgv2rT8yK8XAutGB2a20KRMpXrXfc+lGRgoam3EEVK3PPUCX6e96rITaI1FGPbH
-            3GJ1zT4lAxJHx1p5t8Rgd0j4lfvYXtzDVejukXcpeY1kGSSh00sBhy5prHKRAW8i
-            yq5OSrcmG4kwXC0PGHl+zOOEurg/Pv8tHMfe6x5MC6lrdEgqRHWUWCmau0ipMYva
-            rRA0XTsf6bfirQ7h8RqXo9m+KrVPHn3cj1CdV4KzNQgF/o/OqgLrR8a0jE8kVc9J
-            8D8UKDqyuAxj0dVePoYtSClno11Z99EGQNlQ6HTJ33F88/Co6dDF2oTHFJo4Tjm+
-            DdvAl44Rfn+R2LTiSxX+uV7QJH1j4kpvga343XCqPIFZtZaCBuzC+xQVtIQDUt4k
-            jqgVcOoLXoISQBaWFJZcGhT3FbwJZjH4DfgUDm36VYcsGuNPV2CuTJe53Y2ElVZV
-            5/my+jBx04xB4CBHGbKTASnCQz1yOflS/mF6tocOD1ykfmuMuR4M80atxRCNXHJ/
-            WjVv8mqzYRDpcCk6bmvLOV0CAGEHP5aSb+rs0bppkhpxbs1ZEB76pCIDxkHJ3yPS
-            4AHkRjSymRS5zhrKu+uY8zdH1uGS1uAq4C/hGingIOJwLMYn4G7luLnzYG0nRhLD
-            KRf9Yv4pRhPtDeaSaY1KVNjxbWm1N9bgA+TLwy4jVY10jRW0MLGaeQ4O4g95SBXh
-            DbsA
-            =Spa/
+            wcFMA1gbAjViyxWYARAAu2AKD0ERJIiTjufF4y8aymfdZoo2PH8fbsUw3156YMUC
+            j4i2Pun7///7ZVpbJv7Y+hrlDWiVDxG9KaHrSkabff6QFK/F1xjz6PySBtVzPyDd
+            c6CzhVwQt2qgbYbviPytzM+Z4dBW7rXMlyWLLR1Q/cWKEbyKLeAZ1Mu+I1nOaSvv
+            kdpaug40ZgkIsZO+gUJ9ohsRvH9HpjnVpyyiP2oHLze0Z3OpVwJvCCYGf2EVSgP7
+            Bq/Ob8dWSPNRj2pUyL6vJsl9+WvpqAt/0Ua5Ws/YEbeX6dNCaNgR8r82My8WA2OR
+            UM2BVes5rEVCyTPLX1CtHqv9pDbqPS7eId3bBVz4+ftatZFxG6mvydhe9YyoZzl2
+            ErtECsCqtEw05g49itIHQE0Gl1jAxNRlE/5OetR/dfptKJnCuWzL4s4Xyt9Uj76l
+            POXeALAir9xOiDZTOItY1HN3sO8rCbc/aSWbRYAaSgXmYk3AFlvb0k9VauOWxqAG
+            fEZbQL+8MkEdsqIJn7U5//FOlC5uptf5c/iyl91FA6urZ2LecPlWpgCrPHRp13Sx
+            0X/aNTWfISjX3fi0q76nbI1Ptexzr/IdmidRmpfq1P5214BJLQZK9yiMt3d2HkwH
+            3NnjklNjlQI9kJW4aNItKNtPM9BCb3ilvCeUI0ERiKwmhwoEilw4JeunGfsyaHXS
+            4AHk9/P0MRcBEiQBwDHl3wzsJOHlWeAO4HXhvR3g4eLZr5RZ4MXluDbP+CXAHbbQ
+            wteWpk/fiqcsmXiVFD3tJNq07iFXBTfga+QQHoFs3JApF1ZAFFyffiaE4i3Uq7nh
+            t9oA
+            =t2W2
             -----END PGP MESSAGE-----
         fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
-    -   created_at: '2020-05-05T12:12:13Z'
+    -   created_at: '2020-05-11T15:42:26Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA+/WpawS9RPbAQgAhrXePdklKhq8L4PoSJkUSL7/gCrubWF2wpgJX73nwWZg
-            N91nyBuzufm9xuY8P/fBfxSmdVncsUrqncFbLOp5pvU7oIQRwCFFAqYaGHVeg8Iq
-            wFHouyhIqaDtpWDVwAN8z45wChM4WKGOAivZjXIgk0PQQ3zo4PiDWTaFww5IFL6S
-            hGjGgXQNFlEaOaw5BYoJ/TLjPbR0DPEm00f6smsuqtm5gZ1RysQ0EfShpoamI9gi
-            4vCuby58ElhJZWK3F5C2Ab86pWj9hKAKPjY+27ahobzn2YpIqlw8/uJB88R2ZTuG
-            kUqupmbelBC2LQyAmSVossCu7zSChAB69dvWlKLMM9JeAYaTMWgUHTGbUMSJccWz
-            L00aDKxBLcIIMtmhrnQDi301dJeRu8v/LMdekwck7rQm+supGO9WpFCm3Fc8j5db
-            MpOtac09EEwn2VT/GPI78d22PZhZC8AMyXLUzcs2tA==
-            =bzP/
+            hQEMA+/WpawS9RPbAQf/a8qtiyYPZ/HuGCr9nh/FGMemivkec6scX1NkKVuG3r01
+            T06lwsbxEuYzsZq+JIrpNnaICLfL9CCMsgXbIeq5z8LbVvuWVhOjwgIpX+l4uv6G
+            9LguPadZdIFzR4ELXkH1isXNqzeT16J8I8wK/tsQmxEGh9n82i9m9GiegIVwbRZM
+            Nn6HtUs1CWlceuDQWyuu1Hmv6J/y1+kFkqRmWFqc6HTncQyONqnFq2LKMfLp0SDv
+            rk872X2THjzbqix7nBj9JgqIuw7KmPMaybZXJpzoIA5feuJhErTqko6pTmmVe1/B
+            PQqOg934ZzdVCpW2cAoxZHk8RE5n2jhobm4IC21pLdJeAbq3ceap89NVxP2M1V+m
+            jBN5LJ3eYRvQzF3NKOtVKHB9s7QpuT2Y4AIZbaLs0TxftG0KIX5rGwMfgY6TL6Dq
+            JMSfn3MnPvZYl2Wb+8bf+W9JP/c9eK/tMNkCOYt4AQ==
+            =ZULP
             -----END PGP MESSAGE-----
         fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
-    -   created_at: '2020-05-05T12:12:13Z'
+    -   created_at: '2020-05-11T15:42:26Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf+IA2u3x1YZqqGj0LiXj7ATeC5RV4IUKubo1ejwnZoWq4V
-            KU+5pTgvapEvRFvoA97vDXdTUmchZDNwPkK4fhd0HcrfQkKty409Heah7aDBEftC
-            TrWaLCv87efNtW2TiM1eJhXnyGW77UB6El+Tx+XtDXbqqQhxAbf78lP1GAxLeECt
-            VDO56HnMk+OG8Rf8dicefQXxgo9+KHzht+2/LE5ls93jBXLhtlkmdct7N9qVLueq
-            7zYNura++rWVi9l2kKYul167OcPEzHO8z4AM2dk3OxtpqYS7WGowqZG8K4WW/VX7
-            OlGvFEbFeC1/EB9lHVdArFEirLJexw0f1CT521x5ZtJeAUGIdRaLblxWdnxhE/c2
-            v1cNwLpGZdwxWNP4iYhgHIebHoXBhshbsvaU1vNhI7SMnDzLUQF/5/U2EfQSe010
-            cQw9/rdT3V/lqF7dTFWuFtjNC3OCC9jlJxFfywN8pA==
-            =bL1X
+            hQEMA/irrHa183bxAQgAmZFZEjPA2f68kbgZ3dij+sl46bm/lryh4t9o6I0qBD8g
+            qH8JuH20u/gKl0eAD6ymaGzfZK6k8v/+7kwq/TIwNAayZsINlQ+FFTKCO5TGEiqA
+            shuCoHRI1vPjO5cvd9850cY1Ik5NTQwhw9WW9KdH4M8qk+eXbwuPN4GKeZHbEJLx
+            27NBnvcE28K69fKLYqz3OC0l6HXOenvgnoHj2ph9bISI+dOU7f6BOzgpamGXOjeZ
+            Ws/ARBlaIahOVFwigTtUOmOmzOMl/uqVakavsctx0eJ2ik609myjck0aj4Stmg5a
+            UuM5JfqLhSDn5NqDratCt4DrLRbcGrvlH2esYhqhQ9JeAYCvRUFYI/8QqJ9tufpi
+            shO9wAQs7q5NWRW7UPIX5c/213xpl5V+M9K7Hv6Cl5/CoJpCLhcYF+kF9ZzIfMBg
+            5bfvNevNPHGbmDyK/i7PPffvvzMX2q4IHF+W1b45hw==
+            =+lXD
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
     encrypted_regex: ^(data|stringData)$


### PR DESCRIPTION
Signed-off-by: <hnalla@redhat.com>

## Related Issues and Dependencies

https://github.com/thoth-station/slo-reporter/pull/5

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

update thanos token secret required by slo-reporter
The value is taken from thanos-reader secret in thoth-test-core

## Description

slo-reporter uses thanos-token to connect with thanos deployment.
