### PR TITLE
extend argocd to deploy workflow-helpers

### DIFF
--- a/workflow-helpers/README.md
+++ b/workflow-helpers/README.md
@@ -1,0 +1,3 @@
+# Thoth Workflow helpers
+
+This is a standalone ArgoCD Application for Thoth's Workflow helpers. It is meant to be deployed into a separate OpenShift Project, therefore it is not references from the `kustomization.yaml` file at the root directory of this repository.

--- a/workflow-helpers/base/imagestream.yaml
+++ b/workflow-helpers/base/imagestream.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: workflow-helpers
+spec:
+  lookupPolicy:
+    local: true

--- a/workflow-helpers/base/kustomization.yaml
+++ b/workflow-helpers/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml
+commonLabels:
+  app.kubernetes.io/name: thoth
+  app.kubernetes.io/component: workflow-helpers
+  app.kubernetes.io/managed-by: kustomize-ksops

--- a/workflow-helpers/overlays/test/imagestreamtag.yaml
+++ b/workflow-helpers/overlays/test/imagestreamtag.yaml
@@ -1,0 +1,13 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: workflow-helpers
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/workflow-helpers:v0.1.0-dev
+      importPolicy: {}
+      referencePolicy:
+        type: Source

--- a/workflow-helpers/overlays/test/job-generate-name.yaml
+++ b/workflow-helpers/overlays/test/job-generate-name.yaml
@@ -1,0 +1,3 @@
+- op: move
+  from: /metadata/name
+  path: /metadata/generateName

--- a/workflow-helpers/overlays/test/kustomization.yaml
+++ b/workflow-helpers/overlays/test/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+patchesJson6902:
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-

--- a/workflow-helpers/overlays/test/thoth-notification.yaml
+++ b/workflow-helpers/overlays/test/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have just successfully synchronized an ArgoCD application: *workflow-helpers*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-workflow-helpers|ArgoCD UI> This is TEST environment!!'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-fail-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':':fire: *FAIL* synchronizing *workflow-helpers* to *TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-workflow-helpers|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2


### PR DESCRIPTION
extend argocd to deploy workflow-helpers
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Based on other application I have included workflow-helpers content for deploying the workflow-helpers image.

## Description

Inclusion of workflow-helpers to argocd based deployment.
