### PR TITLE
Fix the wrong spelling of the directory

### DIFF
--- a/kebechet/base/kustomization.yaml
+++ b/kebechet/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - configmap.yaml
   - imagestream.yaml
   - argo-workflows/kebechet.yaml
-  - openshift-template/kebechet.yaml
+  - openshift-templates/kebechet.yaml
 commonLabels:
   app.kubernetes.io/name: thoth
   app.kubernetes.io/component: kebechet


### PR DESCRIPTION
Fix the wrong spelling of the directory
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

missed the `s` in openshift-templates. causing issues in argocd kebechet stage application.
