### PR TITLE
manifest files in different directory are not fetched directly

### DIFF
--- a/kebechet/base/kustomization.yaml
+++ b/kebechet/base/kustomization.yaml
@@ -3,7 +3,9 @@ kind: Kustomization
 resources:
   - configmap.yaml
   - imagestream.yaml
+  - argo-workflows/kebechet.yaml
+  - openshift-template/kebechet.yaml
 commonLabels:
   app.kubernetes.io/name: thoth
   app.kubernetes.io/component: kebechet
-  app.kubernetes.io/managed-by: aicoe-thoth-devops-argocd
+  app.kubernetes.io/managed-by: aicoe-thoth-devops

--- a/kebechet/overlays/stage/kustomization.yaml
+++ b/kebechet/overlays/stage/kustomization.yaml
@@ -4,8 +4,6 @@ commonLabels:
   app.kubernetes.io/version: "0.7.0"
 resources:
   - ../../base
-  - ../../base/argo-workflows/kebechet.yaml
-  - ../../base/openshift-template/kebechet.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
   - configmap.yaml

--- a/kebechet/overlays/test/kustomization.yaml
+++ b/kebechet/overlays/test/kustomization.yaml
@@ -4,8 +4,6 @@ commonLabels:
   app.kubernetes.io/version: "0.7.0"
 resources:
   - ../../base
-  - ../../base/argo-workflows/kebechet.yaml
-  - ../../base/openshift-template/kebechet.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
   - configmap.yaml


### PR DESCRIPTION
## Related Issues and Dependencies

argocd application for `stage-thoth-kebechet` is having issues creating.

## This introduces a breaking change

- [x] No

## This Pull Request implements

- used base kustomize to define argo workflow and openshift templates.

## Description

manifest files in different directory are not fetched directly
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
