### PR TITLE
Stop revsolver and security messages

### DIFF
--- a/graph-refresh/overlays/test/cronjob.yaml
+++ b/graph-refresh/overlays/test/cronjob.yaml
@@ -46,6 +46,12 @@ spec:
                     configMapKeyRef:
                       key: infra-namespace
                       name: thoth
+                - name: THOTH_GRAPH_REFRESH_SOLVER
+                  value: "1"
+                - name: THOTH_GRAPH_REFRESH_REVSOLVER
+                  value: "0"
+                - name: THOTH_GRAPH_REFRESH_SECURITY
+                  value: "0"
                 - name: THOTH_DEPLOYMENT_NAME
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
## Related Issues and Dependencies
Add env variables to test not sending messages for revsolver and si unanalyzed
Depends on - https://github.com/thoth-station/graph-refresh-job/pull/496
Related - https://github.com/thoth-station/graph-refresh-job/issues/488