### PR TITLE
Bump User API to v0.6.15 in stage

### DIFF
--- a/user-api/overlays/stage/imagestreamtag.yaml
+++ b/user-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.6.14
+        name: quay.io/thoth-station/user-api:v0.6.15
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

See https://github.com/thoth-station/user-api/pull/1039

## This introduces a breaking change

- [x] No
