### PR TITLE
Decrease beam width to 10000

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -57,7 +57,7 @@ spec:
           - name: THOTH_ADVISER_DEV
             value: "0"
           - name: THOTH_ADVISER_BEAM_WIDTH
-            value: "17500"
+            value: "10000"
           - name: THOTH_LOG_ADVISER
           - name: THOTH_ADVISER_LIMIT
             value: "100000"

--- a/adviser/base/openshift-templates/adviser.yaml
+++ b/adviser/base/openshift-templates/adviser.yaml
@@ -60,7 +60,7 @@ parameters:
     required: true
     description: Adviser's beam width to restrict memory requirements with states generated.
     displayName: Beam width
-    value: "17500"
+    value: "10000"
   - name: THOTH_LOG_ADVISER
     description: Log adviser actions
     displayName: Log adviser actions


### PR DESCRIPTION
... it still feels like keeping 10,000 candidates is more than enough.

## This introduces a breaking change

- [ ] Yes
- [x] No
