### PR TITLE
amun workflow requires pods patch access

### DIFF
--- a/amun/base/role.yaml
+++ b/amun/base/role.yaml
@@ -69,9 +69,19 @@ rules:
       - ""
     resources:
       - pods
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - pods/log
       - pods/status
-      - configmaps
     verbs:
       - get
       - list


### PR DESCRIPTION
amun workflow requires pods patch access
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Forgot to add this in pervious PR: #190 