### PR TITLE
Bump metrics-exporter version to v0.8.7 in stage

### DIFF
--- a/metrics-exporter/overlays/stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.8.6
+        name: quay.io/thoth-station/metrics-exporter:v0.8.7
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

## This Pull Request implements

Bump metrics-exporter version

