### PR TITLE
Allow the user-api to schedule workflow in backend

### DIFF
--- a/user-api/overlays/stage/role-binding.yaml
+++ b/user-api/overlays/stage/role-binding.yaml
@@ -40,3 +40,17 @@ subjects:
   - kind: ServiceAccount
     name: user-api
     namespace: thoth-frontend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: user-api-argo-admin
+  namespace: thoth-backend-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-admin
+subjects:
+  - kind: ServiceAccount
+    name: user-api
+    namespace: thoth-frontend-stage


### PR DESCRIPTION
Allow the user-api to schedule workflow in backend
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

fixes: #235 

## This introduces a breaking change

- [x] No

## This Pull Request implements

user-api serviceaccount is added with role_binding to use agro-admin role to create workflow in backend.

## Description

adviser workflows are scheduled in the backend namespace.
