### PR TITLE
Fix expansion of env variables

### DIFF
--- a/amun/base/argo-workflows/inspection-build-with-cpu.yaml
+++ b/amun/base/argo-workflows/inspection-build-with-cpu.yaml
@@ -267,10 +267,10 @@ spec:
           mkdir -p "$results"
           kubectl logs "{{inputs.parameters.inspection-id}}-1-build" > "${results}/log"
 
-          cat <<< {{inputs.parameters.specification}} | jq . > "${results}/specification"
+          cat <<< "{{inputs.parameters.specification}}" | jq . > "${results}/specification"
 
           set +e
-          cat <<< {{inputs.parameters.dockerfile}} > "${results}/Dockerfile"
+          cat <<< "{{inputs.parameters.dockerfile}}" > "${results}/Dockerfile"
           set -e
 
           # Fail if the build failed but let the build log, specification and Dockerfile aggregated.

--- a/amun/base/argo-workflows/inspection-build.yaml
+++ b/amun/base/argo-workflows/inspection-build.yaml
@@ -233,10 +233,10 @@ spec:
           mkdir -p "$results"
           kubectl logs "{{inputs.parameters.inspection-id}}-1-build" > "${results}/log"
 
-          cat <<< {{inputs.parameters.specification}} | jq . > "${results}/specification"
+          cat <<< "{{inputs.parameters.specification}}" | jq . > "${results}/specification"
 
           set +e
-          cat <<< {{inputs.parameters.dockerfile}} > "${results}/Dockerfile"
+          cat <<< "{{inputs.parameters.dockerfile}}" > "${results}/Dockerfile"
           set -e
 
           # Fail if the build failed but let the build log, specification and Dockerfile aggregated.


### PR DESCRIPTION
## Related Issues and Dependencies

Related: #624 

```
+ results=/mnt/build/
+ mkdir -p /mnt/build/
+ kubectl logs inspection-test-dca0953e-1-build
+ jq .
+ cat registry.access.redhat.com/ubi8/python-36, batch_size: 1, build: '{requests:' '{cpu:' 1, hardware: '{cpu_family:' 6, cpu_model: 94, physical_cpus: 32, processor: 'Intel-Xeon-Processor-Skylake-IBRS},' memory: '1Gi}},' environment: '[{name:' string, value: 'string}],' files: '[{content:' string, path: 'string}],' identifier: test, package_manager: micropipenv, packages: '[vim],' python: '{requirements:' '{},' requirements_locked: '{}},' python_packages: '[pipenv],' run: '{requests:' '{cpu:' 1, hardware: '{cpu_family:' 6, cpu_model: 94, physical_cpus: 32, processor: 'Intel-Xeon-Processor-Skylake-IBRS},' memory: '512Mi}},' script: '#!/usr/bin/bash\necho "Here should be run tests..."\n,' update: true, upgrade_pip: false, @created: '2020-11-09T12:27:52.078021}'
cat: registry.access.redhat.com/ubi8/python-36,: No such file or directory
cat: 'batch_size:': No such file or directory
cat: 1,: No such file or directory
cat: 'build:': No such file or directory
cat: '{requests:': No such file or directory
cat: '{cpu:': No such file or directory
cat: 1,: No such file or directory
cat: 'hardware:': No such file or directory
cat: '{cpu_family:': No such file or directory
cat: 6,: No such file or directory
cat: 'cpu_model:': No such file or directory
cat: 94,: No such file or directory
```

## This introduces a breaking change

- [x] No
