### PR TITLE
amun workflow requires pod logs access

### DIFF
--- a/amun/base/role.yaml
+++ b/amun/base/role.yaml
@@ -69,6 +69,8 @@ rules:
       - ""
     resources:
       - pods
+      - pods/log
+      - pods/status
       - configmaps
     verbs:
       - get


### PR DESCRIPTION
amun workflow requires pod logs access
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

`Error from server (Forbidden): pods "inspection-test-name-e1fa146d-1-build" is forbidden: User "system:serviceaccount:thoth-test-core:amun-api-workflow" cannot get resource "pods/log" in API group "" in the namespace "thoth-test-core"
`

## This introduces a breaking change

- [x] No

## This Pull Request implements

give role perms for pods/logs.
