### PR TITLE
Bump versions for qeb-hwt and user-api

### DIFF
--- a/qeb-hwt-github-app/overlays/ocp/imagestreamtag.yaml
+++ b/qeb-hwt-github-app/overlays/ocp/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/qeb-hwt-webhook-receiver:v0.3.0
+      name: quay.io/thoth-station/qeb-hwt-webhook-receiver:v0.3.1
     importPolicy: {}
     referencePolicy:
       type: Source

--- a/user-api/overlays/stage/imagestreamtag.yaml
+++ b/user-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.6.17
+        name: quay.io/thoth-station/user-api:v0.6.18
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Bump versions to schedule workflows correctly with new thoth-common