### PR TITLE
use ocp4-test deployment for test and turn on graph backup

### DIFF
--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -5,7 +5,7 @@ metadata:
   name: thoth
 data:
   applicationVersion: 0.7.0-dev
-  deployment-name: ocp-test
+  deployment-name: ocp4-test
   amun-api-url: http://amun-api.thoth-test-core.svc/api/v1
   amun-inspection-namespace: thoth-test-core
   amun-namespace: thoth-test-core
@@ -17,7 +17,7 @@ data:
   postgresql-host: pgbouncer.thoth-test-core.svc
   rsyslog-host: ""
   rsyslog-port: ""
-  storage-bucket-name: ocp-test
+  storage-bucket-name: ocp4-test
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -76,7 +76,7 @@ data:
 
       s3:
         bucket: "thoth"
-        keyPrefix: "data/ocp-test/argo/artifacts/"
+        keyPrefix: "data/ocp4-test/argo/artifacts/"
         endpoint: "s3.upshift.redhat.com"
         insecure: true
         accessKeySecret:
@@ -92,19 +92,19 @@ metadata:
   name: prometheus
 data:
   host-url: "https://prometheus-dh-prod-monitoring.cloud.datahub.psi.redhat.com"
-  user-api-url: "user-api-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
-  instance-metrics-exporter-infra: "metrics-exporter-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
-  instance-metrics-management-api: "management-api-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
+  user-api-url: "user-api-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+  instance-metrics-exporter-infra: "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+  instance-metrics-management-api: "management-api-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
   pushgateway-host: pushgateway-dh-prod-monitoring.cloud.datahub.psi.redhat.com
   pushgateway-port: "80"
   pushgateway-url: pushgateway-dh-prod-monitoring.cloud.datahub.psi.redhat.com:80
-  instance-workflow-controller-metrics-backend: "workflow-controller-metrics-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
-  instance-workflow-controller-metrics-middletier: "workflow-controller-metrics-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
-  instance-workflow-controller-metrics-amun-inspection: "workflow-controller-metrics-thoth-test-core.apps.ocp.prod.psi.redhat.com:80"
+  instance-workflow-controller-metrics-backend: "workflow-controller-metrics-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+  instance-workflow-controller-metrics-middletier: "workflow-controller-metrics-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+  instance-workflow-controller-metrics-amun-inspection: "workflow-controller-metrics-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: qeb-hwt-workflow
 data:
-  webhook-callback-url: "http://qeb-hwt-webhook-receiver-thoth-test-core.apps.ocp.prod.psi.redhat.com"
+  webhook-callback-url: "http://qeb-hwt-webhook-receiver-thoth-test-core.apps.ocp4.prod.psi.redhat.com"

--- a/graph-backup-job/overlays/test/cronjob.yaml
+++ b/graph-backup-job/overlays/test/cronjob.yaml
@@ -1,0 +1,7 @@
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: graph-backup
+spec:
+  suspend: false

--- a/graph-backup-job/overlays/test/kustomization.yaml
+++ b/graph-backup-job/overlays/test/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - cronjob.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml

--- a/kebechet/overlays/test/configmap.yaml
+++ b/kebechet/overlays/test/configmap.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 data:
-  deployment-name: "ocp-test"
+  deployment-name: "ocp4-test"
   verbose: "1"
 kind: ConfigMap
 metadata:

--- a/qeb-hwt-github-app/overlays/test/configmap.yaml
+++ b/qeb-hwt-github-app/overlays/test/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
   name: qeb-hwt
 data:
   subdomain: qeb-hwt-test
-  webhook-callback-url: "http://qeb-hwt-webhook-receiver-thoth-test-core.apps.ocp.prod.psi.redhat.com"
+  webhook-callback-url: "http://qeb-hwt-webhook-receiver-thoth-test-core.apps.ocp4.prod.psi.redhat.com"


### PR DESCRIPTION
use ocp4-test deployment for test and turn on graph backup
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: #745 