### PR TITLE
Bump User API to v0.16.7 in stage environment

### DIFF
--- a/user-api/overlays/stage/imagestreamtag.yaml
+++ b/user-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.6.16
+        name: quay.io/thoth-station/user-api:v0.6.17
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
... this is also probably the last release that is without Kafka support.

## This introduces a breaking change

- [x] No
