### PR TITLE
WIP: verbose default key and store logs

### DIFF
--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -67,11 +67,14 @@ data:
         parallelism: 10
 
     artifactRepository:
-      archiveLogs: False
+      archiveLogs: True
 
       s3:
         bucket: "thoth"
-        keyPrefix: "data/ocp-test/argo/artifacts/"
+        keyFormat: "data/ocp-test/argo/artifacts/\
+          /{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}\
+          /{{workflow.creationTimestamp.d}}/{{workflow.creationTimestamp.H}}\
+          /{{workflow.name}}/{{pod.name}}"
         endpoint: "s3.upshift.redhat.com"
         insecure: true
         accessKeySecret:

--- a/slo-reporter/base/cronjob.yaml
+++ b/slo-reporter/base/cronjob.yaml
@@ -95,7 +95,7 @@ spec:
                 - name: THOTH_CEPH_SECRET_KEY
                   valueFrom:
                     secretKeyRef:
-                      name: ceph 
+                      name: ceph
                       key: secret-key
                 - name: PROMETHEUS_INSTANCE_METRICS_EXPORTER_FRONTEND
                   valueFrom:


### PR DESCRIPTION
## Related Issues and Dependencies
#325 

We should use a much more verbose default archive. This will allow for querying and deleting based on a given time frame.  I also change archiveLogs to true as we move towards automatically clearing workflows from the workflow controller and openshift.