### PR TITLE
provide kafka-secrets for solver send message

### DIFF
--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -87,6 +87,12 @@ objects:
           emptyDir: {}
         - name: output
           emptyDir: {}
+        - name: kafka-secrets
+          secret:
+            secretName: "kafka"
+            items:
+              - key: kafka_ca.crt
+                path: kafka_ca.crt
       templates:
         - name: "solve-and-sync"
           archiveLocation:


### PR DESCRIPTION
## Related Issues and Dependencies

Solver fails to send the topic message to Kafka.

## This introduces a breaking change

- [x] No

## This Pull Request implements

allow workflows to access kafka crt from secrets.

## Description

provide kafka-secrets for solver send message
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
