### PR TITLE
Amun API URL used in dependency monkey needs scheme

### DIFF
--- a/amun/overlays/test/configmaps.yaml
+++ b/amun/overlays/test/configmaps.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 data:
-  amun-api-url: amun-api.thoth-test-core.svc
+  amun-api-url: http://amun-api.thoth-test-core.svc
   deployment-name: ocp-prod-test
   infra-namespace: thoth-test-core
   inspection-namespace: thoth-test-core

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -10,7 +10,7 @@ data:
   backend-namespace: thoth-test-core
   middletier-namespace: thoth-test-core
   frontend-namespace: thoth-test-core
-  amun-api-url: amun-api.thoth-test-core.svc
+  amun-api-url: http://amun-api.thoth-test-core.svc
   infra-namespace: thoth-test-core
   solvers: |
     solver-rhel-8-py36


### PR DESCRIPTION
Otherwise, Dependency Monkey stores result in a file called `amun-api.thoth-test-core.svc` as it fails to detect service URL.