### PR TITLE
bump up graph-refresh job to v0.2.9

### DIFF
--- a/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.2.8
+        name: quay.io/thoth-station/graph-refresh-job:v0.2.9
       importPolicy: {}

--- a/graph-refresh/overlays/stage/imagestreamtag.yaml
+++ b/graph-refresh/overlays/stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.2.8
+        name: quay.io/thoth-station/graph-refresh-job:v0.2.9
       importPolicy: {}


### PR DESCRIPTION
bump up graph-refresh job to v0.2.9
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

With updated investigator, now it consumes topics with versions. The graph-refresh-job is also to be updated to the same level of messaging to have unresolved packages consumed. 
