### PR TITLE
bump nepthys image version v0.2.2-dev

### DIFF
--- a/nepthys/overlays/ocp/imagestreamtag.yaml
+++ b/nepthys/overlays/ocp/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/nepthys:v0.2.2
+        name: quay.io/thoth-station/nepthys:v0.2.2-dev
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: #563 
The kebechet release management is stuck in the pipeline, the consumer is having trouble scheduling these workflows.
causing hindrance in the release cycle. Following issue is stuck https://github.com/thoth-station/nepthys/issues/42
For the time being, this dev image is developed for the successful execution of the application.

## This introduces a breaking change

- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment

## This Pull Request implements

updated the imagestream to new version of image.

## Description

bump nepthys image version v0.2.2-dev
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
