### PR TITLE
[WIP] Let's reconfigure the transformer

### DIFF
--- a/core/base/commonlabels.yaml
+++ b/core/base/commonlabels.yaml
@@ -1,0 +1,5 @@
+commonLabels:
+  - path: spec/selector
+    create: False
+    version: v1
+    kind: Service

--- a/core/base/kustomization.yaml
+++ b/core/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+configurations:
+  - commonlabels.yaml
 commonLabels:
   app.kubernetes.io/name: thoth
   app.kubernetes.io/component: core


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies

#13 

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements

This configures kustomize's built in transformer for commonLabel and does not apply it to pod selectors. 

## Description

Using https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html#configurations which should be working since 3.4+ ... but isn't...