### PR TITLE
amun stage deployment fixes

### DIFF
--- a/amun/base/argo-workflows/inspection-run-with-cpu.yaml
+++ b/amun/base/argo-workflows/inspection-run-with-cpu.yaml
@@ -81,7 +81,7 @@ spec:
           - name: volume
       initContainers:
         - name: inspect-hwinfo
-          image: inspect-hwinfo
+          image: amun-inspect-hwinfo
           volumeMounts:
             - mountPath: "/home/amun/results/"
               name: "{{inputs.parameters.volume}}"

--- a/amun/base/argo-workflows/inspection-run.yaml
+++ b/amun/base/argo-workflows/inspection-run.yaml
@@ -65,7 +65,7 @@ spec:
           - name: volume
       initContainers:
         - name: inspect-hwinfo
-          image: "inspect-hwinfo:latest"
+          image: "amun-inspect-hwinfo:latest"
           volumeMounts:
             - mountPath: "/home/amun/results/"
               name: "{{inputs.parameters.volume}}"

--- a/amun/overlays/amun-inspection/argo-namespace-install.yaml
+++ b/amun/overlays/amun-inspection/argo-namespace-install.yaml
@@ -123,3 +123,13 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: workflow-controller-configmap
+data:
+  config: |
+    containerRuntimeExecutor: "k8sapi"
+    parallelism: 10
+
+    # metricsConfig controls the path and port for prometheus metrics
+    metricsConfig:
+      enabled: true
+      path: /metrics
+      port: 8080

--- a/amun/overlays/stage/kustomization.yaml
+++ b/amun/overlays/stage/kustomization.yaml
@@ -3,9 +3,9 @@ kind: Kustomization
 resources:
   - ../../base
   - role_binding.yaml
+  - configmaps.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
-  - configmaps.yaml
   - imagestreamtag.yaml
 generators:
   - ./secret-generator.yaml
@@ -34,19 +34,19 @@ patchesJson6902:
       version: v1
       kind: Role
       name: metrics-exporter-reader
-  - path: put-into-api-namespace.yaml
-    target:
-      group: ""
-      version: v1
-      kind: ConfigMap
-      name: amun
-  - path: put-into-api-namespace.yaml
-    target:
-      group: ""
-      version: v1
-      kind: ServiceAccount
-      name: amun-api
 
+  - path: put-into-inspection-namespace.yaml
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: kubectl
+  - path: put-into-inspection-namespace.yaml
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: amun-inspect-hwinfo
   - path: put-into-inspection-namespace.yaml
     target:
       group: template.openshift.io
@@ -83,18 +83,6 @@ patchesJson6902:
       version: v1alpha1
       kind: WorkflowTemplate
       name: inspection-run-template
-  - path: put-into-inspection-namespace.yaml
-    target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: Role
-      name: metrics-exporter-reader
-  - path: put-into-inspection-namespace.yaml
-    target:
-      group: ""
-      version: v1
-      kind: ConfigMap
-      name: amun
   - path: put-into-inspection-namespace.yaml
     target:
       group: ""

--- a/amun/overlays/stage/secrets.enc.yaml
+++ b/amun/overlays/stage/secrets.enc.yaml
@@ -1,21 +1,29 @@
 apiVersion: v1
 items:
 -   apiVersion: v1
-    data:
-        app-secret-key: ENC[AES256_GCM,data:FzT/9hBFBpygTkoG,iv:V3YU8lTgN92A6Sp/kAUqQGbXsTGRVIf7p4txuNPhmoI=,tag:qrK7vKmAR/FbEQX2K8qvsg==,type:str]
-        sentry-dsn: ENC[AES256_GCM,data:QE/qsMrBE7dYary40dMV+7tq6wTTSIIMepwO1bWNZkS4SPujP9OoP/AnIVJQt/pwGD/WNYAkvb/otjL6Hi1Q6YTk3gLe9Zj1KxJxKknts2k=,iv:GZqfmQPcMCZ3b2cLFMdcpTefWMmeanaYipdYyVg9QQg=,tag:U/mEt2xX8PFMandc919ZUA==,type:str]
     kind: Secret
     metadata:
         name: amun
