### PR TITLE
Revert "Bump management-api to v0.7.0 in stage"

### DIFF
--- a/management-api/overlays/stage/imagestreamtag.yaml
+++ b/management-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.7.0
+      name: quay.io/thoth-station/management-api:v0.6.4
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Reverts thoth-station/thoth-application#348

I will try to revert this, inspections do not run, no workflows are scheduled. Checking if this update could cause it.