### PR TITLE
switch to ocp4 qebhwt webhook receiver from ocp

### DIFF
--- a/qeb-hwt-github-app/overlays/stage/kustomization.yaml
+++ b/qeb-hwt-github-app/overlays/stage/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - configmap.yaml
-  - ultrahook-deployment.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml


### PR DESCRIPTION
switch to ocp4 qebhwt webhook receiver from ocp
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

The webhook receiver are causing racing condition.
