### PR TITLE
adding role bindings

### DIFF
--- a/metrics-exporter/overlays/stage/kustomization.yaml
+++ b/metrics-exporter/overlays/stage/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - role_bindings.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml

--- a/metrics-exporter/overlays/stage/role_bindings.yaml
+++ b/metrics-exporter/overlays/stage/role_bindings.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-exporter-from-infra
+  namespace: thoth-backend-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-exporter
+    namespace: thoth-infra-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-exporter-from-infra
+  namespace: thoth-middletier-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-exporter
+    namespace: thoth-infra-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-exporter-from-infra
+  namespace: thoth-frontend-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-exporter
+    namespace: thoth-infra-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-exporter-from-infra
+  namespace: thoth-graph-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-exporter
+    namespace: thoth-infra-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-exporter-from-infra
+  namespace: thoth-amun-api-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-exporter
+    namespace: thoth-infra-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: metrics-exporter-from-infra
+  namespace: thoth-amun-inspection-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-exporter
+    namespace: thoth-infra-stage


### PR DESCRIPTION
adding role bindings so that metrics-exporter can read-only from all namespaces

Signed-off-by: Christoph Görn <goern@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [X] No

Depends-On: https://github.com/thoth-station/thoth-application/pull/34