### PR TITLE
Add view verb

### DIFF
--- a/mi-scheduler/base/role.yaml
+++ b/mi-scheduler/base/role.yaml
@@ -29,3 +29,4 @@ rules:
       - patch
       - update
       - watch
+      - view


### PR DESCRIPTION
## Description
mi-scheduler cronjob currently still fails. A part of the error is:
 ```User \\"system:serviceaccount:thoth-test-core:mi-scheduler\\" cannot list resource \\"templates\\" in API group \\"template.openshift.io\\" in the namespace \\"thoth-test-core\\"","reason":"Forbidden","details":{"group":"template.openshift.io","kind":"templates"},"code":403}\n'```
and this could mean that the role currently set is not enough.

mi-scheduler has `list` added to the verbs and also apigroup `template.openshift.io` specified (https://github.com/thoth-station/thoth-application/blob/6818ef5fee948f46d56c116ad6e9a0e3bdd4bff6/mi-scheduler/base/role.yaml#L11-L17), however the openshift says otherwise.

was texting w/ @fridex and he suggested adding `view`, so maybe that could help

## Details
```2020-07-29 11:04:13,771   1 CRITICAL root:102: Traceback (most recent call last):
  File "/opt/app-root/lib/python3.6/site-packages/openshift/dynamic/client.py", line 42, in inner
    resp = func(self, *args, **kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/openshift/dynamic/client.py", line 245, in request
    _return_http_data_only=params.get('_return_http_data_only', True)
  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 334, in call_api
    _return_http_data_only, collection_formats, _preload_content, _request_timeout)
  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 168, in __call_api
    _request_timeout=_request_timeout)
  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 355, in request
    headers=headers)
  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/rest.py", line 231, in GET
    query_params=query_params)
  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/rest.py", line 222, in request
    raise ApiException(http_resp=r)
kubernetes.client.rest.ApiException: (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': '74be17ff-41ee-4401-9325-6c1655cbde76', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Wed, 29 Jul 2020 11:04:13 GMT', 'Content-Length': '393'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"templates.template.openshift.io is forbidden: User \\"system:serviceaccount:thoth-test-core:mi-scheduler\\" cannot list resource \\"templates\\" in API group \\"template.openshift.io\\" in the namespace \\"thoth-test-core\\"","reason":"Forbidden","details":{"group":"template.openshift.io","kind":"templates"},"code":403}\n'


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "app.py", line 99, in <module>
    main()
  File "app.py", line 74, in main
    schedule_repositories(repositories=repos)
  File "app.py", line 93, in schedule_repositories
    workflow_id = oc.schedule_srcopsmetrics_workflow(repository=repo)  # TODO Rename in common to mi
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/openshift.py", line 1348, in schedule_srcopsmetrics_workflow
    "workflow_parameters": {},
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/openshift.py", line 970, in _schedule_workflow
    return workflow(**parameters)
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/workflows.py", line 771, in submit_srcopsmetrics
    workflow_namespace=self.openshift.middletier_namespace,
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/workflows.py", line 485, in submit_workflow_from_template
    namespace, label_selector, parameters=template_parameters
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/workflows.py", line 188, in get_workflow_template
    template = self.openshift._get_template(label_selector, namespace=namespace)
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/openshift.py", line 676, in _get_template
    namespace=namespace or self.infra_namespace, label_selector=_label_selector
  File "/opt/app-root/lib/python3.6/site-packages/openshift/dynamic/client.py", line 94, in get
    return self.request('get', path, **kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/openshift/dynamic/client.py", line 44, in inner
    raise api_exception(e)
openshift.dynamic.exceptions.ForbiddenError: 403
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': '74be17ff-41ee-4401-9325-6c1655cbde76', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Wed, 29 Jul 2020 11:04:13 GMT', 'Content-Length': '393'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"templates.template.openshift.io is forbidden: User \\"system:serviceaccount:thoth-test-core:mi-scheduler\\" cannot list resource \\"templates\\" in API group \\"template.openshift.io\\" in the namespace \\"thoth-test-core\\"","reason":"Forbidden","details":{"group":"template.openshift.io","kind":"templates"},"code":403}\n'
Original traceback: 
  File "/opt/app-root/lib/python3.6/site-packages/openshift/dynamic/client.py", line 42, in inner
    resp = func(self, *args, **kwargs)

  File "/opt/app-root/lib/python3.6/site-packages/openshift/dynamic/client.py", line 245, in request
    _return_http_data_only=params.get('_return_http_data_only', True)

  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 334, in call_api
    _return_http_data_only, collection_formats, _preload_content, _request_timeout)

  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 168, in __call_api
    _request_timeout=_request_timeout)

  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/api_client.py", line 355, in request
    headers=headers)

  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/rest.py", line 231, in GET
    query_params=query_params)

  File "/opt/app-root/lib/python3.6/site-packages/kubernetes/client/rest.py", line 222, in request
    raise ApiException(http_resp=r)```
