### PR TITLE
setup kafka-protocol env var for all kafka using applications

### DIFF
--- a/advise-reporter/base/cronjob.yaml
+++ b/advise-reporter/base/cronjob.yaml
@@ -26,6 +26,11 @@ spec:
                     configMapKeyRef:
                       key: kafka-bootstrap-servers
                       name: kafka
+                - name: KAFKA_PROTOCOL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: kafka-protocol
+                      name: kafka
                 - name: KAFKA_CAFILE
                   value: "/mnt/secrets/kafka_ca.crt"
                 - name: RSYSLOG_HOST

--- a/adviser/base/argo-workflows/investigate-unresolved-package.yaml
+++ b/adviser/base/argo-workflows/investigate-unresolved-package.yaml
@@ -30,6 +30,11 @@ spec:
               configMapKeyRef:
                 key: kafka-bootstrap-servers
                 name: kafka
+          - name: KAFKA_PROTOCOL
+            valueFrom:
+              configMapKeyRef:
+                key: kafka-protocol
+                name: kafka
           - name: KAFKA_CAFILE
             value: "/mnt/secrets/kafka_ca.crt"
           - name: KUBERNETES_API_URL

--- a/core/base/argo-workflows/send-message.yaml
+++ b/core/base/argo-workflows/send-message.yaml
@@ -45,6 +45,11 @@ spec:
               configMapKeyRef:
                 name: kafka
                 key: kafka-bootstrap-servers
+          - name: KAFKA_PROTOCOL
+            valueFrom:
+              configMapKeyRef:
+                key: kafka-protocol
+                name: kafka
           - name: KAFKA_CAFILE
             value: "/mnt/kafka-secrets/kafka_ca.crt"
         volumeMounts:

--- a/core/base/argo-workflows/send-messages.yaml
+++ b/core/base/argo-workflows/send-messages.yaml
@@ -49,6 +49,11 @@ spec:
               configMapKeyRef:
                 name: kafka
                 key: kafka-bootstrap-servers
+          - name: KAFKA_PROTOCOL
+            valueFrom:
+              configMapKeyRef:
+                key: kafka-protocol
+                name: kafka
           - name: KAFKA_CAFILE
             value: "/mnt/kafka-secrets/kafka_ca.crt"
         volumeMounts:

--- a/core/overlays/stage/configmaps.yaml
+++ b/core/overlays/stage/configmaps.yaml
@@ -41,6 +41,7 @@ apiVersion: v1
 metadata:
   name: kafka
 data:
+  kafka-protocol: "SSL"
   kafka-bootstrap-servers: "thoth-kafka-bootstrap-thoth-infra-stage.apps.thoth02.lab.upshift.rdu2.redhat.com:443"
 ---
 kind: ConfigMap

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -41,6 +41,7 @@ apiVersion: v1
 metadata:
   name: kafka
 data:
+  kafka-protocol: "SSL"
   kafka-bootstrap-servers: "thoth-kafka-bootstrap-aicoe.apps.ocp.prod.psi.redhat.com:443"
 ---
 kind: ConfigMap

--- a/graph-refresh/base/cronjob.yaml
+++ b/graph-refresh/base/cronjob.yaml
@@ -35,6 +35,11 @@ spec:
                     configMapKeyRef:
                       name: kafka
                       key: kafka-bootstrap-servers
+                - name: KAFKA_PROTOCOL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: kafka-protocol
+                      name: kafka
                 - name: KAFKA_CAFILE
                   value: "/mnt/secrets/kafka_ca.crt"
                 - name: KUBERNETES_API_URL

--- a/investigator/base/deploymentconfig.yaml
+++ b/investigator/base/deploymentconfig.yaml
@@ -34,6 +34,11 @@ spec:
                 configMapKeyRef:
                   name: kafka
                   key: kafka-bootstrap-servers
+            - name: KAFKA_PROTOCOL
+              valueFrom:
+                configMapKeyRef:
+                  key: kafka-protocol
+                  name: kafka
             - name: KAFKA_CAFILE
               value: "/mnt/secrets/kafka_ca.crt"
             - name: KNOWLEDGE_GRAPH_HOST

--- a/package-releases/base/cronjob.yaml
+++ b/package-releases/base/cronjob.yaml
@@ -34,6 +34,11 @@ spec:
                     configMapKeyRef:
                       key: kafka-bootstrap-servers
                       name: kafka
+                - name: KAFKA_PROTOCOL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: kafka-protocol
+                      name: kafka
                 - name: KAFKA_CAFILE
                   value: "/mnt/secrets/kafka_ca.crt"
                 - name: THOTH_PACKAGE_RELEASES_ONLY_IF_PACKAGE_SEEN

--- a/package-update/base/cronjob.yaml
+++ b/package-update/base/cronjob.yaml
@@ -26,6 +26,11 @@ spec:
                     configMapKeyRef:
                       key: kafka-bootstrap-servers
                       name: kafka
+                - name: KAFKA_PROTOCOL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: kafka-protocol
+                      name: kafka
                 - name: KAFKA_CAFILE
                   value: "/mnt/secrets/kafka_ca.crt"
                 - name: RSYSLOG_HOST

--- a/user-api/base/deploymentconfig.yaml
+++ b/user-api/base/deploymentconfig.yaml
@@ -155,6 +155,11 @@ spec:
                 configMapKeyRef:
                   name: kafka
                   key: kafka-bootstrap-servers
+            - name: KAFKA_PROTOCOL
+              valueFrom:
+                configMapKeyRef:
+                  key: kafka-protocol
+                  name: kafka
             - name: KAFKA_CAFILE
               value: "/mnt/secrets/kafka_ca.crt"
           ports:


### PR DESCRIPTION
## This Pull Request implements

updated the environment variable required for kafka connection.
## Description

setup kafka-protocol env var for all kafka using applications
This variable is required in any application using `thoth-messaging>0.7.11`
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
