### PR TITLE
Fix propagation of predictor and predictor config to argo dag

### DIFF
--- a/adviser/base/openshift-templates/adviser.yaml
+++ b/adviser/base/openshift-templates/adviser.yaml
@@ -192,6 +192,8 @@ objects:
                       value: "{{workflow.parameters.THOTH_ADVISER_RECOMMENDATION_TYPE}}"
                     - name: THOTH_ADVISER_RUNTIME_ENVIRONMENT
                       value: "{{workflow.parameters.THOTH_ADVISER_RUNTIME_ENVIRONMENT}}"
+                    - name: THOTH_ADVISER_PREDICTOR_CONFIG
+                      value: "{{workflow.parameters.THOTH_ADVISER_PREDICTOR_CONFIG}}"
                     - name: THOTH_ADVISER_METADATA
                       value: "{{workflow.parameters.THOTH_ADVISER_METADATA}}"
                     - name: THOTH_ADVISER_SEED

--- a/adviser/base/openshift-templates/dependency-monkey.yaml
+++ b/adviser/base/openshift-templates/dependency-monkey.yaml
@@ -182,6 +182,10 @@ objects:
                       value: "{{workflow.parameters.THOTH_AMUN_CONTEXT}}"
                     - name: THOTH_ADVISER_PIPELINE
                       value: "{{workflow.parameters.THOTH_ADVISER_PIPELINE}}"
+                    - name: THOTH_ADVISER_PREDICTOR
+                      value: "{{workflow.parameters.THOTH_ADVISER_PREDICTOR}}"
+                    - name: THOTH_ADVISER_PREDICTOR_CONFIG
+                      value: "{{workflow.parameters.THOTH_ADVISER_PREDICTOR_CONFIG}}"
                     - name: THOTH_DEPENDENCY_MONKEY_COUNT
                       value: "{{workflow.parameters.THOTH_DEPENDENCY_MONKEY_COUNT}}"
                     - name: THOTH_ADVISER_LIMIT_LATEST_VERSIONS


### PR DESCRIPTION
## Related Issues and Dependencies

```
 Failed: invalid spec: templates.dependency-monkey.tasks.dm templates.dm inputs.parameters.THOTH_ADVISER_PREDICTOR_CONFIG was not supplied
```

## This introduces a breaking change

- [x] No
