### PR TITLE
use the direct service hostname for s3 connection

### DIFF
--- a/core/overlays/cnv-prod/common/configmaps.yaml
+++ b/core/overlays/cnv-prod/common/configmaps.yaml
@@ -27,8 +27,8 @@ data:
   bucket-name: "thoth"
   bucket-prefix: "data"
   public-bucket-name: DH-PLAYPEN
-  host: "https://rgw-openshift-storage.apps.cnv.massopen.cloud/"
-  endpoint: "https://rgw-openshift-storage.apps.cnv.massopen.cloud/"
+  host: "http://rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local"
+  endpoint: "http://rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local"
 ---
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
use the direct service hostname for s3 connection
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>