### PR TITLE
Lower requirements for kebechet-run-results

### DIFF
--- a/adviser/base/argo-workflows/kebechet-run-results.yaml
+++ b/adviser/base/argo-workflows/kebechet-run-results.yaml
@@ -61,8 +61,8 @@ spec:
                 name: thoth
         resources:
           limits:
-            cpu: "2"
-            memory: "2Gi"
+            cpu: "0.75"
+            memory: "256Mi"
           requests:
-            cpu: "2"
-            memory: "2Gi"
+            cpu: "0.75"
+            memory: "256Mi"


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

2Gi feels like too much for this task
