### PR TITLE
Revert "Bump kebechet to v1.2.1 in ocp4"

### DIFF
--- a/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.2.1
+        name: quay.io/thoth-station/kebechet-job:v1.1.4
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Reverts thoth-station/thoth-application#698
Lets revert this back, so that we can release fixes. 
