### PR TITLE
Add metadata.name to cronjob

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -16,6 +16,8 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          name: mi-scheduler
         spec:
           containers:
             - image: mi-scheduler


### PR DESCRIPTION
## Related Issues and Dependencies
This PR fixes absent `metadata.name` from cronjob yaml in #67 

## This introduces a breaking change

- [ ] Yes
- [X] No