### PR TITLE
Add missing metadata

### DIFF
--- a/qeb-hwt-github-app/base/openshift-templates/qeb-hwt.yaml
+++ b/qeb-hwt-github-app/base/openshift-templates/qeb-hwt.yaml
@@ -2,6 +2,18 @@ apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: qeb-hwt
+  annotations:
+    description: "Thoth: Qeb-Hwt Template"
+    openshift.io/display-name: "Thoth: Qeb-Hwt"
+    tags: thoth,ai-stacks,aistacks,qeb-hwt,machinelearning
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines resources needed to run qeb-hwt in Thoth.
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+  labels:
+    template: qeb-hwt
+    app: thoth
+    component: qeb-hwt
 
 parameters:
   - name: WORKFLOW_ID


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/290

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add metadata required for thoth-common library to find template: https://github.com/thoth-station/common/blob/aa5fb4b59f03e651b37af6db0153f995b811f1fc/thoth/common/workflows.py#L718
