### PR TITLE
Allow imagestream to auto update image

### DIFF
--- a/init-job/overlays/test/imagestreamtag.yaml
+++ b/init-job/overlays/test/imagestreamtag.yaml
@@ -8,6 +8,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/thoth-station/init-job:v0.6.0-dev
-    importPolicy: {}
+    importPolicy:
+      scheduled: true
     referencePolicy:
       type: Source


### PR DESCRIPTION
Allow imagestream to auto update image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Allows openshift image stream to pull image tag from base registry periodically to keep it refreshed.
Reference: 
--schedule flag
https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#adding-tag


## Description

Technically, 
whenever a project is updated with a new feature, a new tag is released based on that, 
so Thoth bot would work together to bring that change to the cluster. 
with the new tag, the tag get updated in thoth-application which enables argo to update the cluster. 
the flow works well when we keep on going incrementally on the tag. 

However as we sometimes work on stabilizing one tag for example v0.6.0-dev, as argocd already provided on the open shift, I m not sure, if an update `sha` of the same image gets updated by argocd.
so this PR would allow openshift to pull the image periodically sometimes.
If it feels relevant we can add that variable to other projects too.

@goern WDYT?