### PR TITLE
upgrade argo components to v2.12.5 to tackle ttl issues

### DIFF
--- a/core/overlays/ocp4-stage/backend-stage/argo-namespace-install.yaml
+++ b/core/overlays/ocp4-stage/backend-stage/argo-namespace-install.yaml
@@ -69,7 +69,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argocli:v2.11.0
+      name: quay.io/argoproj/argocli:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -85,7 +85,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-controller:v2.11.0
+      name: quay.io/argoproj/workflow-controller:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -101,7 +101,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argoexec:v2.11.0
+      name: quay.io/argoproj/argoexec:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/ocp4-stage/middletier-stage/argo-namespace-install.yaml
+++ b/core/overlays/ocp4-stage/middletier-stage/argo-namespace-install.yaml
@@ -69,7 +69,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argocli:v2.11.0
+      name: quay.io/argoproj/argocli:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -85,7 +85,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-controller:v2.11.0
+      name: quay.io/argoproj/workflow-controller:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -101,7 +101,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argoexec:v2.11.0
+      name: quay.io/argoproj/argoexec:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/test/argo-namespace-install.yaml
+++ b/core/overlays/test/argo-namespace-install.yaml
@@ -117,7 +117,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argocli:v2.11.0
+      name: quay.io/argoproj/argocli:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -133,7 +133,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-controller:v2.11.0
+      name: quay.io/argoproj/workflow-controller:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -149,7 +149,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argoexec:v2.11.0
+      name: quay.io/argoproj/argoexec:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
upgrade argo components to v2.12.5 to tackle ttl issues
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #797 

## Description

As stated in the description of #797, the v2.12.5 has worked for other teams, we would like to use and test this. 
as the issue is happening in the openshift 4.5, starting with that cluster.