### PR TITLE
Bump adviser version to 0.17.0 in stage

### DIFF
--- a/adviser/overlays/stage/imagestreamtag.yaml
+++ b/adviser/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.16.0
+        name: quay.io/thoth-station/adviser:v0.17.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/issues/1226
Fixes: https://github.com/thoth-station/thoth-application/issues/445

## This introduces a breaking change

- [x] No
