### PR TITLE
kebechet secret required for adviser

### DIFF
--- a/adviser/overlays/test/secrets.enc.yaml
+++ b/adviser/overlays/test/secrets.enc.yaml
@@ -2,10 +2,21 @@ apiVersion: v1
 items:
 -   apiVersion: v1
     data:
-        WEBHOOK_SECRET: ENC[AES256_GCM,data:f9SbdmH6OUBIaThG2qOrVh4eom9ico7oGi5R867A6rIByo2541wL/uP7ox8=,iv:lhM6GU4/8yIu9yJ4WpzWHhScuusyFsLDRI9Hv5rPrKs=,tag:7iS4TPOljaqPx5tzcHZL2Q==,type:str]
+        WEBHOOK_SECRET: ENC[AES256_GCM,data:nS1hF3GmcLA51PKhUo8a9URmQdj8lj9hyqzzYJRIXyOv0Y/lkLPezBQsIi4=,iv:flZhGTN1LK+zaidfc88XCBWw1lDF5IojFnCkKtUJgT4=,tag:veXUHW7lGMAemYeLlm7yuw==,type:str]
     kind: Secret
     metadata:
         name: qeb-hwt-github-app
+    type: Opaque
+-   apiVersion: v1
+    data:
+        github-oauth-token: ENC[AES256_GCM,data:TVj/pOpG9gTHdeiVcgthI5jnaY5j6/GXICCkNfsXG8uDC4LJmbf7qB/hRijgxGGu/YPgUN00nGA=,iv:zApIRu7QVpqifXJrRHcKLI/9VBnmLibHlDhdVOZcX+o=,tag:qTAiPuVfKLO/BmxPw3ruJg==,type:str]
+        gitlab-oauth-token: null
+        kebechet-git-email: ENC[AES256_GCM,data:hfPSw6yKONhKaj6xk5APAX0O2gDoom0+flInJ85cjl0=,iv:+4/1IcdlTqCroRR8f6SlkmRdGIVizJdDuo5VNdKMw9U=,tag:zE7oO1vx212Cl5oFigpBTA==,type:str]
+        pagure-oauth-token: null
+        ssh-privatekey: ENC[AES256_GCM,data:/pjsaj47VF3sYDtlT57z1+yUj5TvfM8b5m32kx5QUF3tECjXlYDHWG8CLmrGPOwgXZjN7dQplrHl8PGylj583X30QQCUslRb4RdjPpRZDPydJavSh5IhKo3eTau/d6BkkIGSU2WfYHQVog39XVFpqxdOJkjvcSFj8/sjsb6XU5EMK8JvPmAD4CE/KKw57FZmTMoAK/gEvTVw9yzc0v+ntVrg5zEZNKZ28+ECyH2jGDANk2FUzvKr6t7vzK4siJH+WJjjCrozzPOHmoZpgBsF1zAOVqah4Pn2HuP6k/mCJC/Qlrqhpmi/RrUX0HEpdXBErJE2u3zMPsPPGBHurl6lnUkYOFRrUmmb7G4XOzVe6F5DonSipxkWeDR9SYPMydptI2Kq4TpZlEFIvksCv9XsqpHKKF45HFzsu6PtNNLAabXZ87GTn+zQs0CqMVKNTtM7MPbelzG09OzURkSypx1lncuXnHiDkZgQfkXenzwEMFGlKQgGgPakm9zq3G0I+p1HTB3MhMYnVmVfmtEi/7RgvyPGTzXDpR/GuTQwoxwpCjaZRzt+LHg4tAKYr0hhweWdryoRMOk/HOVlpWR32VBDqHyvqDWjbHBLb/6Jn4SspXLWU8Ed3npvNfHSdgVvDTjOHuntY97oPp0Pj6eQygTn6CPjPsPzBxpb+DxP6g1hGjIxN4L2mnEvaIwymqrz0WeWBuTuyKr5H2ywSFz5JknPU5Ovs1f5OfMOJW2FtL1Rffuwp5AHUH2YYUqU/eq81grgOxYK8brnU+tz1Wu5iQ3LvDEndfn1Rh06+gJSjJOH9aNbYSuHYTOIEkDZQbcwbqxepVX1RObviEKDxFEgzz7bRwjFZF/mC0ZtuHQIEdpAiAxXrWfF6Ug8mxRSsGHftnmguF+mOsUzwFp2W/VJcd8sQXjOlv7l81fZANyLZBKZQA2HZVdbXjJe6S51G5GjCPl9zrjeCz1LNJekW8ktqX6IGW6pkZ1sj+SXetmcZ5WLVAvcYNNYwM4FjvBbvug6HBvi6LVm+x8jxT8wqynEv1eM3+WjGFc+/FaPNYJ3zgAcy8XhC5W5rDK4YcDIX8OE372sEFlBNhg0oDt2NXoD/GlQtjPr75k+CprWXQ/fiG2HxXG/A2rUV8z1xLJvd82qeptDw3FOvTVgrTr/0uGx19+zZhU8SUkTaQ0+ZedW75UuajSTN4NFiA55PNGc4J6WbKWjMRbMTAhNQQmcmNCjYR9S7db10ccLkRWsq/QOHRSJlkJP0cdQcr9EQaMFV7CjhYcY0K5/4/whwPwwfNYprX8vK8oGAd2Q2y/Ipku0gkscKoajm98k+s1LtaTqayWW/1HEkZFF7CtQcpjI+Ow9ZKheojAJZV0yDgNHUPHyvlcqoCqFCBXPBIz51JQ6hY2mAeAnhhdRvL8qpQCOTuTwtH43G6iznvQSQc9ZwLiPEpGGIIN1RjvhjFcDyiQB8j2MHaSULFN+RoahYVoGVGJ/6Dc0Lib73XDgWbTRMafitQ/upe26HzPN0/zaUw0Hg8ffX5owuJf2+11Qw+r4GWAnvtuSUlEbBLqLAfqdg007suGXVOLPBuehJdfpf3hsWy+HPAIDY540nWNJyRlpIzuTFookfv7LUeReP6WGKufjfbR8Fz6itgNI4G54KPBBVtfxtT0Ko4/agDTReqQqLUZtKibigsRK8V4GIAKx18LARkDqKAiCgl31E6v106HFcD1/hrGBqqnFY+VMi+Y1hQK0UfpkPRnGpKC1EBHneG5tsyDUBrPJgrkLd/ZrrnRWgmexJSpSssY9XzhmCDPgYnWgGeKRHC5UzI7CgUH4XpiTQLEQA3Eb+GVX0SYmjG1258LhhmRydRZvTzGBiCN9O7WlK+acwWq7pnvpQ+6SpUHaH+wqHwuUEHuAdVHCCXQzEbCmoOr8V6yzPktLmDQZixoYEU7zzYu2PgY+2L8l2fx6hIdE8DCZV2R+VpUsm2tjFuKI/weqQwFu3nR4fJCnXRztpyVifbk62B4KaQdqnr9nTwjq4ri7ppj8jijFay+SK+5eLz7fUV47E5eMw3XNjGrdM9KEF6fqrOVhV2z5bYyQOxgCb5PhpbBYecs59sg75rBYuSP0uub0SPACWpOY2OJcX+opoG1d+UgsAEeAemWWQN60XhbDrMHvbJueD+P4yH9/Jzf5ZQS1su5sTyZ/mYtop432B6n53bjlZFq2ZaLCStdRoRJtwO7afdADUAyVMBWMn6DPM/lPcEb2hsI1ZcEp00sScihSntb5X9XFoajry3CclfKdCpbm5TSyuz17NulZXAJVrANX/2+aDvHa8rKMLSOIs+4oGJ6rBl7429F2m4R3QbvI67i5yno2HqEXydQUGIMpYgXdcHonzTG0TzQrhaBVjASbtUmGq3jTvdXSBsb+JAeegmS6dvBeutbsTozukFHOTyRHCP1jez15OAXniudFTM2Bx+6j4UKw0y5ZKW4+cpdPndl/eNgSqJCQBlvUz8tO3ca2VkbKK5/2eNDjYChSI8HLwWgBrHH8sWi/d96X3fhwwgyoF8juuFd4EC5/qznGPPjx115DTn8d/8lvtqFDmiaNmekipN9Pfb1ZiRGXKzXH7nh/PBFKSwDkaMYz9d7b7+49bJydGI5w5uaGw2OD0PyR64uh/+jMEO3mH7m17ZIWCSivs370Gw1+cNcfjMCDPcKFMJsPQWyU610oiGBAT1cpupmHjcZTRnu8Qc8kZJsXCjHOe9Ja6ZPs5Ze+QMVS0PNMBXiYqvdQkZpP7id/t6xxIVPZFkY7qyLpq1gs0Spkrr4qcaxbFLDwL5eEhln43mDjRLxOmizbIvTgnH4r4/tMileRyisFDsuzeml6vYlGjmiKNNqj13bdhce7q3aK1MyZ2+3RpFxhmUtzcEQn3I2i7/xaitaOg83AUR7sJ7fiui1kIDV78s78UHr+Nfu57YUse0GRz7VBMJqnz5qgepu87N25FHNQn2q3Pg==,iv:gM1MXvfXDkjDkchVP5Ep/elRDW10VXUAGww9MiNSqEM=,tag:YJsmNTvhEViaWiThwU3HAg==,type:str]
+    kind: Secret
+    metadata:
+        name: kebechet-secret
     type: Opaque
 kind: List
 metadata:
