### PR TITLE
use ceph based storage for postgresql

### DIFF
--- a/core/overlays/graph-stage/postgresql.yaml
+++ b/core/overlays/graph-stage/postgresql.yaml
@@ -29,7 +29,7 @@ items:
       resources:
         requests:
           storage: 32Gi
-      storageClassName: dynamic-nfs
+      storageClassName: standard
       volumeMode: Filesystem
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig


### PR DESCRIPTION
## Related Issues and Dependencies
better read-write connection.

## This introduces a breaking change
- [x] No

## This Pull Request implements

change pvc storageclass from dynamic-nfs to standard

## Description

use ceph based storage for Postgresql in stage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
