### PR TITLE
patch imagestream in kustomize for argo

### DIFF
--- a/core/overlays/test/kustomization.yaml
+++ b/core/overlays/test/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - configmaps.yaml
+  - imagestreamtags.yaml
 patchesJson6902:
   - path: job-generate-name.yaml
     target:


### PR DESCRIPTION
patch imagestream in kustomize for argo
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Argo cd application test-thoth-core, didn't update imagestream in cluster, when the changes were made in git.

## This introduces a breaking change

- [x] No

## This Pull Request implements

Included imagestreamtags to the Kustomize config, so argocd can see the difference in the image.

## Description

The imagestream tag would be patched when argocd application updates.