### PR TITLE
thamos log requires user-api to have access for pod logs

### DIFF
--- a/user-api/overlays/stage/role-binding.yaml
+++ b/user-api/overlays/stage/role-binding.yaml
@@ -30,6 +30,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
+  name: user-api-argo
+  namespace: thoth-backend-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+  - kind: ServiceAccount
+    name: user-api
+    namespace: thoth-frontend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
   name: user-api-argo-admin
   namespace: thoth-middletier-stage
 roleRef:


### PR DESCRIPTION
thamos log requires user-api to have access for pod logs
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

thamos log fails as user-api dont have permission to access pod-logs in backend namespace.

