### PR TITLE
Add missing parameter in core CM

### DIFF
--- a/core/overlays/stage/configmaps.yaml
+++ b/core/overlays/stage/configmaps.yaml
@@ -49,6 +49,7 @@ metadata:
   name: prometheus
 data:
   host-url: "https://prometheus-dh-prod-monitoring.cloud.datahub.psi.redhat.com"
+  user-api-url: "user-api-thoth-frontend-stage.apps.ocp.prod.psi.redhat.com:80"
   instance-metrics-exporter-infra: "metrics-exporter-thoth-infra-stage.apps.ocp.prod.psi.redhat.com:80"
   instance-metrics-management-api: "management-api-thoth-frontend-stage.apps.ocp.prod.psi.redhat.com:80"
   pushgateway-host: pushgateway-dh-prod-monitoring.cloud.datahub.psi.redhat.com


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

`Error: couldn't find key user-api-url in ConfigMap thoth-frontend-stage/prometheus`