### PR TITLE
migrated build-watcher to deploy with kustomize and agrocd

### DIFF
--- a/build-watcher/README.md
+++ b/build-watcher/README.md
@@ -1,0 +1,7 @@
+# Thoth Build Watcher
+
+Watches for builds done in OpenShift and automatically submit newly built images to Thoth's image analysis.
+
+This is a standalone ArgoCD Application for Thoth Build Watcher.<br>
+It is meant to be deployed into a separate OpenShift Project,<br>
+therefore it is not references from the `kustomization.yaml` file at the root directory of this repository.

--- a/build-watcher/base/configmap.yaml
+++ b/build-watcher/base/configmap.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-watcher

--- a/build-watcher/base/deploymentconfig.yaml
+++ b/build-watcher/base/deploymentconfig.yaml
@@ -1,0 +1,139 @@
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  labels:
+    app: thoth
+    component: build-watcher
+  name: build-watcher
+spec:
+  replicas: 1
+  test: false
+  template:
+    metadata:
+      labels:
+        app: thoth
+        component: build-watcher
+    spec:
+      serviceAccountName: build-watcher
+      containers:
+        - name: build-watcher
+          image: build-watcher
+          env:
+            - name: KUBERNETES_API_URL
+              value: 'https://kubernetes.default.svc.cluster.local'
+            - name: KUBERNETES_VERIFY_TLS
+              value: "0"
+            - name: THOTH_LOG_BUILD_WATCHER
+              value: INFO
+            - name: THOTH_WATCHED_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-watched-namespace
+                  name: build-watcher
+            - name: THOTH_ENVIRONMENT_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-environment-type
+                  name: build-watcher
+            - name: THOTH_PUSH_REGISTRY
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-push-registry
+                  name: build-watcher
+            - name: THOTH_USER_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-user-api-host
+                  name: build-watcher
+            - name: THOTH_NO_TLS_VERIFY
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-no-tls-verify
+                  name: build-watcher
+            - name: THOTH_ANALYZE_EXISTING
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-analyze-exising
+                  name: build-watcher
+            - name: THOTH_BUILD_WATCHER_WORKERS
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-build-watcher-workers
+                  name: build-watcher
+            - name: THOTH_NO_SOURCE_REGISTRY_TLS_VERIFY
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-no-source-registry-tls-verify
+                  name: build-watcher
+            - name: THOTH_NO_DESTINATION_REGISTRY_TLS_VERIFY
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-no-destination-registry-tls-verify
+                  name: build-watcher
+              # If you watch for in-cluster builds, keep pass-token and have view rights assigned in
+              # service account.
+            - name: THOTH_PASS_TOKEN
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-pass-token
+                  name: build-watcher
+              # If you would like to analyze images pushed to external registry (transparent to build-watcher),
+              # provide credentials:
+            - name: THOTH_SRC_REGISTRY_USER
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-src-registry-user
+                  name: build-watcher
+            - name: THOTH_SRC_REGISTRY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-src-registry-password
+                  name: build-watcher
+            - name: THOTH_DST_REGISTRY_USER
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-dst-registry-user
+                  name: build-watcher
+            - name: THOTH_DST_REGISTRY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-dst-registry-password
+                  name: build-watcher
+            - name: THAMOS_DISABLE_TLS_WARNING
+              valueFrom:
+                configMapKeyRef:
+                  key: thamos-disable-tls-warning
+                  name: build-watcher
+            - name: THOTH_DEPLOYMENT_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: thoth-deployment-name
+                  name: build-watcher
+            - name: PROMETHEUS_PUSHGATEWAY_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: prometheus-pushgateway-host
+                  name: build-watcher
+            - name: PROMETHEUS_PUSHGATEWAY_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: prometheus-pushgateway-port
+                  name: build-watcher
+            - name: SENTRY_DSN
+              valueFrom:
+                configMapKeyRef:
+                  key: sentry-dsn
+                  name: build-watcher
+          livenessProbe:
+            failureThreshold: 1
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 1800
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "250m"
+            limits:
+              memory: "384Mi"
+              cpu: "250m"

--- a/build-watcher/base/imagestreamtag.yaml
+++ b/build-watcher/base/imagestreamtag.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: build-watcher
+spec:
+  lookupPolicy:
+    local: true

--- a/build-watcher/base/kustomization.yaml
+++ b/build-watcher/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - imagestreamtag.yaml
+  - serviceaccount.yaml
+  - role.yaml
+  - role_binding.yaml
+  - deploymentconfig.yaml
+commonLabels:
+  app.kubernetes.io/name: thoth
+  app.kubernetes.io/component: build-watcher
+  app.kubernetes.io/managed-by: aicoe-thoth-devops-argocd

