### PR TITLE
Increase workflows

### DIFF
--- a/graph-refresh/base/cronjob.yaml
+++ b/graph-refresh/base/cronjob.yaml
@@ -63,7 +63,7 @@ spec:
                 - name: THOTH_GRAPH_REFRESH_SECURITY
                   value: "0"
                 - name: THOTH_GRAPH_REFRESH_COUNT
-                  value: "450"
+                  value: "800"
                 - name: THOTH_DEPLOYMENT_NAME
                   valueFrom:
                     configMapKeyRef:

--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   serviceAccountName: argo
-  entrypoint: mi-workflow 
+  entrypoint: mi-workflow
   templates:
     - name: mi-workflow
       resubmitPendingPods: true


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Alarms are activated as Thoth is not learning for more than 30 minutes. This is because Thoth workflows are solved very fast and there are not enough workflows scheduled each hour. Let's increase them more.

![Screenshot from 2020-12-18 18-20-29](https://user-images.githubusercontent.com/27498679/102642481-09ad0f80-415e-11eb-9cc6-bb255e14e360.png)
