### PR TITLE
ensure tls cert are decrypted by argo

### DIFF
--- a/amun/overlays/test/kustomization.yaml
+++ b/amun/overlays/test/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - ../../base
   - role_binding.yaml
   - thoth-notification.yaml
+generators:
+  - ./secret-generator.yaml
 patchesStrategicMerge:
   - configmaps.yaml
   - imagestreamtag.yaml
@@ -26,5 +28,3 @@ patchesJson6902:
       version: v1
       kind: Role
       name: metrics-exporter-reader
-generators:
-  - ./secret-generator.yaml

--- a/amun/overlays/test/secret-generator.yaml
+++ b/amun/overlays/test/secret-generator.yaml
@@ -4,3 +4,4 @@ metadata:
   name: thoth-secret-generator
 files:
   - ./secrets.enc.yaml
+  - ./route.enc.yaml

--- a/management-api/overlays/stage/kustomization.yaml
+++ b/management-api/overlays/stage/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - route.enc.yaml
   - role-binding.yaml
   - thoth-notification.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+generators:
+  - ./secret-generator.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patchesJson6902:

--- a/management-api/overlays/stage/secret-generator.yaml
+++ b/management-api/overlays/stage/secret-generator.yaml
@@ -3,5 +3,4 @@ kind: ksops
 metadata:
   name: thoth-secret-generator
 files:
-  - ./secrets.enc.yaml
   - ./route.enc.yaml

--- a/management-api/overlays/test/kustomization.yaml
+++ b/management-api/overlays/test/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - route.enc.yaml
   - role-binding.yaml
   - thoth-notification.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+generators:
+  - ./secret-generator.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/management-api/overlays/test/secret-generator.yaml
+++ b/management-api/overlays/test/secret-generator.yaml
@@ -3,5 +3,4 @@ kind: ksops
 metadata:
   name: thoth-secret-generator
 files:
-  - ./secrets.enc.yaml
   - ./route.enc.yaml

--- a/user-api/overlays/stage/kustomization.yaml
+++ b/user-api/overlays/stage/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - route.enc.yaml
   - role-binding.yaml
   - thoth-notification.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+generators:
+  - ./secret-generator.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/user-api/overlays/stage/secret-generator.yaml
+++ b/user-api/overlays/stage/secret-generator.yaml
@@ -3,5 +3,4 @@ kind: ksops
 metadata:
   name: thoth-secret-generator
 files:
-  - ./secrets.enc.yaml
   - ./route.enc.yaml

--- a/user-api/overlays/test/kustomization.yaml
+++ b/user-api/overlays/test/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - route.enc.yaml
   - role-binding.yaml
   - thoth-notification.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+generators:
+  - ./secret-generator.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/user-api/overlays/test/secret-generator.yaml
+++ b/user-api/overlays/test/secret-generator.yaml
@@ -3,5 +3,4 @@ kind: ksops
 metadata:
   name: thoth-secret-generator
 files:
-  - ./secrets.enc.yaml
   - ./route.enc.yaml


### PR DESCRIPTION
## Related Issues and Dependencies

Argo-cd was unable to decrypt the encrypted tls certs.

## This introduces a breaking change

- [x] No

## This Pull Request implements

- Added a secret generator kustomize file, which uses ksops to decrypt the encrypt of sops content.

## Description

ensure tls cert are decrypted by argo
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

