### PR TITLE
allow metrics exporter to get imagestreams

### DIFF
--- a/metrics-exporter/base/role.yaml
+++ b/metrics-exporter/base/role.yaml
@@ -22,3 +22,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+      - image.openshift.io
+    resources:
+      - imagestreamimages
+      - imagestreammappings
+      - imagestreams
+      - imagestreamtags
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #555 

## This introduces a breaking change

- [x] Yes
- [ ] No

## This Pull Request implements

- roles are added for metrics-exporter.

## Description

allow metrics exporter to get imagestreams
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
