### PR TITLE
Bump multiple component releases to stage

### DIFF
--- a/core/overlays/stage/imagestreamtags.yaml
+++ b/core/overlays/stage/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.5.0
+      name: quay.io/thoth-station/investigator:v0.5.1
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -49,7 +49,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/messaging:v0.7.8
+      name: quay.io/thoth-station/messaging:v0.7.10
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/metrics-exporter/overlays/stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.8.14
+        name: quay.io/thoth-station/metrics-exporter:v0.8.15
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

stage overlays changes for `core` and `metrics-exporter` imagestreams
```
      name: quay.io/thoth-station/investigator:v0.5.1
      name: quay.io/thoth-station/metrics-exporter:v0.8.15
      name: quay.io/thoth-station/messaging:v0.7.10
```