### PR TITLE
:turtle: allow chat notification based upon the environment

### DIFF
--- a/advise-reporter/overlays/test/job-generate-name.yaml
+++ b/advise-reporter/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/adviser/overlays/test/job-generate-name.yaml
+++ b/adviser/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/amun/overlays/amun-api/job-generate-name.yaml
+++ b/amun/overlays/amun-api/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/amun/overlays/amun-api/kustomization.yaml
+++ b/amun/overlays/amun-api/kustomization.yaml
@@ -9,11 +9,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage

--- a/amun/overlays/amun-api/thoth-notification.yaml
+++ b/amun/overlays/amun-api/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/amun/overlays/amun-inspection/job-generate-name.yaml
+++ b/amun/overlays/amun-inspection/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/amun/overlays/amun-inspection/kustomization.yaml
+++ b/amun/overlays/amun-inspection/kustomization.yaml
@@ -12,11 +12,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage

--- a/amun/overlays/amun-inspection/thoth-notification.yaml
+++ b/amun/overlays/amun-inspection/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/amun/overlays/test/job-generate-name.yaml
+++ b/amun/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/core/overlays/backend-stage/job-generate-name.yaml
+++ b/core/overlays/backend-stage/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/core/overlays/backend-stage/kustomization.yaml
+++ b/core/overlays/backend-stage/kustomization.yaml
@@ -15,11 +15,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage

--- a/core/overlays/backend-stage/thoth-notification.yaml
+++ b/core/overlays/backend-stage/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/core/overlays/frontend-stage/job-generate-name.yaml
+++ b/core/overlays/frontend-stage/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/core/overlays/frontend-stage/kustomization.yaml
+++ b/core/overlays/frontend-stage/kustomization.yaml
@@ -10,11 +10,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage

--- a/core/overlays/frontend-stage/thoth-notification.yaml
+++ b/core/overlays/frontend-stage/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/core/overlays/graph-stage/job-generate-name.yaml
+++ b/core/overlays/graph-stage/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/core/overlays/graph-stage/kustomization.yaml
+++ b/core/overlays/graph-stage/kustomization.yaml
@@ -12,11 +12,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage

--- a/core/overlays/graph-stage/thoth-notification.yaml
+++ b/core/overlays/graph-stage/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/core/overlays/middletier-stage/job-generate-name.yaml
+++ b/core/overlays/middletier-stage/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/core/overlays/middletier-stage/kustomization.yaml
+++ b/core/overlays/middletier-stage/kustomization.yaml
@@ -15,11 +15,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage

--- a/core/overlays/middletier-stage/thoth-notification.yaml
+++ b/core/overlays/middletier-stage/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -20,7 +19,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'I have successfully synchronized *Thoth Core* components to <https://console-openshift-console.apps.ocp.prod.psi.redhat.com/k8s/cluster/projects/thoth-middletier-stage|STAGE middletier> namespace, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/stage-thoth-core-middletier|ArgoCD UI> 🚀'}"
+            - "{'text':'I have successfully synchronized *Thoth Core* components to *STAGE* *middletier* namespace, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/stage-thoth-core-middletier|ArgoCD UI> 🚀'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -52,7 +50,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'🔥 *FAILED* syncing *Thoth Core* components to <https://console-openshift-console.apps.ocp.prod.psi.redhat.com/k8s/cluster/projects/thoth-middletier-stage|STAGE middletier> namespace, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/stage-thoth-core-middletier|ArgoCD UI>'}"
+            - "{'text':'🔥 *FAILED* syncing *Thoth Core* components to *STAGE* *middletier* namespace, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/stage-thoth-core-middletier|ArgoCD UI>'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL

--- a/core/overlays/stage/job-generate-name.yaml
+++ b/core/overlays/stage/job-generate-name.yaml
@@ -1,3 +1,0 @@
-- op: move
-  from: /metadata/name
-  path: /metadata/generateName

