### PR TITLE
investigater image is required by adviser in stage

### DIFF
--- a/core/overlays/stage/imagestreamtags.yaml
+++ b/core/overlays/stage/imagestreamtags.yaml
@@ -30,13 +30,27 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
+  name: investigator
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/investigator:v0.4.0
+    importPolicy: {}
+    referencePolicy:
+      type: Source
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
   name: s2i-thoth-ubi8-py36
 spec:
   tags:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.12.6"
+        name: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/test/imagestreamtags.yaml
+++ b/core/overlays/test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:2
+      name: quay.io/thoth-station/workflow-helpers:v0.1.2
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
investigater image is required by adviser in stage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

`Failed to pull image "image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/investigator:latest": rpc error: code = Unknown desc = Error reading manifest latest in image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/investigator: manifest unknown: manifest unknown`

## This Pull Request implements

included investigator image to be deployed in stage.
