### PR TITLE
Correct variable name

### DIFF
--- a/slo-reporter/base/cronjob.yaml
+++ b/slo-reporter/base/cronjob.yaml
@@ -95,9 +95,9 @@ spec:
                 - name: THOTH_CEPH_SECRET_KEY
                   valueFrom:
                     secretKeyRef:
-                      name: ceph
+                      name: ceph 
                       key: secret-key
-                - name: METRICS_EXPORTER_FRONTEND_PROMETHEUS_INSTANCE
+                - name: PROMETHEUS_INSTANCE_METRICS_EXPORTER_FRONTEND
                   valueFrom:
                     configMapKeyRef:
                       name: prometheus


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
INFO:thoth.slo_reporter:Considering interval for metrics of 1 day/s.
INFO:thoth.slo_reporter:THOTH_EVALUATION_METRICS_NUMBER_DAYS set to 1.
INFO:thoth.slo_reporter:Interval: 2020-08-26 - 2020-08-27
INFO:thoth.slo_reporter.sli_report:Thoth Service Level Indicators Update Day (2020-08-27)
Traceback (most recent call last):
  File "app.py", line 328, in <module>
    main()
  File "app.py", line 323, in main
    day_of_week=day_of_week,
  File "app.py", line 255, in run_slo_reporter
    sli_report = SLIReport(configuration=configuration)
  File "/opt/app-root/src/thoth/slo_reporter/sli_report.py", line 64, in __init__
    SLIPyPIKnowledgeGraph._SLI_NAME: SLIPyPIKnowledgeGraph(configuration=self.configuration)._aggregate_info(),
  File "/opt/app-root/src/thoth/slo_reporter/sli_pypi_knowledge_graph.py", line 54, in __init__
    self.instance = os.environ["PROMETHEUS_INSTANCE_METRICS_EXPORTER_FRONTEND"]
  File "/opt/app-root/lib64/python3.6/os.py", line 669, in __getitem__
    raise KeyError(key) from None
KeyError: 'PROMETHEUS_INSTANCE_METRICS_EXPORTER_FRONTEND'
```

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Correct variable name