### PR TITLE
Bump management-api to v0.7.2 to update schema

### DIFF
--- a/management-api/overlays/stage/imagestreamtag.yaml
+++ b/management-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.7.1
+      name: quay.io/thoth-station/management-api:v0.7.2
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

