### PR TITLE
upgrade postgresql pvc

### DIFF
--- a/amun/overlays/test/configmaps.yaml
+++ b/amun/overlays/test/configmaps.yaml
@@ -4,10 +4,7 @@ apiVersion: v1
 metadata:
   name: amun
 data:
-<<<<<<< HEAD
   amun-api-url: http://amun-api.thoth-test-core.svc
-=======
->>>>>>> 9322f50... :alien: setup amun stage deployment in ocp :neckbeard:
   deployment-name: ocp-prod-test
   infra-namespace: thoth-test-core
   inspection-namespace: thoth-test-core

--- a/core/overlays/graph-stage/postgresql.yaml
+++ b/core/overlays/graph-stage/postgresql.yaml
@@ -28,7 +28,7 @@ items:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 32Gi
+          storage: 96Gi
       storageClassName: standard
       volumeMode: Filesystem
   - apiVersion: apps.openshift.io/v1

--- a/mi-scheduler/base/role.yaml
+++ b/mi-scheduler/base/role.yaml
@@ -27,4 +27,3 @@ rules:
       - patch
       - update
       - watch
-


### PR DESCRIPTION
upgrade postgresql pvc
from 32Gi to 64Gi, we have 120 Gi storage limit in the clusters.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>