### PR TITLE
Decrease solver TTL

### DIFF
--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -59,8 +59,8 @@ objects:
       podGC:
         strategy: OnWorkflowSuccess
       ttlStrategy:
-        secondsAfterSuccess: 7200
-        secondsAfterFailure: 7200
+        secondsAfterSuccess: 1200
+        secondsAfterFailure: 1200
       entrypoint: solve-and-sync
       arguments:
         parameters:


### PR DESCRIPTION
## Related Issues and Dependencies

Let's decrease solver TTL so that solvers finish faster and we can check number of solvers pending.
