### PR TITLE
Add missing variable for adviser to send messages

### DIFF
--- a/adviser/base/argo-workflows/investigate-unresolved-package.yaml
+++ b/adviser/base/argo-workflows/investigate-unresolved-package.yaml
@@ -36,6 +36,16 @@ spec:
             value: "https://kubernetes.default.svc.cluster.local"
           - name: KUBERNETES_VERIFY_TLS
             value: "0"
+          - name: THOTH_BACKEND_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: backend-namespace
+          - name: THOTH_MIDDLETIER_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: middletier-namespace
         resources:
           limits:
             cpu: 250m


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

One task in adviser workflow fails:
```
  THOTH_ADVISER_LIBRARY_USAGE: {"report": {"template": ["template.version.__version__"]}, "version": "0.0.7"}
  THOTH_ADVISER_REQUIREMENTS_FORMAT: pipenv
  THOTH_ADVISER_RECOMMENDATION_TYPE: security
  THOTH_ADVISER_RUNTIME_ENVIRONMENT: {"hardware": {"cpu_family": null, "cpu_model": null}, "operating_system": {"name": "ubi", "version": "8"}, "python_version": "3.6", "cuda_version": null, "name": "ubi8", "platform": null}
  THOTH_ADVISER_METADATA: {"github_event_type": null, "github_check_run_id": null, "github_installation_id": null, "github_base_repo_url": null, "origin": "git@github.com:pacospace/thamos-advise-security.git", "re_run_adviser_id": null, "source_type": "CLI"}
  THOTH_ADVISER_PREDICTOR_CONFIG: {}
  THOTH_ADVISER_DEV: 0
  THOTH_ADVISER_SEED: 42
  THOTH_ADVISER_BEAM_WIDTH: 25000
  THOTH_ADVISER_LIMIT: 100000
  THOTH_ADVISER_COUNT: 1
  THOTH_FORCE_SYNC:  0

STEP                        TEMPLATE                                     PODNAME                      DURATION  MESSAGE
 ✖ adviser-f460cd75         adviser                                                                                                                     
 ├-✔ advise                 advise/advise                                adviser-f460cd75-2269396111  18m                                               
 ├-✖ investigator-producer  investigator-producer/investigator-producer  adviser-f460cd75-1648899731  33s       failed with exit code 1                 
 ├-✔ trigger-integration    trigger-integration/trigger-integration      adviser-f460cd75-1679231722  25s                                               
 ├-✔ graph-sync-advise(0)   graph-sync/graph-sync                        adviser-f460cd75-3904643113  27s                                               
 └-○ kebechet-run-results   kebechet-run-results/schedule-kebechet                                              when 'CLI == KEBECHET' evaluated false  

```


```
adviser-f460cd75-3904643113: 2020-10-09T17:03:33.433826423Z 2020-10-09 17:03:33,433   1 WARNING  thoth.storages.graph.postgres:4680: No s2i flag stated in the adviser result 'adviser-f460cd75'
adviser-f460cd75-1648899731: 2020-10-09T17:03:38.308904366Z {"name": "thoth.common", "levelname": "WARNING", "module": "logging", "lineno": 344, "funcname": "init_logging", "created": 1602263018.308493, "asctime": "2020-10-09 17:03:38,308", "msecs": 308.49289894104004, "relative_created": 9609.778881072998, "process": 1, "message": "Logging to a Sentry instance is turned off"}
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.493180677Z Traceback (most recent call last):
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.493180677Z   File "/opt/app-root/bin/faust", line 8, in <module>
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.49337754Z     sys.exit(cli())
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.49337754Z   File "/opt/app-root/lib/python3.6/site-packages/click/core.py", line 829, in __call__
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.493778392Z     return self.main(*args, **kwargs)
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.493778392Z   File "/opt/app-root/lib/python3.6/site-packages/click/core.py", line 781, in main
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494028338Z     with self.make_context(prog_name, args, **extra) as ctx:
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494028338Z   File "/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py", line 407, in make_context
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494212228Z     self._maybe_import_app()
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494212228Z   File "/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py", line 372, in _maybe_import_app
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494345663Z   File "/opt/app-root/lib/python3.6/site-packages/faust/cli/base.py", line 299, in find_app
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494345663Z     find_app(appstr)
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494473821Z   File "/opt/app-root/lib/python3.6/site-packages/mode/utils/imports.py", line 269, in symbol_by_name
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494473821Z     val = symbol_by_name(app, imp=imp)
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494636945Z     **kwargs)
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494636945Z   File "/opt/app-root/lib/python3.6/site-packages/mode/utils/imports.py", line 376, in import_from_cwd
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.49474496Z     return imp(module, package=package)
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.49474496Z   File "/opt/app-root/lib64/python3.6/importlib/__init__.py", line 126, in import_module
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494864685Z     return _bootstrap._gcd_import(name[level:], package, level)
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.494864685Z   File "<frozen importlib._bootstrap>", line 994, in _gcd_import
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495061352Z   File "<frozen importlib._bootstrap>", line 971, in _find_and_load
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495115951Z   File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495219836Z   File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495277889Z   File "<frozen importlib._bootstrap_external>", line 678, in exec_module
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495423328Z   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495515119Z   File "/opt/app-root/src/producer.py", line 26, in <module>
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495588736Z     from investigator.investigator.unresolved_package import investigate_unresolved_package
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495588736Z   File "/opt/app-root/src/investigator/investigator/unresolved_package/__init__.py", line 20, in <module>
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495677953Z     from .investigate_unresolved_package import parse_unresolved_package_message
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495677953Z   File "/opt/app-root/src/investigator/investigator/unresolved_package/investigate_unresolved_package.py", line 36, in <module>
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.49576587Z   File "/opt/app-root/src/investigator/investigator/common.py", line 33, in <module>
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.49576587Z     from .. import common
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495833729Z     from .configuration import Configuration
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495833729Z   File "/opt/app-root/src/investigator/investigator/configuration.py", line 28, in <module>
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495896555Z     class Configuration:
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495896555Z   File "/opt/app-root/src/investigator/investigator/configuration.py", line 32, in Configuration
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495956518Z     THOTH_BACKEND_NAMESPACE = os.environ["THOTH_BACKEND_NAMESPACE"]
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.495956518Z   File "/opt/app-root/lib64/python3.6/os.py", line 669, in __getitem__
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.496226614Z     raise KeyError(key) from None
adviser-f460cd75-1648899731: 2020-10-09T17:03:39.496226614Z KeyError: 'THOTH_BACKEND_NAMESPACE'

```
