### PR TITLE
Bump version v1.6.1 for test solver

### DIFF
--- a/solver/overlays/test/imagestreamtag.yaml
+++ b/solver/overlays/test/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.6.0"
+        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.6.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-31-py37:v1.6.0"
+        name: "quay.io/thoth-station/solver-fedora-31-py37:v1.6.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -36,7 +36,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-31-py38:v1.6.0"
+        name: "quay.io/thoth-station/solver-fedora-31-py38:v1.6.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -50,7 +50,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-32-py37:v1.6.0"
+        name: "quay.io/thoth-station/solver-fedora-32-py37:v1.6.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -64,7 +64,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-32-py38:v1.6.0"
+        name: "quay.io/thoth-station/solver-fedora-32-py38:v1.6.1"
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION

## Related Issues and Dependencies

- un-updated images of solver.

## This introduces a breaking change

- [x] No


## This Pull Request implements

 bumped up solver image version in test to v1.6.1

## Description

Bump version v1.6.1 for test solver
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