@@ -15,59 +26,79 @@ sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2020-05-18T10:00:29Z'
-    mac: ENC[AES256_GCM,data:pmlicHWGAKEMG+vs1GP4w1fPcc6H6nue96Sy3oM9zSH9Danr0Wa8SWAaIIyxgUsnj6Q3/sx6COFerYP5Htr0gg6X9RAB2cvsPUPB2RURako/w4Nna1qJtw2S89rrk/ffiRH96WEarvCMs294eDgjH1bCq+yflGKNP2rK/ILqe1U=,iv:kIMnnF4RMjkdVSchtj4TmoCMxX0xXRA6h4ieLzuZ34s=,tag:tulWvru59JW242dFfzMplA==,type:str]
+    lastmodified: '2020-07-20T15:33:49Z'
+    mac: ENC[AES256_GCM,data:KpPhpd9QVFvC8IQUM9c2bA38LbNM/XdvHZy210+Svjr4URzTFLLJBVytoQN6xjYqnUt8AWT/rTWUFV3/IA8UHJEitHe7HheSJNJE2jhwpQLtQWKoLaB5LEV1sfqEo26RFZ280bkayC2ZDapTih9v3Yjt1oGlO5528s9lcrXfF7w=,iv:PdmS0P3vw0w04sHkNMOZOEQ9mJBmUqgrPOWSqt8OqXc=,tag:vwTyyPN3TET7WO5cGrbNqQ==,type:str]
     pgp:
