### PR TITLE
Set logging to WARNING for sentry_sdk.errors logger

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -99,7 +99,7 @@ spec:
           - name: THOTH_LOG_ADVISER
             value: "{{inputs.parameters.THOTH_LOG_ADVISER}}"
           - name: THOTH_ADJUST_LOGGING
-            value: "alembic.runtime.migration:WARNING,thoth.common:WARNING,thoth.analyzer.cli:WARNING"
+            value: "alembic.runtime.migration:WARNING,thoth.common:WARNING,thoth.analyzer.cli:WARNING,sentry_sdk.errors:WARNING"
           - name: THOTH_SENTRY_IGNORE_LOGGER
             value: "thoth.adviser.run"
           - name: THOTH_ADVISER_COUNT


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/common/issues/1004

## This introduces a breaking change

- [x] No
