### PR TITLE
deploy amun-api tag v0.7.6 to stage cluster

### DIFF
--- a/amun/overlays/stage/imagestreamtag.yaml
+++ b/amun/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/amun-api:v0.7.5
+      name: quay.io/thoth-station/amun-api:v0.7.6
     importPolicy: {}
     referencePolicy:
       type: Source

--- a/amun/overlays/test/kustomization.yaml
+++ b/amun/overlays/test/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - buildconfig.yaml
   - role_binding.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:


### PR DESCRIPTION
deploy amun-api tag v0.7.6 to stage cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## This introduces a breaking change

- [x] No

## This Pull Request implements

- updated new version

## Description

- functioning in test.