-    -   created_at: '2020-05-18T10:00:28Z'
+    -   created_at: '2020-07-20T15:33:49Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA1gbAjViyxWYARAAKR6d3VHafWKukUM36SqYiFRfHq9R7DI4K2JWi3fl45sm
-            SiOvzi07fQ4B2r/jMhcenmmSxcoE0T90xPMNt8MxSVXwftcn6Dvxvx9akHVGuldV
-            Bq/En/Y+CmwS4BDdhDxHqgQDla2wZrTRgsWmDSXDtG7i/FI2qjArfSOoz5HCpuYN
-            2vXphWaxP+uHOOGApGz5CFSjIFzgXDf6ayYEERrwedna5cie5e7o2FNOQcElnL7v
-            RWCHFnAvasOENhNLyiSvak6RkcGUy8Wb7hMe9oOlUAsDgWKzNHLRL+L1KcLLBTDq
-            SFLn6SCjnVanvtNG3WxXDgw0jedrXCaWj8TfcDmpPeFtrlqmixRGkWfopVILwlWg
-            WMHY2euEmjVW3NqeuD6zkDQ2YHEpJJ9HNwEyhwAWLW5gSiCTqa42fOloO8J04Otu
-            zk53ycjNVLVjJWuuI/CwYeAicrCuG+z1n3xvrO8UByDUplVJ/V2gqlbSJUqfdwTt
-            pHw7Ejj4Ik6GEqz2FsfCBA1nURihoQ8gDhGGb+fzi9Bc6g+7VmqQhN8SYoTv66DF
-            gMe/lXBiR+2p0qt+1KHiqHsI8A28qxwZeGAqw9VuqWpLVsZtpAPkDj0rOvcQe06C
-            kKHbN2S2okBp0j0D8ZDz6exhO6w139w94+tKqVXefByfI5cllDXsekHi1qmABV7S
-            4AHkWAWOXo5VdQT0/Og7XirRE+FsVOCl4Dzh3cvgl+IalbGx4LXl1NNmvARiqQWb
-            gt8w749sEF1vOvI97Fj+w/L3AuNDSxzgl+Tyk57W28Ob36kuobKJV1d34kEu77rh
-            CtcA
-            =2i5n
+            wcFMA1gbAjViyxWYARAAwsjp6pPY5zb7yItixPm25LMn10nnLCbQojlLr4PLTr1b
+            bOw3LwIthuMyvtuVLJbaFTFpHXU4XcoCTXyYxiVis29cvGuwMqzrJ7UuILxiGJOJ
+            fTmhJl3y/cNUDuYtP3b3SpnFkXqoV1IZPhDdeUWi2bmX0P5ia/ci+4rZ7N3Tb415
+            fAVAQj1dZGFBVgEKi36ATDoiZbxxDYFDunZStheDahdqfkydg9EtAdIcEKHdGfsU
+            5ifuA/wF9d28J/64Pguj/W/my0B7tKVpoYNlz8nCaEzuji0Npd2WyG39J/LNJxps
+            c2IbvRyh7UpCYGW4IBdZK9A2X2BS2ItHfas7ZNdutRaCqmnzh51bEj92T9uDsYB9
+            I3O9yQmEtm0ay3lxGwniFCzlG64E/MeKHNqw4iliqrAhLffhpniQZW9MP0H1o4fk
+            TorTcwMWb9LdXSifSM9KJb/6ZleRQR/+cQWM5ajLQMtr2IIQ8bJCt10bhZryqPnG
+            ZcLOQZR8FpNpBI2G2J/1pxAdDeQSv6rV2ML1fW6YAxMynk/W1JEQaRhVRnipolxM
+            4NQAGRIPcrs0VMnaV8HZByrGdAmeIl8wJV+QLpeQ99uqJNvNHZDs7rdyUfTtSKmW
+            ywq+93djwZoOJPOrZO2WOCCp5HyC38bU4TAgF0LBk6HEiWWqiov7ALZ9cVcAEYzS
+            4AHkXnTGlPltCW3bO2viQ0HNc+Eis+DI4BDhQrjgueIzxo5y4E/l9rIIZOK/vK8b
+            ipUA9X6W9zrT9SptmSD4N/6LMJ7vceDgReSKvGEzCvBvARhHxm7wcBBh4mjt/UPh
+            ylUA
+            =V9HQ
             -----END PGP MESSAGE-----
         fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
