### PR TITLE
setup backend namespace with argo workflow controller

### DIFF
--- a/core/overlays/backend-stage/argo-namespace-install.yaml
+++ b/core/overlays/backend-stage/argo-namespace-install.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-binding-to-argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+  - kind: ServiceAccount
+    name: argo
+    namespace: thoth-backend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-server-binding-to-argo-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-admin
+subjects:
+  - kind: ServiceAccount
+    name: argo-server
+    namespace: thoth-backend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-server-binding-to-argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+  - kind: ServiceAccount
+    name: argo-server
+    namespace: thoth-backend-stage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-server
+spec:
+  ports:
+    - port: 2746
+      targetPort: 2746
+  selector:
+    app: argo-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argo-server
+spec:
+  selector:
+    matchLabels:
+      app: argo-server
+  template:
+    metadata:
+      labels:
+        app: argo-server
+    spec:
+      containers:
+        - args:
+            - server
+            - --namespaced
+          image: quay.io/thoth-station/argocli:v2.8.1
+          name: argo-server
+          ports:
+            - containerPort: 2746
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 2746
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+      serviceAccountName: argo-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-controller
+spec:
+  selector:
+    matchLabels:
+      app: workflow-controller
+  template:
+    metadata:
+      labels:
+        app: workflow-controller
+    spec:
+      containers:
+        - args:
+            - --configmap
+            - workflow-controller-configmap
+            - --executor-image
+            - quay.io/thoth-station/argoexec:v2.8.1
+            - --namespaced
+          command:
+            - workflow-controller
+          image: quay.io/thoth-station/workflow-controller:v2.8.1
+          name: workflow-controller
+          resources:
+            requests:
+              memory: "6Gi"
+              cpu: "1"
+            limits:
+              memory: "6Gi"
+              cpu: "1"
+      serviceAccountName: argo-server
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: workflow-controller-configmap

--- a/core/overlays/backend-stage/argo-ui-route.yaml
+++ b/core/overlays/backend-stage/argo-ui-route.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: argo-ui
+spec:
+  port:
+    targetPort: 2746
+  to:
+    kind: Service
+    name: argo-server
+    weight: 100

--- a/core/overlays/backend-stage/argo-workflow-controller-metrics.yaml
+++ b/core/overlays/backend-stage/argo-workflow-controller-metrics.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflow-controller-metrics
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: workflow-controller
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: workflow-controller-metrics
+spec:
+  to:
+    kind: Service
+    name: workflow-controller-metrics
+    weight: 100
+  wildcardPolicy: None

--- a/core/overlays/backend-stage/configmaps.yaml
+++ b/core/overlays/backend-stage/configmaps.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   config: |
     containerRuntimeExecutor: "k8sapi"
-    namespace: "thoth-middletier-stage"
+    namespace: "thoth-backend-stage"
     parallelism: 10
 
     workflowDefaults:

--- a/core/overlays/backend-stage/kustomization.yaml
+++ b/core/overlays/backend-stage/kustomization.yaml
@@ -2,7 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../stage/
+  - argo-namespace-install.yaml
+  - argo-workflow-controller-metrics.yaml
+  - argo-ui-route.yaml
   - thoth-notification.yaml
+patchesStrategicMerge:
+  - configmaps.yaml
 patchesJson6902:
   - path: job-generate-name.yaml
     target:

--- a/core/overlays/middletier-stage/argo-ui-route.yaml
+++ b/core/overlays/middletier-stage/argo-ui-route.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: argo-ui
+spec:
+  port:
+    targetPort: 2746
+  to:
+    kind: Service
+    name: argo-server
+    weight: 100

--- a/core/overlays/middletier-stage/kustomization.yaml
+++ b/core/overlays/middletier-stage/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../stage/
   - argo-namespace-install.yaml
   - argo-workflow-controller-metrics.yaml
+  - argo-ui-route.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
   - configmaps.yaml

--- a/core/overlays/stage/configmaps.yaml
+++ b/core/overlays/stage/configmaps.yaml
@@ -6,10 +6,10 @@ metadata:
 data:
   applicationVersion: 0.7.0
   deployment-name: ocp-stage
-  amun-api-url: "UNSET"
+  amun-api-url: "http://amun-api-thoth-amun-api-stage.apps.ocp.prod.psi.redhat.com"
   amun-inspection-namespace: thoth-amun-inspection-stage
   amun-namespace: thoth-amun-api-stage
-  backend-namespace: aicoe-infra-prod
+  backend-namespace: thoth-backend-stage
   middletier-namespace: thoth-middletier-stage
   frontend-namespace: thoth-frontend-stage
   infra-namespace: thoth-infra-stage
@@ -23,7 +23,7 @@ data:
   postgresql-host: pgbouncer.thoth-graph-stage.svc
   rsyslog-host: ""
   rsyslog-port: ""
-  storage-bucket-name: ocp-prod-stage
+  storage-bucket-name: ocp-stage
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/core/overlays/stage/imagestreamtags.yaml
+++ b/core/overlays/stage/imagestreamtags.yaml
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/workflow-helpers:2"
+        name: "quay.io/thoth-station/workflow-helpers:v0.1.2"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -23,7 +23,7 @@ data:
   postgresql-host: pgbouncer.thoth-test-core.svc
   rsyslog-host: ""
   rsyslog-port: ""
-  storage-bucket-name: ocp-prod-test
+  storage-bucket-name: ocp-test
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -70,7 +70,7 @@ data:
 
       s3:
         bucket: "thoth"
-        keyPrefix: "data/ocp-prod-test/argo/artifacts/"
+        keyPrefix: "data/ocp-test/argo/artifacts/"
         endpoint: "s3.upshift.redhat.com"
         insecure: true
         accessKeySecret:


### PR DESCRIPTION
setup backend namespace with argo workflow controller
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-To: #187 

## This introduces a breaking change

- [x] No

## This Pull Request implements

- include workflow-controller manifest in backend-namespace to setup argo
- update configmaps and kustomize.yaml

## Description

- setup backend namespace for adviser workflow to execute.
- allow all the data to be stored in ocp-{stage|test} ceph bucket.
