### PR TITLE
Reduce parallelism in thoth-middletier-stage

### DIFF
--- a/core/overlays/middletier-stage/configmaps.yaml
+++ b/core/overlays/middletier-stage/configmaps.yaml
@@ -7,7 +7,7 @@ data:
   config: |
     containerRuntimeExecutor: "k8sapi"
     namespace: "thoth-middletier-stage"
-    parallelism: 10
+    parallelism: 7
 
     workflowDefaults:
       spec:


### PR DESCRIPTION
## Related Issues and Dependencies

It looks like workflow-controller goes into some deadlock after some time - pods are not scheduled due to resources but also, the finished ones do not proceed. I suspect it's some bug in resources handling. Let's try to decrease parallelism.

## This introduces a breaking change

- [x] No
