### PR TITLE
update argo workloads and metrics-exporter

### DIFF
--- a/amun/overlays/amun-inspection/argo-namespace-install.yaml
+++ b/amun/overlays/amun-inspection/argo-namespace-install.yaml
@@ -56,6 +56,54 @@ spec:
   selector:
     app: argo-server
 ---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argocli
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argocli:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: workflow-controller
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/workflow-controller:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argoexec
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argoexec:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,7 +121,7 @@ spec:
         - args:
             - server
             - --namespaced
-          image: quay.io/thoth-station/argocli:v2.9.5
+          image: argocli
           name: argo-server
           ports:
             - containerPort: 2746
@@ -104,11 +152,11 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - quay.io/thoth-station/argoexec:v2.9.5
+            - argoexec:latest
             - --namespaced
           command:
             - workflow-controller
-          image: quay.io/thoth-station/workflow-controller:fix-3791
+          image: workflow-controller
           name: workflow-controller
           resources:
             requests:

--- a/core/overlays/backend-stage/argo-namespace-install.yaml
+++ b/core/overlays/backend-stage/argo-namespace-install.yaml
@@ -58,6 +58,54 @@ spec:
   selector:
     app: argo-server
 ---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argocli
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argocli:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: workflow-controller
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/workflow-controller:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argoexec
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argoexec:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -75,7 +123,7 @@ spec:
         - args:
             - server
             - --namespaced
-          image: quay.io/thoth-station/argocli:v2.9.5
+          image: argocli
           name: argo-server
           ports:
             - containerPort: 2746
@@ -106,11 +154,11 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - quay.io/thoth-station/argoexec:v2.9.5
+            - argoexec:latest
             - --namespaced
           command:
             - workflow-controller
-          image: quay.io/thoth-station/workflow-controller:fix-3791
+          image: workflow-controller
           name: workflow-controller
           resources:
             requests:
@@ -120,8 +168,3 @@ spec:
               memory: "4Gi"
               cpu: "1"
       serviceAccountName: argo-server
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: workflow-controller-configmap

--- a/core/overlays/backend-stage/kustomization.yaml
+++ b/core/overlays/backend-stage/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - argo-workflow-controller-metrics.yaml
   - argo-ui-route.yaml
   - thoth-notification.yaml
-patchesStrategicMerge:
   - configmaps.yaml
 patchesJson6902:
   - path: job-generate-name.yaml

--- a/core/overlays/middletier-stage/argo-namespace-install.yaml
+++ b/core/overlays/middletier-stage/argo-namespace-install.yaml
@@ -58,6 +58,54 @@ spec:
   selector:
     app: argo-server
 ---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argocli
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argocli:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: workflow-controller
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/workflow-controller:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: argoexec
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/argoexec:v2.11.0
+    importPolicy: {}
+    referencePolicy:
+      type: Local
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -75,7 +123,7 @@ spec:
         - args:
             - server
             - --namespaced
-          image: quay.io/thoth-station/argocli:v2.9.5
+          image: argocli
           name: argo-server
           ports:
             - containerPort: 2746
@@ -106,11 +154,11 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - quay.io/thoth-station/argoexec:v2.9.5
+            - argoexec:latest
             - --namespaced
           command:
             - workflow-controller
-          image: quay.io/thoth-station/workflow-controller:fix-3791
+          image: workflow-controller
           name: workflow-controller
           resources:
             requests:
@@ -120,8 +168,3 @@ spec:
               memory: "8Gi"
               cpu: "1"
       serviceAccountName: argo-server
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: workflow-controller-configmap

--- a/core/overlays/middletier-stage/kustomization.yaml
+++ b/core/overlays/middletier-stage/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - argo-workflow-controller-metrics.yaml
   - argo-ui-route.yaml
   - thoth-notification.yaml
-patchesStrategicMerge:
   - configmaps.yaml
 patchesJson6902:
   - path: job-generate-name.yaml

--- a/metrics-exporter/overlays/stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.8.12
+        name: quay.io/thoth-station/metrics-exporter:v0.8.13
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
- use argo v2.11.0 in stage deployment
- Bump version v0.8.13 for metrics-exporter stage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
