### PR TITLE
Use Argo 2.9.5 for Amun

### DIFF
--- a/amun/overlays/amun-inspection/argo-namespace-install.yaml
+++ b/amun/overlays/amun-inspection/argo-namespace-install.yaml
@@ -73,7 +73,7 @@ spec:
         - args:
             - server
             - --namespaced
-          image: argoproj/argocli:v2.8.1
+          image: quay.io/thoth-station/argocli:v2.9.5
           name: argo-server
           ports:
             - containerPort: 2746
@@ -104,11 +104,11 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoproj/argoexec:v2.8.1
+            - quay.io/thoth-station/argoexec:v2.9.5
             - --namespaced
           command:
             - workflow-controller
-          image: argoproj/workflow-controller:v2.8.1
+          image: quay.io/thoth-station/workflow-controller:2.9.5
           name: workflow-controller
           resources:
             requests:


### PR DESCRIPTION
... also pull images from quay.io not to hit dockerhub limits.

## This introduces a breaking change

- [x] No
