### PR TITLE
Always perform garbage collection of pods

### DIFF
--- a/kebechet/base/openshift-templates/kebechet.yaml
+++ b/kebechet/base/openshift-templates/kebechet.yaml
@@ -40,8 +40,6 @@ objects:
         secondsAfterCompletion: 7200
         secondsAfterSuccess: 7200
         secondsAfterFailure: 7200
-      podGC:
-        strategy: OnWorkflowSuccess
       entrypoint: kebechet
       arguments:
         parameters:

--- a/qeb-hwt-github-app/base/openshift-templates/qeb-hwt.yaml
+++ b/qeb-hwt-github-app/base/openshift-templates/qeb-hwt.yaml
@@ -68,8 +68,6 @@ objects:
         secondsAfterCompletion: 7200
         secondsAfterSuccess: 7200
         secondsAfterFailure: 7200
-      podGC:
-        strategy: OnWorkflowSuccess
       entrypoint: qeb-hwt
       arguments:
         parameters:

--- a/revsolver/base/openshift-templates/revsolve_and_sync-template.yaml
+++ b/revsolver/base/openshift-templates/revsolve_and_sync-template.yaml
@@ -43,8 +43,6 @@ objects:
       serviceAccountName: revsolver
       # kill workflow if running too much time
       activeDeadlineSeconds: 3600
-      podGC:
-        strategy: OnWorkflowSuccess
       ttlStrategy:
         secondsAfterCompletion: 7200
         secondsAfterSuccess: 7200

--- a/security-indicators/base/openshift-templates/security-indicators.yaml
+++ b/security-indicators/base/openshift-templates/security-indicators.yaml
@@ -47,8 +47,6 @@ objects:
           - name: deployment_name
       entrypoint: security-indicators
       onExit: exit-handler
-      podGC:
-        strategy: OnPodCompletion
       serviceAccountName: argo
       templates:
         - archiveLocation:

--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -56,8 +56,6 @@ objects:
       serviceAccountName: argo
       # kill workflow if running too much time
       activeDeadlineSeconds: 2600
-      podGC:
-        strategy: OnWorkflowSuccess
       ttlStrategy:
         secondsAfterCompletion: 1200
         secondsAfterSuccess: 1200


### PR DESCRIPTION
## Related Issues and Dependencies

We do not need to keep objects in the cluster, they can be garbage collected. Otherwise, they occupy quota. All the relevant information regarding failures are reported into Sentry.

## This introduces a breaking change

- [x] No
