### PR TITLE
setup kustomize manifest to handle graph-backup with argocd

### DIFF
--- a/graph-backup-job/overlays/stage/cronjob.yaml
+++ b/graph-backup-job/overlays/stage/cronjob.yaml
@@ -1,0 +1,7 @@
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: graph-backup
+spec:
+  suspend: false

--- a/graph-backup-job/overlays/stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/stage/imagestreamtag.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: graph-backup-job
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/graph-backup-job:v0.7.0
+      importPolicy: {}

--- a/graph-backup-job/overlays/stage/job-generate-name.yaml
+++ b/graph-backup-job/overlays/stage/job-generate-name.yaml
@@ -1,0 +1,6 @@
+- op: move
+  from: /metadata/name
+  path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-infra-stage"

--- a/graph-backup-job/overlays/stage/kustomization.yaml
+++ b/graph-backup-job/overlays/stage/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - cronjob.yaml
+  - imagestreamtag.yaml
+patchesJson6902:
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-success-
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-fail-

--- a/graph-backup-job/overlays/stage/thoth-notification.yaml
+++ b/graph-backup-job/overlays/stage/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-success-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have successfully synchronized *graph-backup* components to *TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-graph-backup|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-fail-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAIL* synchronizing *graph-backup* components to *TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/test-thoth-graph-backup|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2

--- a/graph-backup-job/overlays/test/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/test/imagestreamtag.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: graph-backup-job
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/graph-backup-job:v0.7.0
+      importPolicy: {}

--- a/graph-backup-job/overlays/test/job-generate-name.yaml
+++ b/graph-backup-job/overlays/test/job-generate-name.yaml
@@ -1,0 +1,6 @@
+- op: move
+  from: /metadata/name
+  path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-test-core"

--- a/graph-backup-job/overlays/test/kustomization.yaml
+++ b/graph-backup-job/overlays/test/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+patchesJson6902:
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-success-
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-fail-

--- a/graph-backup-job/overlays/test/thoth-notification.yaml
+++ b/graph-backup-job/overlays/test/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-success-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have successfully synchronized *graph-backup* components to *STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/stage-thoth-graph-backup|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-fail-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAIL* synchronizing *graph-backup* components to *STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp.prod.psi.redhat.com/applications/stage-thoth-graph-backup|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/353

## This introduces a breaking change

- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment

## This Pull Request implements

- setup kustomize manifest to handle graph-backup with argocd

## Description

setup kustomize manifest to handle graph-backup with argocd
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
