### PR TITLE
lower some of the backend stage and advise quota requirment

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -143,10 +143,10 @@ spec:
         resources:
           limits:
             cpu: 1.1
-            memory: 8Gi
+            memory: 6Gi
           requests:
             cpu: 1.1
-            memory: 8Gi
+            memory: 6Gi
         livenessProbe:
           exec:
             command:

--- a/core/overlays/backend-stage/argo-namespace-install.yaml
+++ b/core/overlays/backend-stage/argo-namespace-install.yaml
@@ -114,10 +114,10 @@ spec:
           name: workflow-controller
           resources:
             requests:
-              memory: "6Gi"
+              memory: "4Gi"
               cpu: "1"
             limits:
-              memory: "6Gi"
+              memory: "4Gi"
               cpu: "1"
       serviceAccountName: argo-server
 ---

--- a/core/overlays/backend-stage/configmaps.yaml
+++ b/core/overlays/backend-stage/configmaps.yaml
@@ -7,14 +7,14 @@ data:
   config: |
     containerRuntimeExecutor: "k8sapi"
     namespace: "thoth-backend-stage"
-    parallelism: 10
+    parallelism: 2
 
     workflowDefaults:
       spec:
         ttlStrategy:
           secondsAfterSuccess: 7200
           secondsAfterFailure: 7200
-      parallelism: 10
+      parallelism: 2
 
     # metricsConfig controls the path and port for prometheus metrics
     metricsConfig:


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: #294 
`Message:     pods "adviser-e26e53c3-442233442" is forbidden: exceeded quota: thoth-backend-stage-quota, requested: limits.memory=9192Mi, used: limits.memory=20056Mi, limited: limits.memory=20Gi
`
## This introduces a breaking change

- [x] No

## This Pull Request implements

reduced quota requirements by workflow applications.

## Description

lower some of the backend stage and advise quota requirement
will bring them back once all the quota requirement is fulfilled my cluster team.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
