### PR TITLE
Bump adviser to v0.19.0 in stage

### DIFF
--- a/adviser/overlays/stage/imagestreamtag.yaml
+++ b/adviser/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.18.0
+        name: quay.io/thoth-station/adviser:v0.19.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/pull/1504

## This introduces a breaking change

- [x] No
