### PR TITLE
Add GH access token to cronjob

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -41,4 +41,9 @@ spec:
                     configMapKeyRef:
                       name: thoth
                       key: infra-namespace
+                - name: GITHUB_ACCESS_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: sesheta-srcops
+                      key: github-access-token
           restartPolicy: OnFailure


### PR DESCRIPTION
`mi-scheduler` also uses the GH API for repository inspection (if it is archived, if it exists, or scan all repos of an organization)
therefore new env var with sesheta-srcops github-access-token was added to the `mi-scheduler` cronjob