### PR TITLE
Move SI workflow to stage to start collecting SI

### DIFF
--- a/graph-sync/overlays/stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.7.2-dev
+        name: quay.io/thoth-station/graph-sync-job:v0.7.4
       importPolicy: {}

--- a/security-indicators/overlays/stage/imagestreamtag.yaml
+++ b/security-indicators/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/si-aggregator:v0.1.2
+      name: quay.io/thoth-station/si-aggregator:v0.1.5
     importPolicy: {}
     referencePolicy:
       type: Source
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/si-bandit:v0.1.3
+      name: quay.io/thoth-station/si-bandit:v0.1.5
     importPolicy: {}
     referencePolicy:
       type: Source
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/si-cloc:v0.1.2
+      name: quay.io/thoth-station/si-cloc:v0.1.3
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related-To: https://github.com/thoth-station/adviser/issues/1178

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment

## This Pull Request implements

Bump versions for SI workflow to start collecting SI about packages