### PR TITLE
patch the correct url in qebhwt workflow configmap

### DIFF
--- a/core/overlays/ocp4-stage/common/configmaps.yaml
+++ b/core/overlays/ocp4-stage/common/configmaps.yaml
@@ -69,4 +69,4 @@ apiVersion: v1
 metadata:
   name: qeb-hwt-workflow
 data:
-  webhook-callback-url: "http://qeb-hwt-webhook-receiver-aicoe-prod-bots.apps.ocp4.prod.psi.redhat.com"
+  webhook-callback-url: "http://qeb-hwt-webhook-receiver-thoth-frontend-stage.apps.ocp4.prod.psi.redhat.com"


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/qeb-hwt/issues/137

## This Pull Request implements

patch the correct url in qebhwt workflow configmap
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

the URL was missed while migrating. 