+    data:
+        app-secret-key: ENC[AES256_GCM,data:OQ3IiJoS3DF3fc5n,iv:PF0Gd5lCZNvpbx4AU5h6X/M+rW3GfvClBz7jhwPGngM=,tag:99s8ADkNRv7e9y6f9gPxNQ==,type:str]
+        sentry-dsn: ENC[AES256_GCM,data:6vdUXZgzw+r9Ncq2GuPaCsTUBNfLRvvjnt7v09tZi/wJ9OKmv9+naMP2ssVCYtv2cKj7x2fTb+ECQ4c+2LOSm6zjt9bSvh4EUK6Nvqlkx/Q=,iv:p2j/bibNNMxnLBhDMyaMSKn7iOTwo9hXRVpfoYWB9Fg=,tag:DcpPBtmaLaPmN4ZVrM7Vgg==,type:str]
     type: Opaque
 -   apiVersion: v1
     kind: Secret
-    type: Opaque
     metadata:
         name: ceph
     data:
-        key-id: ENC[AES256_GCM,data:Af+xp2wCVU3qxsyYMcN5/JidOiNgH99uT0zVIg==,iv:l2mhbnRaNMPkaWys/c8JMYrXGfuadu61Csfi3LNfRro=,tag:QfqPiQmv2Yoo7RdMXYsuUg==,type:str]
-        secret-key: ENC[AES256_GCM,data:L9TpntQpHJEI1GCvt2HhTzo25VPt+z7wPNkoCBJ3EbZSqzM7ChV9+S5q+bolpgUevn2vqigvAnM=,iv:NhD7X2WA8aSIekN/rdBK1u180SUVYkWpTVYJkj7hhtk=,tag:QELh0pNGeAGtGp3ZYgTeLg==,type:str]
+        key-id: ENC[AES256_GCM,data:CjtpeOzxbcLgaHRZQt3anR7dDJ1UI3jz1Boulg==,iv:0ZbEy24h06BmTemQb6VM5BG/TWKZrMRgOc11Jn0Aeug=,tag:FrRbaX5rTyLc6lTE3yALVg==,type:str]
+        secret-key: ENC[AES256_GCM,data:7g6qyvy3BTDjqnf2RE/+Vs9ClHzeTJqqyVUA63r8YQwjJqnPkoNTLZek1UdNjxXKPZmH0EytvsI=,iv:YictaqigOejOPZf6rabd9e731kGYM3pqHfjkTqWMdkY=,tag:fkHq2m5IPXxk7wpJjE+gxg==,type:str]
+    type: Opaque
+-   apiVersion: v1
+    kind: Secret
+    metadata:
+        name: argo-artifact-repository-secrets
+    data:
+        accessKey: ENC[AES256_GCM,data:gV6t3f5ICkBxzzbNopwitphoK3B08aPb4ZQXRA==,iv:cjc/yUO1buu0GvzHPQKLagsynagpT07uLQYLLJ3As5Y=,tag:wWJ/MN6Il6BkP2dH7Qq0fQ==,type:str]
+        secretKey: ENC[AES256_GCM,data:yEnJgMBHnRobhhJMSCpV2R6l6J3NHu7znU/OBC8zDerYolcquZTjQZHh8SvfBXDZ+zLObyBUo7o=,iv:dpYknMxcQ7hPLJlnm6y3iZ0UHfkYspiRCwFUS3qSLKA=,tag:gC+66C7O62xS4qI2il589g==,type:str]
+    type: Opaque
 kind: List
 metadata:
     resourceVersion: ""
