### PR TITLE
Thoth does not SI analyze package that do not provide distro

### DIFF
--- a/core/overlays/stage/imagestreamtags.yaml
+++ b/core/overlays/stage/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.1.13
+      name: quay.io/thoth-station/workflow-helpers:v0.1.15
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/security-indicators/base/argo-workflows/download-package-template.yaml
+++ b/security-indicators/base/argo-workflows/download-package-template.yaml
@@ -7,7 +7,24 @@ metadata:
     component: download-package
 spec:
   templates:
-    - container:
+    - name: download-package
+      resubmitPendingPods: true
+      inputs:
+        parameters:
+          - name: THOTH_PACKAGE_NAME
+          - name: THOTH_PACKAGE_VERSION
+          - name: THOTH_PACKAGE_INDEX
+      outputs:
+        artifacts:
+          - name: messagestobesentdocument
+            path: "/mnt/workdir/message"
+        parameters:
+          - name: failed_status
+            valueFrom:
+              path: /mnt/workdir/failed_status
+      container:
+        name: download-package
+        image: workflow-helpers:test
         env:
           - name: THOTH_WORKFLOW_TASK
             value: download_package
@@ -19,8 +36,6 @@ spec:
             value: "{{inputs.parameters.THOTH_PACKAGE_VERSION}}"
           - name: THOTH_PACKAGE_INDEX
             value: "{{inputs.parameters.THOTH_PACKAGE_INDEX}}"
-        image: "workflow-helpers"
-        name: download-package
         resources:
           limits:
             cpu: 250m
@@ -31,10 +46,3 @@ spec:
         volumeMounts:
           - mountPath: /mnt/workdir
             name: workdir
-      inputs:
-        parameters:
-          - name: THOTH_PACKAGE_NAME
-          - name: THOTH_PACKAGE_VERSION
-          - name: THOTH_PACKAGE_INDEX
-      resubmitPendingPods: true
-      name: download-package

--- a/security-indicators/base/openshift-templates/security-indicators.yaml
+++ b/security-indicators/base/openshift-templates/security-indicators.yaml
@@ -87,6 +87,13 @@ objects:
 
       onExit: exit-handler
       serviceAccountName: argo
+      volumes:
+        - name: kafka-secrets
+          secret:
+            secretName: "kafka"
+            items:
+              - key: kafka_ca.crt
+                path: kafka_ca.crt
       templates:
         - name: security-indicators
           archiveLocation:
@@ -132,6 +139,7 @@ objects:
                         {{workflow.parameters.THOTH_SECURITY_INDICATORS_PACKAGE_INDEX}}
                     - name: THOTH_SI_BANDIT_DIR
                       value: /mnt/workdir/package
+                when: "{{tasks.download-package.outputs.parameters.failed_status}} == 0"
 
               - name: cloc
                 templateRef:
@@ -156,6 +164,28 @@ objects:
                         {{workflow.parameters.THOTH_SECURITY_INDICATORS_PACKAGE_INDEX}}
                     - name: THOTH_SI_CLOC_DIR
                       value: /mnt/workdir/package
+                when: "{{tasks.download-package.outputs.parameters.failed_status}} == 0"
+
+              - name: "send-messages"
+                dependencies:
+                  - "download-package"
+                templateRef:
+                  name: "send-messages"
+                  template: "send-messages"
+                arguments:
+                  artifacts:
+                    - name: messagesdocument
+                      from: "{{tasks.download-package.outputs.artifacts.messagestobesentdocument}}"
+                  parameters:
+                    - name: THOTH_MESSAGING_FROM_FILE
+                      value: "/mnt/workdir/message"
+                    - name: THOTH_DEPLOYMENT_NAME
+                      value: "{{workflow.parameters.deployment_name}}"
+                    - name: THOTH_MESSAGING_CREATE_IF_NOT_EXIST
+                      value: "1"
+                    - name: MESSAGES_DOCUMENT_NAME
+                      value: "message"
+                when: "{{tasks.download-package.outputs.parameters.failed_status}} == 1"
 
               - name: aggregator
                 templateRef:
