### PR TITLE
use quay based images for argo workflow controller

### DIFF
--- a/core/overlays/middletier-stage/argo-namespace-install.yaml
+++ b/core/overlays/middletier-stage/argo-namespace-install.yaml
@@ -75,7 +75,7 @@ spec:
         - args:
             - server
             - --namespaced
-          image: argoproj/argocli:v2.8.1
+          image: quay.io/thoth-station/argocli:v2.8.1
           name: argo-server
           ports:
             - containerPort: 2746
@@ -106,11 +106,11 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoproj/argoexec:v2.8.1
+            - quay.io/thoth-station/argoexec:v2.8.1
             - --namespaced
           command:
             - workflow-controller
-          image: argoproj/workflow-controller:v2.8.1
+          image: quay.io/thoth-station/workflow-controller:v2.8.1
           name: workflow-controller
           resources:
             requests:


### PR DESCRIPTION
use quay based images for argo server and workflow controller in middletier
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

dockerhub is restricting the number times an image pulls

## This introduces a breaking change

- [x] No
