### PR TITLE
Package module dont require build-check

### DIFF
--- a/prow/overlays/thoth-station/config.yaml
+++ b/prow/overlays/thoth-station/config.yaml
@@ -246,11 +246,9 @@ tide:
           storages:
             required-contexts:
               - aicoe-ci/pytest-check
-              - aicoe-ci/build-check
           tensorflow-symbols:
             required-contexts:
               - aicoe-ci/pre-commit-check
-              - aicoe-ci/build-check
           investigator:
             required-contexts:
               - aicoe-ci/build-check


### PR DESCRIPTION
Package module doesn't require build-check
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/storages/pull/2129