@@ -24,78 +32,78 @@ sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2020-07-20T20:24:17Z'
-    mac: ENC[AES256_GCM,data:zkenx7gcjH0bnbVjb0aayapodYZ6whYaZ4IJ5tCfyMFxARRiST1myMcwgxqqWnUYZGiOq2tvOJNFIHmZ5Jrwk8OFsPae+e3LDISgQhqNow9N/8Kt9DwO0ZvBBkGG9Uuo1E9nrIE1IgJrt2YJP1Z2gQNy+6iWK5tv4neAn+QTK4s=,iv:7UXIFJw4bkOsr8tIuXUQSOgvKP5AK5Kjpye0aPpoDOM=,tag:GsL4ecCgL1SrvgmNmVb4Kg==,type:str]
+    lastmodified: '2020-07-30T20:10:52Z'
+    mac: ENC[AES256_GCM,data:ApPwm7zZ5AwnM+H7tNfjVHL9C+c4HoatygV8dCFPFyrbfED0L6xS4K3wY5FXUdgZUZafX0qcO/exaYeeckevWcSZNP504k3vPmF0stFwSEW9P+IoT5QOnu5NYhD8xwWV5+IebSQT6Q4YYwDqameWYU/lOHs3qhkdCKa0JGPOEA4=,iv:rjow4Rp1Z0X63CchNtFBci5sRT6qDrCQtFczImTZ7hA=,tag:UWyfWzQ6VAU8l2f9sT/rEw==,type:str]
     pgp:
-    -   created_at: '2020-07-20T20:24:16Z'
+    -   created_at: '2020-07-30T20:10:52Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA1gbAjViyxWYARAADtTxM1B/OJTcYIzXhjxxFttFfWGtPIiWyRqd9h4nTIIl
-            XvF0mNsAXk2ZMxN2GQZG+uhnIhH86RhJQbdrSBCAGXPHhz/3iHZJFbho02Vaq7b0
-            5sCf9ibapW0EsnblL3Hw+XwG1XgL7iFE9dQni/DF0aAnjQhtneWmfxOw9Doe564C
-            /J0MDc2xhflpDrR8I/H7+o8bA3YrLjCW2cZqAyVyLK0sHt6VR0AbSjLqHuqUgCVI
-            +44mXyuBqVZwJFN4WEzp8OhrphZeHNVUxYVNjgHZtVI3aWt/hmXCz1M6Gn6EoB7v
-            CaxGwOIkvwuc20v6bx/kmKm6fEKjixdyMDnr378oOPSEZiezkUh8F9cjwXdpqT4K
-            c9vf5RftNLEt/ahFhjRaIOov+2giIKADNikfmG3pMAMCItU3hfd0NQ2KvV36rs8G
-            orE9m9GalH6kjbYXVIRUYB5R4Zt7Pr+7qSmlG1NxgYW/vEBpntzbwRjuxcmLfw9W
-            1pDh03Q29Y90UBuTSQFODWg+x0gMFJ2BZEH/Sj8bgvqlNAW97W/wVFIAqv8mjz4R
-            DtUIkZaPaPdz4Hqct4WcjQA06gZcAUEaYQQHegBrAKweuMlJIt/EnrJi45Dvr6kh
-            tZ4AYSuP9ScWqwu/eeq7hkYJEtC7ga9tUfPEX8JvAfXWvGExXbuLvyZTFjK2T8TS
-            4AHk+b8bzU4cy6QfDDiW5U2KCeEvJeBM4A7hjJjgDeJbPT+f4PLlkn+Rq/jGlmBo
-            gftsrh9seAzOz5PqC26VqX0ZeWvrEuzg3uTuXa6Wxop64t3yvVK92TXK4nxKGJXh
-            i/gA
-            =B/v1
+            wcFMA1gbAjViyxWYARAAx90qXEBu6GaOPLf1v8dUhE7uKLFe/x022g9Nn+hH0SI4
+            g1MxGXe2NxSOtWYmy9x1kV0ihr07nQsnH3vJqtSNll4HcGUxqSAicHtVPawxldyY
+            2MqMfORUNbqBetMcInNRtSEN8N2yzES8uTpmgd7u5TMIvasU6tRTyVOHO3VKZNNI
+            ilQfKNdozw0raWlIJl83jRSnixEYVCdi3Nc5aSgsfNzlk804HK4p9h/aM1nTbBZJ
+            HDRwXBpyB22QpTGwdk1U57PEnZotHz7YJUg87PkSEPk+Cf36TbNqV2FEPSgr35T9
+            kV8EFrvLM3P88/azDjRiRbGijrkE12NSdzGwyLHXcTXWEZ3Idy/zFM0TVqbob2+Q
+            8Ocj5OmoJy6wRM/WPh37QSkmagHX81Nf1b8l+gtD67nry6gjlpdr3cxuUUuQoE8r
+            tNcC79ioOgS6LAi0QwxWA2r19GNQUfoFbH2F0t+idMOyQM8WS2ZUYC4orG49G/aw
+            NRvvo8/Wxh7Nj1HFZji8kDH4XMbg8K0KanlFcUXVvNPRdp2Nve1783w266R5rE5M
+            KyWukvffRiJtXYkzbURZWKQ39n4vZRsi7sI2HruhJbr691WTncViWTsYDv8dlPp9
+            7Bgm70AbyLYsvVrPbeBr6S4qv2TvZ1cATlnb+YC6SH6IaJ4G5IB7s5iaV54UXvzS
+            4AHkiR7jxZ+mbg9bQICHB+eswOGACuDU4KXhhijgOeLRYJMn4J7lQci9DWoz6RWt
+            Kgywu6In6kkeZY+jPFSnej7owUTmcu7g4uQjMbgdAsadeCroYLBCKB9y4pJUq4Hh
+            M+AA
+            =MAWB
             -----END PGP MESSAGE-----
         fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
