### PR TITLE
namespace specific roles are used in cnv cluster

### DIFF
--- a/amun/overlays/cnv-prod/amun-api/role_binding.yaml
+++ b/amun/overlays/cnv-prod/amun-api/role_binding.yaml
@@ -48,7 +48,7 @@ metadata:
   namespace: thoth-amun-inspection-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -62,7 +62,7 @@ metadata:
   namespace: thoth-amun-inspection-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount

--- a/graph-refresh/overlays/cnv-prod/rolebindings.yaml
+++ b/graph-refresh/overlays/cnv-prod/rolebindings.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -48,7 +48,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount

--- a/investigator/overlays/cnv-prod/role_binding.yaml
+++ b/investigator/overlays/cnv-prod/role_binding.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -47,7 +47,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount
@@ -75,7 +75,7 @@ metadata:
   namespace: thoth-backend-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -89,7 +89,7 @@ metadata:
   namespace: thoth-backend-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount

--- a/management-api/overlays/cnv-prod/role-binding.yaml
+++ b/management-api/overlays/cnv-prod/role-binding.yaml
@@ -17,10 +17,10 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: management-api-argo
-  namespace: thoth-frontend-prod
+  namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -34,7 +34,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount

--- a/revsolver/overlays/cnv-prod/rolebinding.yaml
+++ b/revsolver/overlays/cnv-prod/rolebinding.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -34,7 +34,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount

--- a/user-api/overlays/cnv-prod/role-binding.yaml
+++ b/user-api/overlays/cnv-prod/role-binding.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -48,7 +48,7 @@ metadata:
   namespace: thoth-backend-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo
 subjects:
   - kind: ServiceAccount
@@ -62,7 +62,7 @@ metadata:
   namespace: thoth-middletier-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount
@@ -76,7 +76,7 @@ metadata:
   namespace: thoth-backend-prod
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argo-admin
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
## Related Issues and Dependencies

```
"workflows.argoproj.io is forbidden: User \"system:serviceaccount:thoth-infra-prod:investigator\" cannot create resource \"workflows\" in API group \"argoproj.io\" in the namespace \"thoth-backend-prod\": RBAC: [clusterrole.rbac.authorization.k8s.io \"argo\" not found
```

## This Pull Request implements

namespace specific roles are used in cnv cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

In the cnv cluster, we defined namespace specific roles, rather than relying upon cluster roles. 
 https://github.com/thoth-station/thoth-application/blob/ab0b69fef0370c19554092aa438432e53255831a/core/overlays/cnv-prod/backend-prod/argo-namespace-install.yaml#L17
https://github.com/thoth-station/thoth-application/blob/ab0b69fef0370c19554092aa438432e53255831a/core/overlays/cnv-prod/backend-prod/argo-namespace-install.yaml#L30

 https://github.com/thoth-station/thoth-application/blob/ab0b69fef0370c19554092aa438432e53255831a/core/overlays/cnv-prod/middletier-prod/argo-namespace-install.yaml#L17
 https://github.com/thoth-station/thoth-application/blob/ab0b69fef0370c19554092aa438432e53255831a/core/overlays/cnv-prod/middletier-prod/argo-namespace-install.yaml#L30
 
 https://github.com/thoth-station/thoth-application/blob/ab0b69fef0370c19554092aa438432e53255831a/amun/overlays/cnv-prod/amun-inspection/argo-namespace-install.yaml#L42
 https://github.com/thoth-station/thoth-application/blob/ab0b69fef0370c19554092aa438432e53255831a/amun/overlays/cnv-prod/amun-inspection/argo-namespace-install.yaml#L30
 