### PR TITLE
Bump Kebechet in stage to v0.6.1

### DIFF
--- a/kebechet/overlays/stage/imagestreamtag.yaml
+++ b/kebechet/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v0.6.0-dev
+        name: quay.io/thoth-station/kebechet-job:v0.6.1
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/kebechet/pull/496

## This introduces a breaking change

- [x] No

## Description

See automatically image in quay based on the kebechet repo push https://quay.io/repository/thoth-station/kebechet-job?tab=tags see https://github.com/thoth-station/kebechet/pull/496 for more info.
