### PR TITLE
Adjust version string based on the last version identifier

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
 """Thoth Application."""
 
 __name__ = "thoth-station"
-__version__ = "0.5.0"
+__version__ = "2020.09.17"


### PR DESCRIPTION
## Related Issues and Dependencies

See https://github.com/thoth-station/thoth-application/releases/tag/2020.09.17

## This introduces a breaking change

- [x] No

## Description

With this change, next `New calendar release` issue will trigger computing changelog based on the changes since the last tagged version (that is `2020.09.17`). See https://github.com/thoth-station/kebechet/tree/master/kebechet/managers/version#available-package-release-commands
