### PR TITLE
Bump management-api to v0.9.0

### DIFF
--- a/management-api/overlays/test/imagestreamtag.yaml
+++ b/management-api/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.8.5
+      name: quay.io/thoth-station/management-api:v0.9.0
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>
]