### PR TITLE
Bump metrics-exporter version to v0.8.8

### DIFF
--- a/metrics-exporter/overlays/stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.8.7
+        name: quay.io/thoth-station/metrics-exporter:v0.8.8
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/test/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/metrics-exporter:v0.8.7
+      name: quay.io/thoth-station/metrics-exporter:v0.8.8
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>


## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment

## This Pull Request implements

Bump metrics-exporter version to v0.8.8