### PR TITLE
remove non used manifest from kustomize manifest

### DIFF
--- a/package-update/base/kustomization.yaml
+++ b/package-update/base/kustomization.yaml
@@ -3,8 +3,6 @@ kind: Kustomization
 resources:
   - cronjob.yaml
   - imagestream.yaml
-  - route.yaml
-  - service.yaml
   - serviceaccount.yaml
 commonLabels:
   app: thoth


### PR DESCRIPTION
## Related Issues and Dependencies

argo application is falling due this.

## This introduces a breaking change

- [x] No

## This Pull Request implements

route and service are removed as they don't exist anymore.

## Description

remove non used manifest from kustomize manifest
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