-    -   created_at: '2020-07-20T20:24:16Z'
+    -   created_at: '2020-07-30T20:10:52Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA+/WpawS9RPbAQf9F9YstXXSuSLfZzV2i9qH8LVHwl/16frybYwsjymq63Nk
-            +32dCXEIUinYR5VqMuflmXoNQXFTqso5Efw0h9EyavLPxAwvm5DOEdR5s3kczoyR
-            ItxNhn1R6eZqdzdPFv46Qp/+81p1Vi0ldkVhzeidkGOyy9tcPQxBMBDeaCjqLuRp
-            +nNHontJwFqoaQH5b0yXY7l+B7ozqbzn/z+XX/Vm/H04kBPIud0ZVtlMMN9nR5Jy
-            jQKGcnp0psfpG7RIZHU1LDIEVvsLwPtVXCqyzzaUCwg7NN5lmq5/T9Lk2rxf+Otv
-            770TKLzkYbSoI9QHOsytX3mfMnb7h4+uR1pkHf4oi9JcAZ1UT6pv5bg0oHPthJZP
-            hHAFuyl/1Xh1JkK8U3fTK2RW/pmuX54jFEqukhE5qTHbAJwm0CkXE+mlft1BZeXL
-            WLFdu49i3PvMyvzblOWqQU/7lVvQMrcWsyZREjw=
-            =ty0g
+            hQEMA+/WpawS9RPbAQf/bWA0eCb3Hh69d6EqXoPeysJQTXYN8BvrrE8nHBbeFcxx
+            wlANCBaWAK8WpRXopBZuGbnYlZbcsuGy4MxUeSonifrJunZuRyaMO5zZrhi2v2Q+
+            LVs5mAFPfHb7ghF93oDLaRgycyrUmbBYBE8NyePzODDB2kgu2nKcngmhvt25mSAu
+            ufCQC/Q/8t7NuHvkT1WVN+LlUd5d4JHb1bV//Ek44JY0CNQozTU51+k3QgUMgS3y
+            CGVg8t61/tDvlP6gW5HwA8lkaSGSBhZLucLZgJLU71B68uCRDILQyEZGP5o8l+qz
+            s7um5nRR4jPK6voinF4VQP6oYivfYtGU/FRte1vfQdJcAZvPwXhl5OvhyLHIjqE3
+            HQWfuyVXXb/LMBtWjEEgZuWfqFCHVAqAa3SL4Mn3+NJ1r5TwAMaTARvQao6jG+WA
+            rLYsaXqRlC94M4yKtmCLhMtVNE7c/m0XzpeSje0=
+            =huyh
             -----END PGP MESSAGE-----
         fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
