### PR TITLE
use only required roles for graph-refresh-job

### DIFF
--- a/graph-refresh/base/role.yaml
+++ b/graph-refresh/base/role.yaml
@@ -6,29 +6,20 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - secrets
       - serviceaccounts
+      - secrets
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ""
     resources:
-      - pods
-      - pods/exec
       - configmaps
     verbs:
-      - create
-      - delete
-      - deletecollection
-      - patch
-      - update
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - jobs
-    verbs:
+      - get
+      - list
+      - watch
       - create
       - delete
       - deletecollection
@@ -39,8 +30,6 @@ rules:
       - template.openshift.io
     resources:
       - processedtemplates
-      - templateconfigs
-      - templateinstances
       - templates
     verbs:
       - create
@@ -50,29 +39,4 @@ rules:
       - list
       - patch
       - update
-      - watch
-  - apiGroups:
-      - ""
-      - image.openshift.io
-    resources:
-      - imagestreamimages
-      - imagestreammappings
-      - imagestreams
-      - imagestreamtags
-      - imagestreams/status
-      - imagestreams/layers
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - cronjobs/status
-      - jobs
-      - jobs/status
-    verbs:
-      - get
-      - list
       - watch

--- a/graph-refresh/base/rolebindings.yaml
+++ b/graph-refresh/base/rolebindings.yaml
@@ -10,3 +10,15 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: graph-refresh-job
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: graph-refresh-job-argo-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-admin
+subjects:
+  - kind: ServiceAccount
+    name: graph-refresh-job


### PR DESCRIPTION
use only required roles for graph-refresh-job
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

#58 
https://github.com/thoth-station/thoth-application/pull/77#issuecomment-655122673
https://github.com/thoth-station/thoth-application/pull/77#issuecomment-655123737

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

The application needs permissions to create the processed template, configmaps(graph-refresh-job roles), and workflows(argo-admin roles).
Tested this on test namespace in ocp cluster.