### PR TITLE
Reduce adviser memory to 2Gi

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -180,10 +180,10 @@ spec:
         resources:
           limits:
             cpu: 1.1
-            memory: 20Gi
+            memory: 2Gi
           requests:
             cpu: 1.1
-            memory: 20Gi
+            memory: 2Gi
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
## Related Issues and Dependencies

See https://github.com/thoth-station/adviser/issues/1575#issuecomment-735771164

## This introduces a breaking change

- [x] No
