### PR TITLE
Fix mis-match of workflow-helper env vars

### DIFF
--- a/adviser/base/argo-workflows/trigger-integration.yaml
+++ b/adviser/base/argo-workflows/trigger-integration.yaml
@@ -26,7 +26,7 @@ spec:
         name: trigger-integration
         image: workflow-helpers
         env:
-          - name: WORKFLOW_TASK
+          - name: THOTH_WORKFLOW_TASK
             value: "trigger_integration"
           - name: WORKFLOW_NAME
             value: "{{inputs.parameters.WORKFLOW_NAME}}"

--- a/qeb-hwt-github-app/base/argo-workflows/qeb-hwt-integration.yaml
+++ b/qeb-hwt-github-app/base/argo-workflows/qeb-hwt-integration.yaml
@@ -29,7 +29,7 @@ spec:
         name: qeb-hwt-integration
         image: workflow-helpers
         env:
-          - name: WORKFLOW_TASK
+          - name: THOTH_WORKFLOW_TASK
             value: "qeb_hwt"
           - name: APP_SCRIPT
             value: "app.sh"


### PR DESCRIPTION
Fix mis-match of workflow-helper env vars
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

workflow failed after a adviser run: `/opt/app-root/src/app.sh: line 13: THOTH_WORKFLOW_TASK: THOTH_WORKFLOW_TASK is not selected!`

workflow helper requires `THOTH_WORKFLOW_TASK` 
https://github.com/thoth-station/workflow-helpers/blob/ac25943b8aecd060461bd90648a979c8332445c6/app.sh#L13