### PR TITLE
Correct env name not present in the application

### DIFF
--- a/graph-sync/base/argo-workflows/sync-template.yaml
+++ b/graph-sync/base/argo-workflows/sync-template.yaml
@@ -165,7 +165,7 @@ spec:
               secretKeyRef:
                 name: ceph
                 key: secret-key
-          - name: THOTH_METRICS_PUSHGATEWAY_URL
+          - name: PROMETHEUS_PUSHGATEWAY_URL
             valueFrom:
               configMapKeyRef:
                 name: prometheus


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Metrics are not exposed from graph-sync


See: https://github.com/thoth-station/graph-sync-job/blob/49c672f9a990fd8034db5b425a389fe0536760be/app.py#L47