### PR TITLE
Provide workflow-role permission to agro-server sa

### DIFF
--- a/core/overlays/test/argo-namespace-install.yaml
+++ b/core/overlays/test/argo-namespace-install.yaml
@@ -9,6 +9,41 @@ metadata:
   name: argo-server
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflow-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-server-binding-to-workflow-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflow-role
+subjects:
+  - kind: ServiceAccount
+    name: argo-server
+    namespace: thoth-test-core
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argo-binding-to-argo


### PR DESCRIPTION
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

#44 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

these change would add a role which can watch, create, delete and patch pods, this role is bonded to argo-server for  OnPodCompletion - delete pods immediately when pod is completed 

## Description

The role permission issue was observed in the cluster. 
```
time="2020-06-23T18:33:09Z" level=error msg="Failed to delete pod thoth-test-core/volumes-pvc-mzgs6-19516656 for gc: pods \"volumes-pvc-mzgs6-19516656\" is forbidden: User \"system:serviceaccount:thoth-test-core:argo-server\" cannot delete resource \"pods\" in API group \"\" in the namespace \"thoth-test-core\""
```