### PR TITLE
Bump adviser version in stage to v0.15.1

### DIFF
--- a/adviser/overlays/stage/imagestreamtag.yaml
+++ b/adviser/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.15.0
+        name: quay.io/thoth-station/adviser:v0.15.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/pull/1149

## This introduces a breaking change

- [x] No