@@ -190,6 +220,7 @@ objects:
                       value: "{{workflow.parameters.ceph_bucket_prefix}}"
                     - name: THOTH_DEPLOYMENT_NAME
                       value: "{{workflow.parameters.deployment_name}}"
+                when: "{{tasks.download-package.outputs.parameters.failed_status}} == 0"
 
               - name: "graph-sync-security-indicators"
                 dependencies:
@@ -206,6 +237,7 @@ objects:
                       value: "{{workflow.parameters.THOTH_DOCUMENT_ID}}"
                     - name: "THOTH_FORCE_SYNC"
                       value: "{{workflow.parameters.THOTH_FORCE_SYNC}}"
+                when: "{{tasks.download-package.outputs.parameters.failed_status}} == 0"
 
         - name: exit-handler
           steps:

--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -189,7 +189,7 @@ objects:
                     - name: "THOTH_SOLVER_NAME"
                       value: "{{workflow.parameters.THOTH_SOLVER_NAME}}"
 
-              - name: "send-messages-to-be-sent"
+              - name: "send-messages"
                 dependencies:
                   - "parse-solver-output"
                 templateRef:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/507

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

## This Pull Request implements

- Introduce new SI workflow modified to handle SI packages that cannot be analyzed by SI workflow due to missing distro.

finalizing work done with @KPostOffice 

## Description
nominal behaviour of SI workflow
```
STEP                                    TEMPLATE                           PODNAME                                 DURATION  MESSAGE
 ✔ security-indicator-daf9123a          security-indicators                                                                                                                 
 ├-✔ download-package                   download-package/download-package  security-indicator-daf9123a-2672485178  41s                                                      
 ├-✔ bandit                             bandit/bandit-from-dir             security-indicator-daf9123a-3229911405  24s                                                      
 ├-✔ cloc                               cloc/cloc-from-dir                 security-indicator-daf9123a-4211979394  21s                                                      
 ├-○ send-messages                      send-messages/send-messages                                                          when '0 == 1' evaluated false                  
 ├-✔ aggregator                         aggregator/aggregator              security-indicator-daf9123a-2893587926  33s                                                      
 └-✔ graph-sync-security-indicators(0)  graph-sync/graph-sync              security-indicator-daf9123a-2375423464  41s                                                      
                                                                                                                                                                                     
 ✔ security-indicator-daf9123a.onExit   exit-handler                                                                                                                        
 └---○ delete-pvc                       delete-pvc                                                                           when 'Succeeded != Succeeded' evaluated false  
```

known errors for downloading package in SI workflow
```
STEP                                   TEMPLATE                           PODNAME                                 DURATION  MESSAGE
 ✔ security-indicator-40216e1d         security-indicators                                                                                                                 
 ├-✔ download-package                  download-package/download-package  security-indicator-40216e1d-1845393890  36s                                                      
 ├-○ aggregator                        aggregator/aggregator                                                                when '1 == 0' evaluated false                  
 ├-○ bandit                            bandit/bandit-from-dir                                                               when '1 == 0' evaluated false                  
 ├-○ cloc                              cloc/cloc-from-dir                                                                   when '1 == 0' evaluated false                  
 ├-○ graph-sync-security-indicators    graph-sync/graph-sync                                                                when '1 == 0' evaluated false                  
 └-✔ send-messages                     send-messages/send-messages        security-indicator-40216e1d-3487424176  23s                                                      
                                                                                                                                                                                    
 ✔ security-indicator-40216e1d.onExit  exit-handler                                                                                                                        
 └---○ delete-pvc                      delete-pvc                                                                           when 'Succeeded != Succeeded' evaluated false  
```

thoth database is updated with the message sent by SI workflow and next run graph-refresh does not send message to reschedule SI workflow:

![Screenshot from 2020-10-02 11-18-57](https://user-images.githubusercontent.com/27498679/94908188-9cb0a480-04a1-11eb-8c70-36f939e0681f.png)

Thoth becomes smarter