-    -   created_at: '2020-05-18T10:00:28Z'
+    -   created_at: '2020-07-20T15:33:49Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA+/WpawS9RPbAQf+MGLG2botD5uePixyId010m/m9QXXT0+BzfEbeW6FRlpx
-            v95o7/OPPmrtG/4idwImeP/215OFgl5xwstE9MiLy7VwjZUI3p7+Op1fiMFY0bp0
-            bGMxkKQRmeil0EQRQM2fDiKgwfYtJzh4yCs37Gs4uGMmxFE5GmqOt/kEyOeuAaSM
-            CJvAiW/VeGcjTgCrBg4o+7xZeELnPShNXaZIo+RFApo7vfJh+8b4//ADkb3zxv7V
-            MgdGwSQGeM3chjSbNfpTYJKmZ6eryIJPPMAUPc9beA+ileTsNDRgLLi0/1wxXYuq
-            Ru+dgq1zlqJEcdJE2AhAvKKrlZqi8eq6OsyZhW6kfdJeAbv40J7PhAJwHf/pawnr
-            V75tN9ntG8iFB2GU/PKLi6iMXY/oJMslJnJe20CKQrP0tAUH8bhMNar7dB/ILV98
-            XY0kx52nm9MtxDwd7wIghri5MbrPdqvtlljuLJwk9w==
-            =oqrO
+            hQEMA+/WpawS9RPbAQf/SdNjxqigGDFOYRRnsbSEiJuwxcadFFVFmGDMI5f8HJs2
+            o3IHsDgfd1mYWK28QWv70R48JcAoEplxorog6GmVAjKeztWDcu81nkCxeRLAUVzD
+            0bB6PvFCZh/Ff3JOpyDoKRNhbs5i5vjFhWNQQLC5A66atSEOAm41W/ePz0bSnbXH
+            tzbGvj7lLj7v857YAdzwcYXG/OZIYnwAzYyREwm0vMSx51zcdQTWdNoEuIpMHX/J
+            B4+VcKLi0aj0DBUEkYXw0KLxuxdpFvPaKq0N7fiCMRl2KVkcookZMExNgoI3jBCa
+            N+RErsRTEo4MkA2pBJdf4z3rkWV2ILU4yKkCAqST99JeAUsx9RKY7SwNzh07sTTo
+            HhHNoeLnO378wqhQiwZ8ZXAT9El/WeDhRF3jUZ+MIiBjdddMC2PT5x7ZASyvCDSE
+            B10NQ/J98H6AzDOISSw2Zd1qNAwKcdk1wPo+yMdjRg==
+            =Qn8h
             -----END PGP MESSAGE-----
         fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
