### PR TITLE
Increase the amount of workflow to run in parallel for ocp middletier

### DIFF
--- a/core/overlays/stage/middletier-stage/configmaps.yaml
+++ b/core/overlays/stage/middletier-stage/configmaps.yaml
@@ -7,7 +7,7 @@ data:
   config: |
     containerRuntimeExecutor: "k8sapi"
     namespace: "thoth-middletier-stage"
-    parallelism: 45
+    parallelism: 50
 
     workflowDefaults:
       spec:


### PR DESCRIPTION

## This Pull Request implements

Increase the amount of workflow to run in parallel for ocp middletier
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

![ocp](https://user-images.githubusercontent.com/14028058/103561331-5182a500-4e87-11eb-90b1-d637ce9fec69.png)
let workflows consume all the available resource.