### PR TITLE
Reduce workflow parallelism to 1 in amun-inspection-stage

### DIFF
--- a/amun/overlays/amun-inspection/configmaps.yaml
+++ b/amun/overlays/amun-inspection/configmaps.yaml
@@ -24,7 +24,7 @@ metadata:
 data:
   config: |
     containerRuntimeExecutor: "k8sapi"
-    parallelism: 10
+    parallelism: 1
 
     # metricsConfig controls the path and port for prometheus metrics
     metricsConfig:


### PR DESCRIPTION
... as amun inspections run builds, Argo has no control on resources used by
builds. This leads to issues when a workflow is stuck waiting for a build that
failed because of resources available in the cluster.

## This introduces a breaking change

- [x] No
<!--- Describe your changes in detail -->
