### PR TITLE
include serviceaccount and roles for apps fucntion

### DIFF
--- a/graph-refresh/base/kustomization.yaml
+++ b/graph-refresh/base/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cronjob.yaml
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebindings.yaml
   - imagestream.yaml
 generatorOptions:
   disableNameSuffixHash: true

--- a/graph-refresh/base/role.yaml
+++ b/graph-refresh/base/role.yaml
@@ -1,0 +1,78 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: graph-refresh-job
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/exec
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - ""
+      - template.openshift.io
+    resources:
+      - processedtemplates
+      - templateconfigs
+      - templateinstances
+      - templates
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+      - image.openshift.io
+    resources:
+      - imagestreamimages
+      - imagestreammappings
+      - imagestreams
+      - imagestreamtags
+      - imagestreams/status
+      - imagestreams/layers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - cronjobs/status
+      - jobs
+      - jobs/status
+    verbs:
+      - get
+      - list
+      - watch

--- a/graph-refresh/base/rolebindings.yaml
+++ b/graph-refresh/base/rolebindings.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: graph-refresh-job
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: graph-refresh-job
+subjects:
+  - kind: ServiceAccount
+    name: graph-refresh-job

--- a/graph-refresh/base/serviceaccount.yaml
+++ b/graph-refresh/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: graph-refresh-job


### PR DESCRIPTION
include serviceaccount and roles for apps fucntion
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/graph-refresh-job/issues/398

## This introduces a breaking change

- [x] Maybe

## Description

Pull request contains serviceaccount and roles creation with binding them together, so graph-refresh-job can function.