--- a/build-watcher/base/role.yaml
+++ b/build-watcher/base/role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: build-watcher
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - pods/attach
+      - services
+      - configmaps
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch

--- a/build-watcher/base/role_binding.yaml
+++ b/build-watcher/base/role_binding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: build-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: build-watcher
+# roleRef:
+#   kind: ClusterRole
+#   name: edit
+subjects:
+  - kind: ServiceAccount
+    name: build-watcher

--- a/build-watcher/base/serviceaccount.yaml
+++ b/build-watcher/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-watcher

--- a/build-watcher/overlays/amun-api/configmap.yaml
+++ b/build-watcher/overlays/amun-api/configmap.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-watcher
+data:
+  thoth-watched-namespace: ""
+  thoth-environment-type: ""
+  thoth-push-registry: ""
+  thoth-user-api-host: ""
+  thoth-analyze-exising: ""
+  thoth-src-registry-user: ""
+  thoth-src-registry-password: ""
+  thoth-dst-registry-user: ""
+  thoth-dst-registry-password: ""
+  thoth-no-tls-verify: "0"
+  thoth-build-watcher-workers: "1"
+  thoth-no-source-registry-tls-verify: "0"
+  thoth-no-destination-registry-tls-verify: "0"
+  thoth-pass-token: "0"
+  thamos-disable-tls-warning: "0"
+  thoth-deployment-name: ""
+  sentry-dsn: ""
+  prometheus-pushgateway-host: "pushgateway-dh-prod-monitoring.cloud.datahub.psi.redhat.com"
+  prometheus-pushgateway-port: "80"

--- a/build-watcher/overlays/amun-api/imagestreamtag.yaml
+++ b/build-watcher/overlays/amun-api/imagestreamtag.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: build-watcher
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/build-watcher:v0.6.0-dev
+      importPolicy: {}

--- a/build-watcher/overlays/amun-api/job-generate-name.yaml
+++ b/build-watcher/overlays/amun-api/job-generate-name.yaml
@@ -1,0 +1,6 @@
+- op: move
+  from: /metadata/name
+  path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/build-watcher/overlays/amun-api/kustomization.yaml
+++ b/build-watcher/overlays/amun-api/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - configmap.yaml
+  - imagestreamtag.yaml
+patchesJson6902:
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-success-
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-fail-

--- a/build-watcher/overlays/amun-api/thoth-notification.yaml
+++ b/build-watcher/overlays/amun-api/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-success-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have just successfully synchronized *build-watcher* to *Amun* namespace, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/amun-stage-thoth-build-watcher|ArgoCD UI> 🚚'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-fail-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAIL* synchronizing *build-watcher* to *Amun*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/amun-stage-thoth-build-watcher|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2

--- a/build-watcher/overlays/test/buildconfig.yaml
+++ b/build-watcher/overlays/test/buildconfig.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: build-watcher
+  labels:
+    app: thoth
+    component: build-watcher
+spec:
+  successfulBuildsHistoryLimit: 1
+  failedBuildsHistoryLimit: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  output:
+    to:
+      kind: ImageStreamTag
+      name: "build-watcher:test"
+  source:
+    type: Git
+    git:
+      uri: "https://github.com/thoth-station/build-watcher"
+      ref: "master"
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: s2i-thoth-ubi8-py36:latest
+      env:
+        - name: ENABLE_PIPENV
+          value: '1'
+        - name: UPGRADE_PIP_TO_LATEST
+          value: ''
+        - name: "THOTH_DRY_RUN"
+          value: "1"
+        - name: "THOTH_ADVISE"
+          value: "1"
+        - name: "THAMOS_VERBOSE"
+          value: "1"
+        - name: "THAMOS_DEBUG"
+          value: "0"
+        - name: "THAMOS_CONFIG_TEMPLATE"
+          value: ".thoth.yaml"
+        - name: "THAMOS_CONFIG_EXPAND_ENV"
+          value: "1"
+  triggers:
+    - type: ImageChange
+      imageChange: {}

--- a/build-watcher/overlays/test/configmap.yaml
+++ b/build-watcher/overlays/test/configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-watcher
+data:
+  storage-bucket-name: ${THOTH_DEPLOYMENT_NAME}
+  prometheus-pushgateway-host: ${PROMETHEUS_PUSHGATEWAY_HOST}
+  prometheus-pushgateway-port: ${PROMETHEUS_PUSHGATEWAY_PORT}
+  sentry-dsn: ${SENTRY_DSN}


### PR DESCRIPTION
migrated build-watcher to deploy with kustomize and agrocd
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/58

## This introduces a breaking change

- [x] No

## This Pull Request implements

Includes manifests required for deployment of build-watcher.

## Description

As build-watcher would be a component that can be deployed to any namespace, tried to move the required information  in to the configmap for easy change by the user.