### PR TITLE
Bump version metrics-exporter stage to v0.8.6

### DIFF
--- a/metrics-exporter/overlays/stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.8.3
+        name: quay.io/thoth-station/metrics-exporter:v0.8.6
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Solve errors in thoth-metrics-exporter-stage

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Bump version