--- a/core/overlays/test/job-generate-name.yaml
+++ b/core/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/core/overlays/test/kustomization.yaml
+++ b/core/overlays/test/kustomization.yaml
@@ -18,14 +18,12 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/core/overlays/test/thoth-notification.yaml
+++ b/core/overlays/test/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/cve-update/overlays/test/job-generate-name.yaml
+++ b/cve-update/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/graph-refresh/overlays/test/job-generate-name.yaml
+++ b/graph-refresh/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/graph-sync/overlays/test/job-generate-name.yaml
+++ b/graph-sync/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/init-job/overlays/test/job-generate-name.yaml
+++ b/init-job/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/investigator/overlays/test/job-generate-name.yaml
+++ b/investigator/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/kebechet/overlays/prod/job-generate-name.yaml
+++ b/kebechet/overlays/prod/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/management-api/overlays/test/job-generate-name.yaml
+++ b/management-api/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/metrics-exporter/overlays/stage/job-generate-name.yaml
+++ b/metrics-exporter/overlays/stage/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/metrics-exporter/overlays/stage/kustomization.yaml
+++ b/metrics-exporter/overlays/stage/kustomization.yaml
@@ -20,11 +20,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-success-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-fail-
-      namespace: thoth-infra-stage

--- a/metrics-exporter/overlays/stage/thoth-notification.yaml
+++ b/metrics-exporter/overlays/stage/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-success-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-fail-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/metrics-exporter/overlays/test/kustomization.yaml
+++ b/metrics-exporter/overlays/test/kustomization.yaml
@@ -19,11 +19,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-success-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-fail-
-      namespace: thoth-infra-stage

--- a/metrics-exporter/overlays/test/thoth-notification.yaml
+++ b/metrics-exporter/overlays/test/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-success-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-fail-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/mi-scheduler/overlays/test/job-generate-name.yaml
+++ b/mi-scheduler/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/package-releases/overlays/test/job-generate-name.yaml
+++ b/package-releases/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/slo-reporter/overlays/stage/kustomization.yaml
+++ b/slo-reporter/overlays/stage/kustomization.yaml
@@ -21,11 +21,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-succeeded-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-failed-
-      namespace: thoth-infra-stage

--- a/slo-reporter/overlays/stage/thoth-notification.yaml
+++ b/slo-reporter/overlays/stage/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-succeeded-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-failed-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/slo-reporter/overlays/test/job-generate-name.yaml
+++ b/slo-reporter/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/solver/overlays/test/job-generate-name.yaml
+++ b/solver/overlays/test/job-generate-name.yaml
@@ -1,6 +1,3 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
-- op: add
-  path: /metadata/namespace
-  value: "thoth-infra-stage"

--- a/user-api/overlays/stage/job-generate-name.yaml
+++ b/user-api/overlays/stage/job-generate-name.yaml
@@ -1,3 +1,6 @@
 - op: move
   from: /metadata/name
   path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/user-api/overlays/stage/kustomization.yaml
+++ b/user-api/overlays/stage/kustomization.yaml
@@ -21,14 +21,12 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-success-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-fail-
-      namespace: thoth-infra-stage
   - path: put-into-infra-namespace.yaml
     target:
       group: rbac.authorization.k8s.io

--- a/user-api/overlays/stage/thoth-notification.yaml
+++ b/user-api/overlays/stage/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-success-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-fail-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/user-api/overlays/test/kustomization.yaml
+++ b/user-api/overlays/test/kustomization.yaml
@@ -21,11 +21,9 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-success-
-      namespace: thoth-infra-stage
   - path: job-generate-name.yaml
     target:
       group: batch
       version: v1
       kind: Job
       name: chat-notification-fail-
-      namespace: thoth-infra-stage

--- a/user-api/overlays/test/thoth-notification.yaml
+++ b/user-api/overlays/test/thoth-notification.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-success-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -35,7 +34,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: chat-notification-fail-
-  namespace: thoth-infra-stage
   annotations:
     argocd.argoproj.io/hook: SyncFail
     argocd.argoproj.io/hook-delete-policy: HookSucceeded


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

- migrated chat notification of stage component to take place in thoth-infra-stage
- migrated chat notification of test component to take place in thoth-test-core 

## Description

allow chat notification based upon the environment
As component get deployed chat notification job should execute in respective environments. 
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
