### PR TITLE
bump up management-api app version to v0.8.2

### DIFF
--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.8.1
+      name: quay.io/thoth-station/management-api:v0.8.2
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/stage/imagestreamtag.yaml
+++ b/management-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.8.1
+      name: quay.io/thoth-station/management-api:v0.8.2
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
bump up management-api app version to v0.8.2
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/management-api/issues/636

