### PR TITLE
disable enlisting of encrypted secret and routes for cnv deployment

### DIFF
--- a/amun/overlays/cnv-prod/amun-api/kustomization.yaml
+++ b/amun/overlays/cnv-prod/amun-api/kustomization.yaml
@@ -9,8 +9,6 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
-generators:
-  - ./secret-generator.yaml
 patchesJson6902:
   - path: job-generate-name.yaml
     target:

--- a/chat-notification/overlays/cnv-prod/kustomization.yaml
+++ b/chat-notification/overlays/cnv-prod/kustomization.yaml
@@ -16,7 +16,3 @@ patchesJson6902:
       version: v1
       kind: Job
       name: chat-notification-fail-
-generatorOptions:
-  disableNameSuffixHash: true
-generators:
-  - ./secret-generator.yaml

--- a/core/overlays/cnv-prod/common/kustomization.yaml
+++ b/core/overlays/cnv-prod/common/kustomization.yaml
@@ -6,7 +6,3 @@ resources:
 patchesStrategicMerge:
   - configmaps.yaml
   - imagestreamtags.yaml
-generatorOptions:
-  disableNameSuffixHash: true
-generators:
-  - ./secret-generator.yaml

--- a/management-api/overlays/cnv-prod/kustomization.yaml
+++ b/management-api/overlays/cnv-prod/kustomization.yaml
@@ -25,7 +25,3 @@ patchesJson6902:
       version: v1
       kind: Role
       name: management-api
-generatorOptions:
-  disableNameSuffixHash: true
-generators:
-  - ./secret-generator.yaml

--- a/user-api/overlays/cnv-prod/kustomization.yaml
+++ b/user-api/overlays/cnv-prod/kustomization.yaml
@@ -38,7 +38,3 @@ patchesJson6902:
       version: v1
       kind: Role
       name: user-api-pods-info
-generatorOptions:
-  disableNameSuffixHash: true
-generators:
-  - ./secret-generator.yaml


### PR DESCRIPTION
## Related Issues and Dependencies

Related-To: #709 

## This Pull Request implements

disable enlisting of encrypted secret and routes for cnv deployment
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

ksops setup for operate-first argocd is in progress, till then we would disable these.