### PR TITLE
enable argoserver sa to access secrets

### DIFF
--- a/core/overlays/test/argo-namespace-install.yaml
+++ b/core/overlays/test/argo-namespace-install.yaml
@@ -16,6 +16,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get


### PR DESCRIPTION
enable argoserver sa to access secrets
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

`secrets "argo-artifact-repository-secrets" is forbidden: User "system:serviceaccount:thoth-test-core:argo-server" cannot get resource "secrets" in API group "" in the namespace "thoth-test-core"`

## This introduces a breaking change

- [x] No

## This Pull Request implements

Role would enable serviceaccount argo-server to list secrets and access them.
