### PR TITLE
update investigator stage to v0.5.6 to run with messaging v0.7.13

### DIFF
--- a/core/overlays/stage/common/imagestreamtags.yaml
+++ b/core/overlays/stage/common/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.5.5
+      name: quay.io/thoth-station/investigator:v0.5.6
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -49,7 +49,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/messaging:v0.7.10
+      name: quay.io/thoth-station/messaging:v0.7.13
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/test/imagestreamtags.yaml
+++ b/core/overlays/test/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.5.6
+      name: quay.io/thoth-station/investigator:v0.6.0
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
update investigator stage to v0.5.6 to run with messaging v0.7.13
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>