### PR TITLE
set the rolebinding for user-api to get pod logs

### DIFF
--- a/user-api/overlays/test/role-binding.yaml
+++ b/user-api/overlays/test/role-binding.yaml
@@ -14,6 +14,18 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
+  name: user-api-pods-info
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: user-api-pods-info
+subjects:
+  - kind: ServiceAccount
+    name: user-api
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
   name: user-api-argo
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #762 

## Description

set the role binding for user-API to get pod logs
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
