### PR TITLE
Add secrets to resources for `mi-scheduler`

### DIFF
--- a/mi-scheduler/base/role.yaml
+++ b/mi-scheduler/base/role.yaml
@@ -7,6 +7,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
The `mi-scheduler` cronjob now uses `github-access-token` from `sesheta-srcops` secrets