### PR TITLE
Bump workflows helpers to v0.3.2

### DIFF
--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.3.1
+      name: quay.io/thoth-station/workflow-helpers:v0.3.2
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/stage/common/imagestreamtags.yaml
+++ b/core/overlays/stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.3.1
+      name: quay.io/thoth-station/workflow-helpers:v0.3.2
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## This Pull Request implements

Bump version to v0.3.2. This will solve bug in Qeb-Hwt.
