### PR TITLE
updated management-api role to allow creating jobs

### DIFF
--- a/management-api/base/role.yaml
+++ b/management-api/base/role.yaml
@@ -13,6 +13,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - create
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - configmaps


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #741 

## This introduces a breaking change

- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to ALL environment

## This Pull Request implements

updated management-api role to allow creating jobs
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

Allow management-api serviceaccount to be able to create jobs through openshift api call. 