-    -   created_at: '2020-05-18T10:00:28Z'
+    -   created_at: '2020-07-20T15:33:49Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf/f8V3qwU0z/Vt+Zo3a+X3C1SNZlNeNMahGHLO2p27C2Vf
-            D0VEPNDKHLtUSsIbwj6/CReb1G0XsogJRDMkYSM+1n4XvUE1C75egLsUQhCzLIhH
-            2HWpRfGCeiKOtWI7ORp/QgSxaegxPSYST2Os77DwcAXyFKxZlaH9cH0M9JVRAm1S
-            c6R4Yycz2SErvfHiOByjtpu6mY/MrtXrzrG26jsuEMT7DKG9BYuTYqcSXhyJISrn
-            cDh1KEmkWhLQ/SlJgsOHRSgtUXxD3RRCBBsgtZTpXxVZnDAyLdDx8NMw9f2duU68
-            LlMwiOogiZv4+Rg9YEPFAP36urPPTznHVEyBWKwordJeARfMqYijsyA82cKggwTc
-            BwMvWa/e2WPBIKA7MZR5jKxtg2ib8PNUWXUsj29wf72h3fuxkQd3TQuyPyfbU4FE
-            LzlYPz9Drt2NOxznGbIorlU0XtPIAWukcD7+h+u+3A==
-            =RKtw
+            hQEMA/irrHa183bxAQf9EnVBee96yE1mIZb0CAlnhpoKVgB+PWa4oFbOuNq8kkHF
+            mmkXYXk+5WhoP2qD1Pb5yj3X9xb2vIW15fik8jfHbjnGIPcA3m7VfJZUQnbV2PcV
+            EuGhG0YywS5XT0VyFj1uWhFkGxNkGjuiNa+m5Vlc6f5rn52Slo32Svk+HT5DfhT6
+            nNW4cT4dYevQFm65wGsYZPBPb156VYDv0eEelgAk9unx++n1kCaLtR0NtyAe3tNB
+            S5VHBLmcLFriEh7KLTQk1OvrRNbOJSEKeh64r2vp70gHJKZyPFdeLMzEw6ObW1Zs
+            ThEZS3E/lxESKA6wB9uP5+XCsZrOCap18aVoBM/B4tJeAZ9EyCwZC5V/fNvSPrEu
+            R1mu/iG1r84SH2W+eN+CT1+ZSFJoGO5HlCYcmGOFFLEyXV/vd3Ox6/T1MuMBRd+J
+            WCj6yXNfMIBgxPeje8NY0UfEN93Xyw+Uj8pycac3mQ==
+            =S4K/
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    -   created_at: '2020-07-20T15:33:49Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA7vMDF1jUn3mAQ/5AX3YN2APFRQQAvTq1Scc0kLnhjQbbbrIPXs5vbs36Fya
+            1mJrmcG+TAEkmXLrH3iv2YyjZi+mLYghVjhAu3rb+dfv6srPHB/YEUad66m2HdoW
+            NjB3vpvGT154F5r3cE/ZlPcUMIQuNhpOrs9zyNs3Ee0QyHqmTt1u0R9J501pMpxs
+            F1Gx3t+/7WX8nl6NMqu8OlNMBEm7/xifemo2mxAm9jYja4DjYQyg0OGZrRBzvvuV
+            wKnvOz0ji2wHWl/oQV8ICEicQv+nentdbaqpN8Wp7cU8yzdL8r3zuwGuz37dulb6
+            oBkshH1QV0MnXh7qy7fbnSSUOtq+gKzs7El5snnXZuV7vZGvPeUJRfUoREYfQn7s
+            NvN5Ktasd9f6OAXrSfLpnLAFFzMbNGjwYUM6YwCiLx+e0hyn4h/Pb1ht/ZAlaHqv
+            Rn/srgdAT+HVqJiIQQJbxY/Ksy99wH4B3oK0jyvwDh/TJvyG+COxuBiEx3a+ySs5
+            31yHA19QU1DNcmCyekDPql5lztCtjZEHvfZgWkPrFhwCw6yR9Y7DiGYPexQ/b4Lc
+            GBjaHIxDffqv/AZy/xLeLQ/tpLQCfaLjtoK5W29jbvGD+lbWG6JVJwL3QR/WW1Tz
+            t5+GRVkPbVO1I5QWd6dGn79LQiAHkGva4PzNZmH6j01lVUUuZkGxabs9ixqQl63S
+            XgHIpAdMMcM4NdHZ+c3vCh/fnRC9t+j/B9r6hlNML/BWvdXAu12x8hW/SXwdIucA
+            bI89R+wrUhIs0oIRBgWfnJGU5IE9TOmB3q3aVgiYrFmsNPfiSYfKL8c/ihXebE0=
+            =Qh0P
+            -----END PGP MESSAGE-----
+        fp: 68BD1529A372C8BA561C9DDC377298152D08B95B
     encrypted_regex: ^(data|stringData)$
     version: 3.5.0


### PR DESCRIPTION
:lock: kebechet secret required for adviser
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #129 

## This introduces a breaking change

- [x] No

## This Pull Request implements

Include kebechet needed secrets with the adviser.

## Description

kebechet secret are presently add to the adviser , we can further discuss on which other components need them.