### PR TITLE
bump up package-update job to v0.8.4

### DIFF
--- a/package-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.3
+        name: quay.io/thoth-station/package-update-job:v0.8.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-update/overlays/stage/imagestreamtag.yaml
+++ b/package-update/overlays/stage/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.3
+        name: quay.io/thoth-station/package-update-job:v0.8.4
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
bump up package-update job to v0.8.4
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

With updated investigator, now it consumes topics with versions. The package-update-job is also to be updated to the same level of messaging to have packages consumed.