### PR TITLE
fix the kustomize manifest for properly propogating cronjob

### DIFF
--- a/graph-backup-job/overlays/test/kustomization.yaml
+++ b/graph-backup-job/overlays/test/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - cronjob.yaml
   - thoth-notification.yaml
 patchesStrategicMerge:
+  - cronjob.yaml
   - imagestreamtag.yaml
 patchesJson6902:
   - path: job-generate-name.yaml


### PR DESCRIPTION
fix the kustomize manifest for properly propagating cronjob
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
