### PR TITLE
Fix configmap reference for Prometheus configuration

### DIFF
--- a/adviser/base/argo-workflows/dependency-monkey.yaml
+++ b/adviser/base/argo-workflows/dependency-monkey.yaml
@@ -100,16 +100,11 @@ spec:
             value: "dependency-monkey"
           - name: THOTH_DEPENDENCY_MONKEY_REPORT_OUTPUT
             value: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
-          - name: PROMETHEUS_PUSHGATEWAY_HOST
+          - name: PROMETHEUS_PUSHGATEWAY_URL
             valueFrom:
               configMapKeyRef:
-                key: prometheus-pushgateway-host
-                name: thoth
-          - name: PROMETHEUS_PUSHGATEWAY_PORT
-            valueFrom:
-              configMapKeyRef:
-                name: thoth
-                key: prometheus-pushgateway-port
+                name: prometheus
+                key: pushgateway-url
           - name: SENTRY_DSN
             valueFrom:
               secretKeyRef:

--- a/adviser/base/argo-workflows/provenance-check.yaml
+++ b/adviser/base/argo-workflows/provenance-check.yaml
@@ -76,16 +76,11 @@ spec:
               configMapKeyRef:
                 name: thoth
                 key: isis-api-url
-          - name: PROMETHEUS_PUSHGATEWAY_HOST
+          - name: PROMETHEUS_PUSHGATEWAY_URL
             valueFrom:
               configMapKeyRef:
-                key: prometheus-pushgateway-host
-                name: thoth
-          - name: PROMETHEUS_PUSHGATEWAY_PORT
-            valueFrom:
-              configMapKeyRef:
-                name: thoth
-                key: prometheus-pushgateway-port
+                name: prometheus
+                key: pushgateway-url
           - name: THOTH_DEPLOYMENT_NAME
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes:
```
CreateContainerConfigError: couldn't find key prometheus-pushgateway-host in ConfigMap thoth-test-core/thoth
```

