### PR TITLE
Drop use-argo from configmaps

### DIFF
--- a/advise-reporter/base/configmap.yaml
+++ b/advise-reporter/base/configmap.yaml
@@ -4,5 +4,4 @@ apiVersion: v1
 metadata:
   name: advise-reporter
 data:
-  use-argo: "1"
   api-https: "0"

--- a/adviser/base/configmap.yaml
+++ b/adviser/base/configmap.yaml
@@ -4,5 +4,4 @@ apiVersion: v1
 metadata:
   name: qeb-hwt
 data:
-  use-argo: "1"
   webhook-callback-url: "http://qeb-hwt-aicoe-prod-bots.cloud.paas.psi.redhat.com"

--- a/management-api/base/configmap.yaml
+++ b/management-api/base/configmap.yaml
@@ -4,5 +4,4 @@ apiVersion: v1
 metadata:
   name: management-api
 data:
-  use-argo: "1"
   api-https: "1"

--- a/qeb-hwt-github-app/base/configmap.yaml
+++ b/qeb-hwt-github-app/base/configmap.yaml
@@ -4,5 +4,4 @@ apiVersion: v1
 metadata:
   name: qeb-hwt
 data:
-  use-argo: "1"
   webhook-callback-url: "http://qeb-hwt-aicoe-prod-bots.cloud.paas.psi.redhat.com"  # TODO: Add correct url

--- a/user-api/base/configmap.yaml
+++ b/user-api/base/configmap.yaml
@@ -4,6 +4,5 @@ apiVersion: v1
 metadata:
   name: user-api
 data:
-  use-argo: "1"
   api-https: "1"
   amun-api-url: "http://amun-api-thoth-test-core.cloud.paas.psi.redhat.com/api/v1"

--- a/user-api/base/deploymentconfig.yaml
+++ b/user-api/base/deploymentconfig.yaml
@@ -158,11 +158,6 @@ spec:
                 configMapKeyRef:
                   name: user-api
                   key: api-https
-            - name: THOTH_USE_ARGO
-              valueFrom:
-                configMapKeyRef:
-                  name: user-api
-                  key: use-argo
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

We no longer support use_argo configuration option to switch to old legacy workload-operator implementation.