### PR TITLE
Bump image version for core images

### DIFF
--- a/core/overlays/stage/imagestreamtags.yaml
+++ b/core/overlays/stage/imagestreamtags.yaml
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/workflow-helpers:v0.1.2"
+        name: "quay.io/thoth-station/workflow-helpers:v0.1.3"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -50,7 +50,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0"
+        name: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/test/imagestreamtags.yaml
+++ b/core/overlays/test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.1.2
+      name: quay.io/thoth-station/workflow-helpers:v0.1.3
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -49,7 +49,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0
+      name: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/graph-refresh/overlays/stage/imagestreamtag.yaml
+++ b/graph-refresh/overlays/stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.6.0-dev
+        name: quay.io/thoth-station/graph-refresh-job:v0.1.2
       importPolicy: {}

--- a/graph-refresh/overlays/test/imagestreamtag.yaml
+++ b/graph-refresh/overlays/test/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.6.0-dev
+        name: quay.io/thoth-station/graph-refresh-job:v0.1.2
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/graph-refresh-job/issues/449

## This introduces a breaking change

- [x] No

## Description

Bump image version for core images
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
