### PR TITLE
Bump user-api to v0.7.0 in stage environment

### DIFF
--- a/user-api/overlays/stage/imagestreamtag.yaml
+++ b/user-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.6.20
+        name: quay.io/thoth-station/user-api:v0.7.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/user-api/issues/1130

## This introduces a breaking change

- [x] No
