### PR TITLE
Bump adviser version to 0.14.0 in stage env

### DIFF
--- a/adviser/overlays/stage/imagestreamtag.yaml
+++ b/adviser/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:0.9.5
+        name: quay.io/thoth-station/adviser:0.14.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/adviser/issues/1112

## This introduces a breaking change

- [x] No
