### PR TITLE
Fix storing of dockerfile artifact

### DIFF
--- a/amun/base/argo-workflows/inspection-build-with-cpu.yaml
+++ b/amun/base/argo-workflows/inspection-build-with-cpu.yaml
@@ -234,13 +234,16 @@ spec:
           results="/mnt/build/"
           mkdir -p "$results"
           kubectl logs "{{inputs.parameters.inspection-id}}-1-build" > "${results}/log"
-          cat <<EOFEOF  | jq . > "${results}/specification"
+          cat << EOF  | jq . > "${results}/specification"
           {{inputs.parameters.specification}}
-          EOFEOF
-          cat <<EOFEOF > "${results}/Dockerfile"
-          {{inputs.parameters.dockerfile}}
-          EOFEOF
+          EOF
 
+          set +e
+          cat << EOF > "${results}/Dockerfile"
+          {{inputs.parameters.dockerfile}}
+          EOF
+          set -e
+          
           # Fail if the build failed but let the build log, specification and Dockerfile aggregated.
           exit `kubectl get pod "{{inputs.parameters.inspection-id}}-1-build" -o json | \
             jq '.status.containerStatuses[0].state.terminated.exitCode'`

--- a/amun/base/argo-workflows/inspection-build.yaml
+++ b/amun/base/argo-workflows/inspection-build.yaml
@@ -205,9 +205,11 @@ spec:
           {{inputs.parameters.specification}}
           EOF
 
+          set +e
           cat << EOF > "${results}/Dockerfile"
           {{inputs.parameters.dockerfile}}
           EOF
+          set -e
 
           # Fail if the build failed but let the build log, specification and Dockerfile aggregated.
           exit `kubectl get pod "{{inputs.parameters.inspection-id}}-1-build" -o json | \


### PR DESCRIPTION
Fix storing of dockerfile artifact
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #100 

## This introduces a breaking change
- [x] No

## This Pull Request implements

The copying content of Dockerfile doesn't require bash error checking.
