### PR TITLE
Use correct output file name

### DIFF
--- a/core/base/argo-workflows/send-messages.yaml
+++ b/core/base/argo-workflows/send-messages.yaml
@@ -24,10 +24,10 @@ spec:
             value: "1"
           - name: THOTH_MESSAGING_TOPIC_RETENTION_TIME
             value: "2160000"
-          - name: THOTH_DOCUMENT_ID
+          - name: MESSAGES_DOCUMENT_NAME
         artifacts:
           - name: "messagesdocument"
-            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+            path: "/mnt/workdir/{{inputs.parameters.MESSAGES_DOCUMENT_NAME}}"
       container:
         name: send-messages
         image: messaging

--- a/solver/base/argo-workflows/parse-solved-package.yaml
+++ b/solver/base/argo-workflows/parse-solved-package.yaml
@@ -18,8 +18,8 @@ spec:
             path: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
       outputs:
         artifacts:
-          - name: messagesdocument
-            path: "/mnt/workdir/adviser_runs_messages.json"
+          - name: solvedmessagesdocument
+            path: "/mnt/workdir/solved_messages.json"
       container:
         name: parse-solved-package
         image: workflow-helpers

--- a/solver/base/argo-workflows/parse-solved-package.yaml
+++ b/solver/base/argo-workflows/parse-solved-package.yaml
@@ -18,8 +18,8 @@ spec:
             path: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
       outputs:
         artifacts:
-          - name: solvedmessagesdocument
-            path: "/mnt/workdir/solved_messages.json"
+          - name: advisermessagesdocument
+            path: "/mnt/workdir/adviser_runs_messages.json"
       container:
         name: parse-solved-package
         image: workflow-helpers

--- a/solver/base/argo-workflows/parse-solved-package.yaml
+++ b/solver/base/argo-workflows/parse-solved-package.yaml
@@ -19,7 +19,7 @@ spec:
       outputs:
         artifacts:
           - name: messagesdocument
-            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+            path: "/mnt/workdir/adviser_runs_messages.json"
       container:
         name: parse-solved-package
         image: workflow-helpers

--- a/solver/base/argo-workflows/parse-solver-inputs.yaml
+++ b/solver/base/argo-workflows/parse-solver-inputs.yaml
@@ -18,8 +18,8 @@ spec:
             path: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
       outputs:
         artifacts:
-          - name: advisermessagesdocument
-            path: "/mnt/workdir/adviser_runs_messages.json"
+          - name: solvermessagesdocument
+            path: "/mnt/workdir/solved_messages.json"
       container:
         name: parse-solver-inputs
         image: workflow-helpers

--- a/solver/base/argo-workflows/parse-solver-inputs.yaml
+++ b/solver/base/argo-workflows/parse-solver-inputs.yaml
@@ -17,10 +17,9 @@ spec:
           - name: "outputdocument"
             path: "/mnt/component/document/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
       outputs:
-        parameters:
-          - name: kafka_message
-            valueFrom:
-              path: /mnt/workdir/kafka_message
+        artifacts:
+          - name: advisermessagesdocument
+            path: "/mnt/workdir/adviser_runs_messages.json"
       container:
         name: parse-solver-inputs
         image: workflow-helpers

--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -169,7 +169,7 @@ objects:
                   template: "send-messages"
                 arguments:
                   artifacts:
-                    - name: solvermessagesdocument
+                    - name: messagesdocument
                       from: "{{tasks.parse-solver-inputs.outputs.artifacts.solvermessagesdocument}}"
                   parameters:
                     - name: THOTH_MESSAGING_FROM_FILE
@@ -209,7 +209,7 @@ objects:
                   template: "send-messages"
                 arguments:
                   artifacts:
-                    - name: advisermessagesdocument
+                    - name: messagesdocument
                       from: "{{tasks.parse-solved-package.outputs.artifacts.advisermessagesdocument}}"
                   parameters:
                     - name: THOTH_MESSAGING_FROM_FILE

--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -165,18 +165,21 @@ objects:
                 dependencies:
                   - "parse-solver-inputs"
                 templateRef:
-                  name: "send-message"
-                  template: "send-message"
+                  name: "send-messages"
+                  template: "send-messages"
                 arguments:
+                  artifacts:
+                    - name: solvermessagesdocument
+                      from: "{{tasks.parse-solved-package.outputs.artifacts.solvermessagesdocument}}"
                   parameters:
-                    - name: THOTH_MESSAGING_TOPIC_NAME
-                      value: "thoth.solver.solved-package"
-                    - name: THOTH_MESSAGING_MESSAGE_CONTENTS
-                      value: "{{tasks.parse-solver-inputs.outputs.parameters.kafka_message}}"
+                    - name: THOTH_MESSAGING_FROM_FILE
+                      value: "/mnt/workdir/solved_messages.json"
                     - name: THOTH_DEPLOYMENT_NAME
                       value: "{{workflow.parameters.deployment_name}}"
                     - name: THOTH_MESSAGING_CREATE_IF_NOT_EXIST
                       value: "1"
+                    - name: MESSAGES_DOCUMENT_NAME
+                      value: "solved_messages.json"
 
               - name: "parse-solved-package"
                 dependencies:
@@ -206,14 +209,14 @@ objects:
                   template: "send-messages"
                 arguments:
                   artifacts:
-                    - name: messagesdocument
-                      from: "{{tasks.parse-solved-package.outputs.artifacts.messagesdocument}}"
+                    - name: advisermessagesdocument
+                      from: "{{tasks.parse-solved-package.outputs.artifacts.advisermessagesdocument}}"
                   parameters:
                     - name: THOTH_MESSAGING_FROM_FILE
-                      value: "/mnt/workdir/{{workflow.parameters.THOTH_SOLVER_WORKFLOW_ID}}"
+                      value: "/mnt/workdir/adviser_runs_messages.json"
                     - name: THOTH_DEPLOYMENT_NAME
                       value: "{{workflow.parameters.deployment_name}}"
                     - name: THOTH_MESSAGING_CREATE_IF_NOT_EXIST
                       value: "1"
-                    - name: THOTH_DOCUMENT_ID
-                      value: "{{workflow.parameters.THOTH_SOLVER_WORKFLOW_ID}}"
+                    - name: MESSAGES_DOCUMENT_NAME
+                      value: "adviser_runs_messages.json"

--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -170,7 +170,7 @@ objects:
                 arguments:
                   artifacts:
                     - name: solvermessagesdocument
-                      from: "{{tasks.parse-solved-package.outputs.artifacts.solvermessagesdocument}}"
+                      from: "{{tasks.parse-solver-inputs.outputs.artifacts.solvermessagesdocument}}"
                   parameters:
                     - name: THOTH_MESSAGING_FROM_FILE
                       value: "/mnt/workdir/solved_messages.json"


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/413

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

## This Pull Request implements

Use the correct name of the file to avoid overlapping paths.

Reference: https://github.com/thoth-station/workflow-helpers/blob/cf94990bbddaecb98175bc39abbbf40a32dc04c3/parse_solved_package.py#L148