-    -   created_at: '2020-07-20T20:24:16Z'
+    -   created_at: '2020-07-30T20:10:52Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf/dVsECQhGsDaDZ+Hf23PLqZWK779ptPx/5Zjup+2tqM3X
-            ubi9nqPYQs6U6H3YWIYbcBbYI1R9lFmuelLWqjTfFz6aOsNpRlvvpyQo6p7RtrbQ
-            yzP5zQWHWcbpqr3r7JGKIO+BnPPdxcA3AzV/edwu8V8708iVPq8vwvyG5C0NCA8s
-            FSSkCD+Y0I7t0Ey8Pxj/dyrBorhOeBQdXrSUEK1hwagYPcoAIKRHAp/d5NhXr7ex
-            hJ77WVik1wWOT6lEW2rWxATa8jllGHgo5tBlNPjNcwijcIAVX/6LCm/wKZOdoI+j
-            YS1qyFhzk5JMwEPC7pqD2XpF/yCr4I/YKqYuTrCYBNJcAcL8agHCD9BapefboAFW
-            uuADopUs/J/hhsLAH0RljnpIP2Zn2gwnjlXXrUsSIyLJOREVq8LspjtKpVpIk5O0
-            La0FLnuPrB37AsSKXdFUhOG9eCU/OxjiE1ASaOs=
-            =rxNa
+            hQEMA/irrHa183bxAQgAiutCOY7jiyUiHmuesyPV867JNV7YWv6yG+LHy+fXU8IZ
+            m+v6/cPz23PS78VAE6iVQPLRIw8MDjHD0/7CJFT7wmDwcJDsugypJYfVKWDj9v4y
+            5vlVIlv41GVNAHRcQBrorl/uxUv+837EdbbZjyns02AqI6u1s+z8GGEzQnciwq5o
+            BrMikdCwJbJodlh8MTbgkgni4G1tO7Du3BB9PjBRaFBqGakrArdrEJop8prn1iSO
+            91F0VI9Tws74qCKSd+KOV1OVJNx9nYqemvdzF7FlumqknqX2q/KL//QHbABXgZYJ
+            gxpTwwEHeElwAy+VEaVxdbUjNx6V167XOsTwuGtYLNJcAcoKaDL2uAPL1JMh2tGt
+            hZTyPHVzmqE8q3kFr0QUE35BU4enuFLSGt6YJpdG5shf1ahX2oA+y/TH+5r5DWgO
+            4F0uwoisSkCm2dv0XaIh5qh+s2J7Di1zbSZ+vqo=
+            =+RC5
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
-    -   created_at: '2020-07-20T20:24:16Z'
+    -   created_at: '2020-07-30T20:10:52Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA7vMDF1jUn3mAQ//VvfsM1BVARUTZQA233+Ud5UWjfs//nnvKG2O3Vh2gPY9
-            ohTbFAzjmS52F8cGBOAaxLiKNsa6c5eds/L9jj2ydEpQ/92yRehvyl5qKOVX4MPM
-            UTVdiuF9Xz9aooU4B/mWggaGmICKJh5a9dV+HGj6dYN7ZiqJ2WM5XhOOoMFs07p0
-            VLcugqe5xDAc7m+pbwqgWxNyTGk7lfUN806I8cofOdUzKC49fZFAlC8jsm2EA4ne
-            rN4ce16aUgGCzkawoMT5qfR7A7Bib9MZlvG6lwjnxgI9nKeGpwZUNmWlcxocX6QR
-            AKDakiLPigiYOKtjRyzkD8r+nLbqt+oR9wO7Xu9y26feO95MPLKJtXoAPQoUN8Nl
-            GqfqmBZI7jZqGaUroNXljKSjV5JyHlsru87YeO+WD5GdRojslWtkkKT2CaFvHQ34
-            zO75QglxJOHtCMAqPaBlOhlNlbfi8qCTd7dXehgOzogM9cUUde92anc5ePuF3SE8
-            Snirq6l0arpNPtOHXmTDV/pAQc/UARo1+X3xqxFjJp5sFQL0KOojLYsEiGR3csma
-            T/flBkKMaJbwABleIoeu5A1VQ9GZUU5jQhSt+bjvkjf6iwIL7riYe6Z/HHL7TDCQ
-            LZ7g0+gb/EzoxFtcgSR1edPwl6/jhyNbX/0aDAYskPtLua3cLZarPZIro8amvprS
-            XAFJSZDz4X4yLl7Ng1sxvLfcHb/L1IWmAC0baicb7zIYiYmd5OQB+CyRj5krPfzb
-            A7eQduimDMg3JONRbdw4aWwuXRFoSWvv2wK4myaHhX0ec3cHBi/2YIHskNKc
-            =HbF+
+            hQIMA7vMDF1jUn3mARAAtVK6x1O+PsC9F0UBVPOFz1wO+pL+Oo3f/pnJzDT5hHLq
+            TIfa+JAUM70YpgHEbtL7FpvJHJ2SXZMTHvItE8D756mtNg+RIJQ4583a2md8rL7/
+            mBxWa+Nd/iRyN0PVJtlqaeRZsi4HRbSu0ekI1LjHQxdWo6S+mTibb/racuULUjyc
+            4xtiSJnk1QnJ9c9B3F14qtmGeLrTRr0Ya/e74jhipheaucy9wsGYKJtBh7Tf2LTO
+            yldmHoJiCSoDhlwD9hiAb/w5WjUaUEPNYRw4HkqaIdV+zZUoUSeOVreY+M5M3rKV
+            TbHT9twGfeA0QcSMBD4QQHJZ2y4C/2jYturqe+a92c4kJva1ZxyAhPTDG/diuaCQ
+            8otvnvhz8rwJI7jqxSK5pdabzNyX6LN4qgUvCfzd4sIaIqAS0ixAkKLdpLP74v5K
+            G69OclmGLQ8TUKhsQgzDiPeK/zwREkFgdEEhjTJzPMs5N7jVsMdTStIdFmkORpAB
+            +wahWMWo8PqNl3lqkpSOSN7Y/IOyL65qKPYBYJUDFnsHTvyITLr0ob6OMdJH8yfI
+            8OPzDkSd3qEGpfj8oe13BHI5zTZW0UbG6hvYLvRiDXg7Okrx2t8MJAlG1J7k2PTN
+            lSyWnh1u12NeuVJ5UiU7zhdqyZ0BUCaD3Xaxglo/6SLJTUQDEDWm9zRNC2m8yl3S
+            XAGYrqiMhZjAE+qWJUMGnsWlR1zmR7QW9g/5k/m0XtM3oiU/oR0iElXVKXvhv0Us
+            tHTU81BHcaGNfq+mzhLKqQVwJ/Aklz9WMOH4YGl0RMP38bqPkiSTm9dMd7Pe
+            =fkQy
             -----END PGP MESSAGE-----
         fp: 68BD1529A372C8BA561C9DDC377298152D08B95B
     encrypted_regex: ^(data|stringData)$

--- a/amun/overlays/test/buildconfig.yaml
+++ b/amun/overlays/test/buildconfig.yaml
@@ -53,7 +53,7 @@ spec:
 kind: BuildConfig
 apiVersion: build.openshift.io/v1
 metadata:
-  name: inspect-hwinfo
+  name: amun-inspect-hwinfo
 spec:
   output:
     to:


### PR DESCRIPTION
## Related Issues and Dependencies

- This error was caused by workflow-controller-config not containing:  `containerRuntimeExecutor: "k8sapi"`
```
pods "inspection-test-bad96503-2767987541" is forbidden: unable to validate against any security context constraint: [spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used]
```
- Images are to be present in correct namespace.
- missing secrets

## This introduces a breaking change

- [x] No

## This Pull Request implements

include new secrets, updates kustomize and configmaps

## Description

amun stage deployment fixes
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
