### PR TITLE
add missing variables to list solvers

### DIFF
--- a/graph-refresh/base/cronjob.yaml
+++ b/graph-refresh/base/cronjob.yaml
@@ -46,6 +46,11 @@ spec:
                     configMapKeyRef:
                       key: infra-namespace
                       name: thoth
+                - name: THOTH_INFRA_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      key: infra-namespace
+                      name: thoth
                 - name: THOTH_GRAPH_REFRESH_SOLVER
                   value: "1"
                 - name: THOTH_GRAPH_REFRESH_REVSOLVER


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
020-09-25 17:22:51,112] [1] [ERROR] [^Worker]: Error: ConfigurationError('Infra namespace is required in order to list solvers',) 
Traceback (most recent call last):
  File "/opt/app-root/lib/python3.6/site-packages/mode/worker.py", line 273, in execute_from_commandline
    self.loop.run_until_complete(self._starting_fut)
  File "/usr/lib64/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
    await self._default_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
    await self._actually_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 767, in _actually_start
    await child.maybe_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 795, in maybe_start
    await self.start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
    await self._default_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
    await self._actually_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 760, in _actually_start
    await self.on_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 1073, in on_start
    await self._fut
  File "/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py", line 598, in execute
    await self.run(*args, **kwargs)
  File "/opt/app-root/src/producer.py", line 136, in main
    packages = _unsolved_packages(indexes)
  File "/opt/app-root/src/producer.py", line 89, in _unsolved_packages
    solver_names = _OPENSHIFT.get_solver_names()
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/openshift.py", line 841, in get_solver_names
    "Infra namespace is required in order to list solvers"
thoth.common.exceptions.ConfigurationError: Infra namespace is required in order to list solvers
[2020-09-25 17:22:51,147] [1] [ERROR] [^Worker]: Error while stopping child <main: stopping >: ConfigurationError('Infra namespace is required in order to list solvers',) 
Traceback (most recent call last):
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 863, in _default_stop_children
    await asyncio.shield(child.stop())
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 839, in stop
    await self.on_stop()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 1084, in on_stop
    fut.result()
  File "/opt/app-root/lib/python3.6/site-packages/mode/worker.py", line 273, in execute_from_commandline
    self.loop.run_until_complete(self._starting_fut)
  File "/usr/lib64/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
    await self._default_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
    await self._actually_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 767, in _actually_start
    await child.maybe_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 795, in maybe_start
    await self.start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 736, in start
    await self._default_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 743, in _default_start
    await self._actually_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 760, in _actually_start
    await self.on_start()
  File "/opt/app-root/lib/python3.6/site-packages/mode/services.py", line 1073, in on_start
    await self._fut
  File "/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py", line 598, in execute
    await self.run(*args, **kwargs)
  File "/opt/app-root/src/producer.py", line 136, in main
    packages = _unsolved_packages(indexes)
  File "/opt/app-root/src/producer.py", line 89, in _unsolved_packages
    solver_names = _OPENSHIFT.get_solver_names()
  File "/opt/app-root/lib/python3.6/site-packages/thoth/common/openshift.py", line 841, in get_solver_names
    "Infra namespace is required in order to list solvers"
thoth.common.exceptions.ConfigurationError: Infra namespace is required in order to list solvers
```