### PR TITLE
Bump user-api to v0.10.0 in test environment

### DIFF
--- a/user-api/overlays/test/imagestreamtag.yaml
+++ b/user-api/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/user-api:pr-1175
+      name: quay.io/thoth-station/user-api:v0.10.0
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
