### PR TITLE
Modify templates for component name and service

### DIFF
--- a/solver/base/argo-workflows/parse-solver-inputs.yaml
+++ b/solver/base/argo-workflows/parse-solver-inputs.yaml
@@ -8,9 +8,13 @@ spec:
     - name: parse-solver-inputs
       inputs:
         parameters:
+          - name: "THOTH_DOCUMENT_ID"
           - name: "THOTH_SOLVER_NAME"
           - name: "THOTH_SOLVER_PACKAGES"
           - name: "THOTH_SOLVER_INDEXES"
+        artifacts:
+          - name: "outputdocument"
+            path: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
       outputs:
         parameters:
           - name: kafka_message
@@ -22,6 +26,10 @@ spec:
         env:
           - name: THOTH_WORKFLOW_TASK
             value: "parse_solver_inputs"
+          - name: "THOTH_MESSAGING_COMPONENT_NAME"
+            value: "solver"
+          - name: "THOTH_SOLVER_DOCUMENT_PATH"
+            value: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
           - name: THOTH_SOLVER_NAME
             value: "{{inputs.parameters.THOTH_SOLVER_NAME}}"
           - name: THOTH_SOLVER_PACKAGES

--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -149,7 +149,12 @@ objects:
                   name: "parse-solver-inputs"
                   template: "parse-solver-inputs"
                 arguments:
+                  artifacts:
+                    - name: outputdocument
+                      from: "{{tasks.solverany.outputs.artifacts.outputdocument}}"
                   parameters:
+                    - name: "THOTH_DOCUMENT_ID"
+                      value: "{{workflow.parameters.THOTH_SOLVER_WORKFLOW_ID}}"
                     - name: "THOTH_SOLVER_NAME"
                       value: "{{workflow.parameters.THOTH_SOLVER_NAME}}"
                     - name: "THOTH_SOLVER_PACKAGES"
@@ -157,7 +162,7 @@ objects:
                     - name: "THOTH_SOLVER_INDEXES"
                       value: "{{workflow.parameters.THOTH_SOLVER_INDEXES}}"
 
-              - name: "send-message"
+              - name: "send-solved-message"
                 dependencies:
                   - "parse-solver-inputs"
                 templateRef:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/workflow-helpers/pull/52

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Modify logic to have component name and service name sending a Kafka message


Need new release of workflow-helpers
