### PR TITLE
Bump adviser to v0.16.0 in stage

### DIFF
--- a/adviser/overlays/stage/imagestreamtag.yaml
+++ b/adviser/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.15.1
+        name: quay.io/thoth-station/adviser:v0.16.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/adviser/issues/1167

## This introduces a breaking change

- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment
