### PR TITLE
mi-scheduler need perms to view configmaps

### DIFF
--- a/mi-scheduler/base/role.yaml
+++ b/mi-scheduler/base/role.yaml
@@ -5,6 +5,14 @@ metadata:
 rules:
   - apiGroups:
       - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
       - template.openshift.io
     resources:
       - processedtemplates


### PR DESCRIPTION
mi-scheduler need perms to view configmaps
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

#139 #140 

## This introduces a breaking change

- [x] No
