### PR TITLE
perms for mi scheduler to lookup on configmaps

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -17,6 +17,7 @@ spec:
         metadata:
           name: mi-scheduler
         spec:
+          serviceAccount: mi-scheduler
           containers:
             - image: mi-scheduler
               name: mi-scheduler

--- a/mi-scheduler/base/role.yaml
+++ b/mi-scheduler/base/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mi-scheduler
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch

--- a/mi-scheduler/base/role_binding.yaml
+++ b/mi-scheduler/base/role_binding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: mi-scheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mi-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: mi-scheduler

--- a/mi-scheduler/base/serviceaccount.yaml
+++ b/mi-scheduler/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mi-scheduler


### PR DESCRIPTION
perms for mi scheduler to lookup on configmaps
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

```
"status":"Failure","message":"configmaps \\"mi-scheduler\\" is forbidden: User \\"system:serviceaccount:thoth-test-core:default\\" cannot get resource \\"configmaps\\" in API group \\"\\" in the namespace \\"thoth-test-core\\""
```

## This introduces a breaking change

- [ ] Yes
- [x] No
