### PR TITLE
Bump management-api to v0.8.1 in stage

### DIFF
--- a/management-api/overlays/stage/imagestreamtag.yaml
+++ b/management-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.8.0
+      name: quay.io/thoth-station/management-api:v0.8.1
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

