### PR TITLE
Move CM to core so it is available to adviser and qeb-hwt

### DIFF
--- a/core/base/configmaps.yaml
+++ b/core/base/configmaps.yaml
@@ -36,3 +36,11 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus
+---
+# Change webhook and split into test, stage, prod once available
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: qeb-hwt-workflow
+data:
+  webhook-callback-url: "http://qeb-hwt-webhook-receiver-aicoe-prod-bots.apps.ocp.prod.psi.redhat.com"

--- a/core/base/configmaps.yaml
+++ b/core/base/configmaps.yaml
@@ -36,3 +36,8 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: qeb-hwt-workflow

--- a/core/base/configmaps.yaml
+++ b/core/base/configmaps.yaml
@@ -36,11 +36,3 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus
----
-# Change webhook and split into test, stage, prod once available
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: qeb-hwt-workflow
-data:
-  webhook-callback-url: "http://qeb-hwt-webhook-receiver-aicoe-prod-bots.apps.ocp.prod.psi.redhat.com"

--- a/core/overlays/stage/configmaps.yaml
+++ b/core/overlays/stage/configmaps.yaml
@@ -58,3 +58,10 @@ data:
   instance-workflow-controller-metrics-backend: "workflow-controller-metrics-thoth-backend-stage.apps.ocp.prod.psi.redhat.com:80"
   instance-workflow-controller-metrics-middletier: "workflow-controller-metrics-thoth-middletier-stage.apps.ocp.prod.psi.redhat.com:80"
   instance-workflow-controller-metrics-amun-inspection: "workflow-controller-metrics-thoth-amun-inspection-stage.apps.ocp.prod.psi.redhat.com:80"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: qeb-hwt-workflow
+data:
+  webhook-callback-url: "http://qeb-hwt-webhook-receiver-aicoe-prod-bots.apps.ocp.prod.psi.redhat.com"

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -97,3 +97,10 @@ data:
   instance-workflow-controller-metrics-backend: "workflow-controller-metrics-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
   instance-workflow-controller-metrics-middletier: "workflow-controller-metrics-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
   instance-workflow-controller-metrics-amun-inspection: "workflow-controller-metrics-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: qeb-hwt-workflow
+data:
+  webhook-callback-url: "http://qeb-hwt-webhook-receiver-aicoe-prod-bots.apps.ocp.prod.psi.redhat.com"

--- a/qeb-hwt-github-app/overlays/ocp/configmap.yaml
+++ b/qeb-hwt-github-app/overlays/ocp/configmap.yaml
@@ -6,11 +6,3 @@ metadata:
 data:
   subdomain: qeb-hwt
   webhook-callback-url: "http://qeb-hwt-webhook-receiver-aicoe-prod-bots.apps.ocp.prod.psi.redhat.com"
----
-# Duplicate configmap as this would be moved to backend namespace
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: qeb-hwt-workflow
-data:
-  webhook-callback-url: "http://qeb-hwt-webhook-receiver-aicoe-prod-bots.apps.ocp.prod.psi.redhat.com"

--- a/qeb-hwt-github-app/overlays/ocp/kustomization.yaml
+++ b/qeb-hwt-github-app/overlays/ocp/kustomization.yaml
@@ -43,9 +43,3 @@ patchesJson6902:
       version: v1
       kind: Secret
       name: qeb-hwt-secret
-  - path: put-into-backend-namespace.yaml
-    target:
-      group: ""
-      version: v1
-      kind: ConfigMap
-      name: qeb-hwt-workflow


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

`CreateContainerConfigError: configmap "qeb-hwt-workflow" not found` in trigger integration task in adviser workflow