### PR TITLE
Add additional wait before the resolver is terminated

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -189,6 +189,7 @@ spec:
             command:
               - python3
               - liveness.py
-          failureThreshold: 1
+          failureThreshold: 3
           initialDelaySeconds: 1500
           timeoutSeconds: 600
+          periodSeconds: 120


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/pull/1527

## This introduces a breaking change

- [x] No

## This Pull Request implements

With  https://github.com/thoth-station/adviser/pull/1527 we implemented https://github.com/thoth-station/adviser/issues/1526. When running adviser in deployment, we expect the first liveness probe to send SIGUSR1 signal which tells predictor to perform the exploitation phase as it will soon be terminated. The second signal SIGINT is handled by the resolver to stop the resolution process and report back any results computed so far. With SIGUSR1 and subsequent SIGINT signals, we are able to start the exploitation phase (if it haven't been reached until that point) before the adviser terminates and deliver better results that were found until that point.