### PR TITLE
move the metric exporter role to individual applications

### DIFF
--- a/amun/base/kustomization.yaml
+++ b/amun/base/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
   - argo-workflows/inspection-run-with-cpu.yaml
   - openshift-templates/inspection-workflow.yaml
   - openshift-templates/inspection-with-cpu-workflow.yaml
-  - roles/
   - deploymentconfig.yaml
   - imagestream.yaml
   - role.yaml

--- a/amun/base/roles/kustomization.yaml
+++ b/amun/base/roles/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - metrics-exporter-reader.yaml

--- a/amun/overlays/amun-api/kustomization.yaml
+++ b/amun/overlays/amun-api/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - configmaps.yaml
   - thoth-notification.yaml
+  - metrics-exporter-reader.yaml
 patchesJson6902:
   - path: job-generate-name.yaml
     target:

--- a/amun/overlays/amun-api/metrics-exporter-reader.yaml
+++ b/amun/overlays/amun-api/metrics-exporter-reader.yaml
@@ -1,5 +1,4 @@
 ---
-# TODO commonLabels are missing
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/amun/overlays/amun-inspection/kustomization.yaml
+++ b/amun/overlays/amun-inspection/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - argo-ui-route.yaml
   - argo-workflow-controller-metrics.yaml
   - thoth-notification.yaml
+  - metrics-exporter-reader.yaml
 patchesJson6902:
   - path: job-generate-name.yaml
     target:

--- a/amun/overlays/amun-inspection/metrics-exporter-reader.yaml
+++ b/amun/overlays/amun-inspection/metrics-exporter-reader.yaml
@@ -1,0 +1,289 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metrics-exporter-reader
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - podmonitors.monitoring.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - prometheuses.monitoring.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - prometheusrules.monitoring.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+      - project.openshift.io
+    resources:
+      - projects
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - servicemonitors.monitoring.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - pods
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - serviceaccounts
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - events
+      - limitranges
+      - namespaces/status
+      - pods/log
+      - pods/status
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+      - daemonsets
+      - daemonsets/status
+      - deployments
+      - deployments/scale
+      - deployments/status
+      - replicasets
+      - replicasets/scale
+      - replicasets/status
+      - statefulsets
+      - statefulsets/scale
+      - statefulsets/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+      - horizontalpodautoscalers/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - cronjobs/status
+      - jobs
+      - jobs/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - daemonsets/status
+      - deployments
+      - deployments/scale
+      - deployments/status
+      - ingresses
+      - ingresses/status
+      - networkpolicies
+      - replicasets
+      - replicasets/scale
+      - replicasets/status
+      - replicationcontrollers/scale
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+      - poddisruptionbudgets/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - ingresses/status
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+      - deploymentconfigs/scale
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs/log
+      - deploymentconfigs/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - quota.openshift.io
+    resources:
+      - appliedclusterresourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - route.openshift.io
+    resources:
+      - routes/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - template.openshift.io
+    resources:
+      - processedtemplates
+      - templateconfigs
+      - templateinstances
+      - templates
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotausages
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - cronworkflows
+      - cronworkflows/finalizers
+      - workflows
+      - workflows/finalizers
+      - workflowtemplates
+      - workflowtemplates/finalizers
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
## Related Issues and Dependencies

![a](https://user-images.githubusercontent.com/14028058/90803247-76b2b480-e2e6-11ea-9fb0-60c60f1a0830.png)


## This introduces a breaking change

- [x] No

## This Pull Request implements

metrics-exporter-reader role is added to both amun-api and amun-inspection namespaces.

## Description

move the metric exporter role to individual applications
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
