### PR TITLE
Enable ocp stage to solve fedora solvers

### DIFF
--- a/core/overlays/stage/common/configmaps.yaml
+++ b/core/overlays/stage/common/configmaps.yaml
@@ -36,7 +36,6 @@ metadata:
   name: solvers
 data:
   solvers: |
-    solver-rhel-8-py36
     solver-fedora-32-py37
     solver-fedora-32-py38
 ---

--- a/graph-refresh/overlays/stage/cronjob.yaml
+++ b/graph-refresh/overlays/stage/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: graph-refresh
 spec:
-  suspend: true
+  suspend: false


### PR DESCRIPTION
## This Pull Request implements

Enable ocp stage to solve fedora solvers
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

With end of the year, we would like to dedicate this period for data aggregation. Allowing ocp stage to solver fedora based solvers and ocp4 would take on ubi.