### PR TITLE
Add missing env variables for advise-reporter

### DIFF
--- a/advise-reporter/base/cronjob.yaml
+++ b/advise-reporter/base/cronjob.yaml
@@ -84,6 +84,11 @@ spec:
                     configMapKeyRef:
                       key: bucket-name
                       name: ceph
+                - name: THOTH_PUBLIC_CEPH_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: public-bucket-name
+                      name: ceph
                 - name: THOTH_CEPH_BUCKET_PREFIX
                   valueFrom:
                     configMapKeyRef:
@@ -104,6 +109,11 @@ spec:
                     secretKeyRef:
                       name: ceph
                       key: secret-key
+                - name: THOTH_ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: deployment-name
               volumeMounts:
                 - name: secrets
                   mountPath: /mnt/secrets

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -31,6 +31,7 @@ metadata:
   name: ceph
 data:
   bucket-name: "thoth"
+  public-bucket-name: DH-PLAYPEN
   bucket-prefix: "data"
   host: "https://s3.upshift.redhat.com/"
   endpoint: "https://s3.upshift.redhat.com/"


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/advise-reporter/issues/57

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add missing variables to run advise-reporter
