### PR TITLE
imagestream required for mi scheduler workflows

### DIFF
--- a/mi-scheduler/base/imagestream.yaml
+++ b/mi-scheduler/base/imagestream.yaml
@@ -6,3 +6,11 @@ metadata:
 spec:
   lookupPolicy:
     local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: mi
+spec:
+  lookupPolicy:
+    local: true

--- a/mi-scheduler/overlays/test/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/test/imagestreamtag.yaml
@@ -1,3 +1,18 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: mi
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/mi:v2.0.1
+    importPolicy: {}
+    referencePolicy:
+      type: Source
+---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
@@ -7,7 +22,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/mi:v2.0.1
+      name: quay.io/thoth-station/mi-scheduler:v0.1.0
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
imagestream required for mi scheduler workflows
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

The mi-scheduler cronjob was configured to wrong image.