### PR TITLE
place the package extract template in infra-stage

### DIFF
--- a/package-extract/overlays/stage/kustomization.yaml
+++ b/package-extract/overlays/stage/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-middletier-stage
 commonLabels:
   app: thoth
   component: package-extract
@@ -22,3 +21,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-failed-
+  - path: put-into-infra-namespace.yaml
+    target:
+      group: template.openshift.io
+      version: v1
+      kind: Template
+      name: package-extract

--- a/package-extract/overlays/stage/put-into-infra-namespace.yaml
+++ b/package-extract/overlays/stage/put-into-infra-namespace.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/namespace
+  value: thoth-infra-stage


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #155 

## This introduces a breaking change

- [x] No

## This Pull Request implements

The templates are placed in the infra stage.

## Description

place the package extract template in infra-stage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
