### PR TITLE
enable package release in ocp cluster

### DIFF
--- a/package-releases/overlays/stage/cronjob.yaml
+++ b/package-releases/overlays/stage/cronjob.yaml
@@ -7,4 +7,4 @@ metadata:
     app: thoth
     component: package-releases
 spec:
-  suspend: true
+  suspend: false


### PR DESCRIPTION
## This Pull Request implements

enable package release in ocp cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

# Description

![ocp-workflow](https://user-images.githubusercontent.com/14028058/103564728-0a97ae00-4e8d-11eb-83c3-d906ffbcb2fa.png)

as graph-refresh workflow are finished before the next set start, there is enough resources to accommodate package-releases as well.