### PR TITLE
role_binding for management-api to schedule workflows

### DIFF
--- a/management-api/base/role_binding.yaml
+++ b/management-api/base/role_binding.yaml
@@ -10,3 +10,27 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: management-api
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: management-api-argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+  - kind: ServiceAccount
+    name: management-api
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: management-api-argo-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-admin
+subjects:
+  - kind: ServiceAccount
+    name: management-api


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #159 

## This introduces a breaking change

- [x] No

## This Pull Request implements

argo and argo-admin roles are required for scheduling workflows.

## Description

role_binding for management-api to schedule workflows
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

