### PR TITLE
Bump management-api to v0.7.0 in stage

### DIFF
--- a/management-api/overlays/stage/imagestreamtag.yaml
+++ b/management-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.6.4
+      name: quay.io/thoth-station/management-api:v0.7.0
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/management-api/issues/560

## This introduces a breaking change

- [x] No
