### PR TITLE
setup basic for cve-update application in ocp

### DIFF
--- a/cve-update/base/buildconfig.yaml
+++ b/cve-update/base/buildconfig.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: thoth
+    component: cve-update
+  name: cve-update-job
+spec:
+  resources:
+    limits:
+      cpu: 1
+      memory: 512Mi
+    requests:
+      cpu: 1
+      memory: 512Mi
+  output:
+    to:
+      kind: ImageStreamTag
+      name: "cve-update-job:latest"
+  runPolicy: Serial
+  source:
+    git:
+      uri: "https://github.com/thoth-station/cve-update-job"
+      ref: "master"
+    type: Git
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: s2i-thoth-ubi8-py36:latest
+      env:
+        - name: ENABLE_PIPENV
+          value: '1'
+        - name: UPGRADE_PIP_TO_LATEST
+          value: ''
+        - name: "THOTH_DRY_RUN"
+          value: "1"
+        - name: "THOTH_ADVISE"
+          value: "0"
+        - name: "THAMOS_VERBOSE"
+          value: "1"
+        - name: "THAMOS_DEBUG"
+          value: "0"
+        - name: "THAMOS_CONFIG_TEMPLATE"
+          value: ".thoth.yaml"
+        - name: "THAMOS_CONFIG_EXPAND_ENV"
+          value: "1"
+  triggers:
+    - imageChange: {}
+      type: ImageChange

--- a/cve-update/base/cronjob.yaml
+++ b/cve-update/base/cronjob.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cve-update
+  labels:
+    app: thoth
+    component: cve-update
+spec:
+  schedule: "@daily"
+  suspend: true
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 4
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: null
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: thoth
+            component: cve-update
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - image: "cve-update-job:latest"
+              name: cve-update
+              env:
+                - name: KUBERNETES_API_URL
+                  value: "https://kubernetes.default.svc.cluster.local"
+                - name: THOTH_LOG_CVE_UPDATE
+                  value: "DEBUG"
+                - name: RSYSLOG_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: rsyslog-host
+                      name: thoth
+                - name: RSYSLOG_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: rsyslog-port
+                      name: thoth
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: sentry-dsn
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      key: deploymentName
+                      name: thoth
+                - name: KNOWLEDGE_GRAPH_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: postgresql-host
+                      name: thoth
+                - name: KNOWLEDGE_GRAPH_PORT
+                  value: "5432"
+                - name: KNOWLEDGE_GRAPH_SSL_DISABLED
+                  value: "1"
+                - name: KNOWLEDGE_GRAPH_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: database-user
+                - name: KNOWLEDGE_GRAPH_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: database-password
+                - name: KNOWLEDGE_GRAPH_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: database-name
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "128Mi"
+                  cpu: "250m"

--- a/cve-update/base/imagestream.yaml
+++ b/cve-update/base/imagestream.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: cve-update-job
+spec:
+  lookupPolicy:
+    local: true

--- a/cve-update/base/kustomization.yaml
+++ b/cve-update/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml
+  - imagestream.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+commonLabels:
+  app: thoth
+  component: cve-update

--- a/cve-update/overlays/stage/imagestreamtag.yaml
+++ b/cve-update/overlays/stage/imagestreamtag.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: cve-update-job
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/cve-update-job:v0.6.0-dev
+      importPolicy: {}

--- a/cve-update/overlays/stage/job-generate-name.yaml
+++ b/cve-update/overlays/stage/job-generate-name.yaml
@@ -1,0 +1,6 @@
+- op: move
+  from: /metadata/name
+  path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/cve-update/overlays/stage/kustomization.yaml
+++ b/cve-update/overlays/stage/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: thoth-frontend-stage
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+patchesJson6902:
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-success-
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-fail-

--- a/cve-update/overlays/stage/thoth-notification.yaml
+++ b/cve-update/overlays/stage/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-success-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have successfully synchronized *cve-update* components to *TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-cve-update|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-fail-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':':fire: *FAIL* synchronizing *cve-update* components to *TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-cve-update|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2

--- a/cve-update/overlays/test/imagestreamtag.yaml
+++ b/cve-update/overlays/test/imagestreamtag.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: cve-update-job
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/cve-update-job:v0.6.0-dev
+      importPolicy: {}

--- a/cve-update/overlays/test/job-generate-name.yaml
+++ b/cve-update/overlays/test/job-generate-name.yaml
@@ -1,0 +1,6 @@
+- op: move
+  from: /metadata/name
+  path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/cve-update/overlays/test/kustomization.yaml
+++ b/cve-update/overlays/test/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: thoth-test-core
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+patchesJson6902:
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-success-
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-fail-

--- a/cve-update/overlays/test/thoth-notification.yaml
+++ b/cve-update/overlays/test/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-success-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have successfully synchronized *cve-update* components to *TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-cve-update|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-fail-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':':fire: *FAIL* synchronizing *cve-update* components to *TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-cve-update|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2


### PR DESCRIPTION
setup basic for cve-update application in ocp
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

#58 

## This introduces a breaking change

- [x] Maybe

## This Pull Request implements

Include cve-update-job  deployment via argocd 