### PR TITLE
Bump graph-sync version to v0.7.3

### DIFF
--- a/core/overlays/test/imagestreamtags.yaml
+++ b/core/overlays/test/imagestreamtags.yaml
@@ -49,7 +49,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/messaging:v0.7.2
+      name: quay.io/thoth-station/messaging:v0.7.3
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies
Related-To: https://github.com/thoth-station/adviser/issues/1178

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
 Bump version of graph-sync job