### PR TITLE
enable argocli and wc to use local images

### DIFF
--- a/core/overlays/test/argo-namespace-install.yaml
+++ b/core/overlays/test/argo-namespace-install.yaml
@@ -106,6 +106,48 @@ spec:
   selector:
     app: argo-server
 ---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argocli
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argocli:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: workflow-controller
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/workflow-controller:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argoexec
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argoexec:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -123,7 +165,7 @@ spec:
         - args:
             - server
             - --namespaced
-          image: quay.io/thoth-station/argocli:v2.9.5
+          image: argocli
           name: argo-server
           ports:
             - containerPort: 2746
@@ -154,11 +196,11 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoproj/argoexec:v2.11.0
+            - argoexec:latest
             - --namespaced
           command:
             - workflow-controller
-          image: argoproj/workflow-controller:v2.11.0
+          image: workflow-controller
           name: workflow-controller
           resources:
             requests:


### PR DESCRIPTION
## Related Issues and Dependencies

would like to rely on the internal registry

## This introduces a breaking change

- [x] Yes

## Test or Stage Environment

- [x] Pull Requests added content to TEST environment

## This Pull Request implements

include imagestream with refrencepolicy:local

## Description

enable argocli and wc to use local images
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

