### PR TITLE
Bump kebechet to v1.2.1 in ocp4

### DIFF
--- a/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.1.4
+        name: quay.io/thoth-station/kebechet-job:v1.2.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

https://github.com/thoth-station/kebechet/pull/642