### PR TITLE
Add middletier and infra namespaces vars

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -31,4 +31,14 @@ spec:
               env:
                 - name: APP_FILE
                   value: "app.py"
+                - name: THOTH_MIDDLETIER_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: middletier-namespace
+                - name: THOTH_INFRA_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: infra-namespace
           restartPolicy: OnFailure


### PR DESCRIPTION
## Description
`mi-scheduler` runs in infra namespace and it has to know which one is that
`mi-scheduler` then submits workflows for mi project, which is run in middletier, so that namespace specification is needed as well

