### PR TITLE
Another try to fix expansion

### DIFF
--- a/amun/base/argo-workflows/inspection-build-with-cpu.yaml
+++ b/amun/base/argo-workflows/inspection-build-with-cpu.yaml
@@ -267,10 +267,18 @@ spec:
           mkdir -p "$results"
           kubectl logs "{{inputs.parameters.inspection-id}}-1-build" > "${results}/log"
 
-          cat <<< "{{inputs.parameters.specification}}" | jq . > "${results}/specification"
+          spec=`cat <<__EOF__
+          {{inputs.parameters.specification}}
+          __EOF__
+          `
+          echo "${spec}" | jq . > "${results}/specification"
 
           set +e
-          cat <<< "{{inputs.parameters.dockerfile}}" > "${results}/Dockerfile"
+          dockerfile=`cat <<__EOF__
+          {{inputs.parameters.dockerfile}}
+          __EOF__
+          `
+          echo "${dockerfile}" > "${results}/dockerfile"
           set -e
 
           # Fail if the build failed but let the build log, specification and Dockerfile aggregated.

--- a/amun/base/argo-workflows/inspection-build.yaml
+++ b/amun/base/argo-workflows/inspection-build.yaml
@@ -233,10 +233,18 @@ spec:
           mkdir -p "$results"
           kubectl logs "{{inputs.parameters.inspection-id}}-1-build" > "${results}/log"
 
-          cat <<< "{{inputs.parameters.specification}}" | jq . > "${results}/specification"
+          spec=`cat <<__EOF__
+          {{inputs.parameters.specification}}
+          __EOF__
+          `
+          echo "${spec}" | jq . > "${results}/specification"
 
           set +e
-          cat <<< "{{inputs.parameters.dockerfile}}" > "${results}/Dockerfile"
+          dockerfile=`cat <<__EOF__
+          {{inputs.parameters.dockerfile}}
+          __EOF__
+          `
+          echo "${dockerfile}" > "${results}/dockerfile"
           set -e
 
           # Fail if the build failed but let the build log, specification and Dockerfile aggregated.


### PR DESCRIPTION
## Related Issues and Dependencies

```
+ results=/mnt/build/
+ mkdir -p /mnt/build/
+ kubectl logs inspection-test-8641726c-1-build
+ cat '"Here' should be run 'tests..."n, update: true, upgrade_pip: false, @created: 2020-11-09T12:54:44.755753}'
+ jq .
cat: '"Here': No such file or directory
cat: should: No such file or directory
cat: be: No such file or directory
cat: run: Is a directory
cat: 'tests..."n, update: true, upgrade_pip: false, @created: 2020-11-09T12:54:44.755753}': No such file or directory
```

Related: #624 #625 

## This introduces a breaking change

- [x] No
