### PR TITLE
Revert "Bump user-api to v0.7.0 in stage environment"

### DIFF
--- a/user-api/overlays/stage/imagestreamtag.yaml
+++ b/user-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.7.0
+        name: quay.io/thoth-station/user-api:v0.6.20
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Reverts thoth-station/thoth-application#621
See issue reported in https://github.com/thoth-station/user-api/issues/1133