### PR TITLE
upgrade workflow-controller with more memory

### DIFF
--- a/core/overlays/middletier-stage/argo-namespace-install.yaml
+++ b/core/overlays/middletier-stage/argo-namespace-install.yaml
@@ -114,10 +114,10 @@ spec:
           name: workflow-controller
           resources:
             requests:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "1"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "1"
       serviceAccountName: argo-server
 ---


### PR DESCRIPTION
upgrade workflow-controller with more memory
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

workflow controller is crash looping in middletier

## This introduces a breaking change

- [x] No

