### PR TITLE
set package dir for si cloc

### DIFF
--- a/security-indicators/base/argo-workflows/cloc-template.yaml
+++ b/security-indicators/base/argo-workflows/cloc-template.yaml
@@ -78,6 +78,8 @@ spec:
             value: "{{inputs.parameters.THOTH_SI_CLOC_PACKAGE_VERSION}}"
           - name: THOTH_SI_CLOC_PACKAGE_INDEX
             value: "{{inputs.parameters.THOTH_SI_CLOC_PACKAGE_INDEX}}"
+          - name: THOTH_SI_CLOC_DIR
+            value: "{{inputs.parameters.THOTH_SI_CLOC_DIR}}"
         image: si-cloc
         name: si-cloc
         resources:


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/659

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

env for cloc package dir was not set even though it was passed causing the step to try to download the package
