### PR TITLE
Bump adviser to version 0.16.0 in stage

### DIFF
--- a/adviser/overlays/stage/imagestreamtag.yaml
+++ b/adviser/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.15.1
+        name: quay.io/thoth-station/adviser:v0.16.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/adviser/pull/1171#issue-481594416


## This introduces a breaking change

- [x] No

