### PR TITLE
re-encrypt sefkhet secrets with updates sops

### DIFF
--- a/sefkhet-abwy/overlays/cnv-prod/secrets.enc.yaml
+++ b/sefkhet-abwy/overlays/cnv-prod/secrets.enc.yaml
@@ -7,84 +7,103 @@ items:
     metadata:
         name: new-label-normalizer
     data:
-        github-access-token: ENC[AES256_GCM,data:cUqJSi0a5x1TK8LKnDfT+uCf6qP35IkMv/XRC5RTspFrLYXoSOBh1w==,iv:aGMBOKyOEQo8qssdQMublLhL/H0znJ8uGmsFJ8TN/cw=,tag:7XN99ftv+TK2Ok9WfQJqXg==,type:str]
+        github-access-token: ENC[AES256_GCM,data:8VmpydSrptOBlw9aef+dfTq3xp9a7fUJqKJeggwHqlyHiimqoTnm5A==,iv:LdkVW9oIoyEs2tjc+cu1+xEk8mxu7te7T8F5/hf3Dlg=,tag:yORvmqiQHVe9h5eY4GtkHQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-01-13T11:54:38Z'
-    mac: ENC[AES256_GCM,data:qocownLWS8xKEF//NnzW2l1/7h/tgX/VDb+/GMFkzUoQMh0Vi420IdO7QrfEURCxglnVMD6idLG8bw6pccNZWlPBPamTCWaz+sonyErXJiayP96WBdr+0pDftzlW+Eihk9sRcru/zCq9Zi+EoyitSlBcvxXWElBzQyX4l20qY20=,iv:jo8l2W0qSyOGx5AC/yNHrHI1cmG7NcYp3J7F27Vn4H4=,tag:7kqezto5TXv+Qn1N/1Z/Pg==,type:str]
+    lastmodified: '2021-01-26T17:02:28Z'
+    mac: ENC[AES256_GCM,data:OCUOJr0U3sFn+Y1N+f4FVLXGAbeZbhAq+egpYM538/vv+AyqzVsOsXVtXn7WV0WKUTU9in3kHpxJMIOVfkdU6dNO4rnN/UJobDDfTXAM4y+RN/9tGpf8hS+VYRSv+InycLmhabWpddsA9ZJhKSVkI1TfiASOio7iyX/Y7zla89E=,iv:pGvMTgaG4F2Ob5czslIu++RW9SADFmuFSbEiQw4JGBc=,tag:5uH4nI0DL+s3KCOjFyH2hQ==,type:str]
     pgp:
-    -   created_at: '2021-01-13T11:54:37Z'
-        enc: |-
+    -   created_at: '2021-01-26T17:02:28Z'
+        enc: |
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA1gbAjViyxWYARAABj7jNZi/8+bUXLAehk+ag/T5QpOWV1UvxoCa/kIbHB++
-            VK1oAbkUFNrNfax+FZ9HpYQbQHTgfxiQNmn3NfoB9elXF1tMEXuAsPWhiE9s0Og2
-            N1Q5SMLfCtAJnSjTl4hmeChE0H0/hA6M1RJx42kPaswbsd8m/y97mkdWISV7FEyM
-            fALjnURHlRsSMMhMUh1EMy2TdYAS1xxw673Afr9Efio743MK4GDMwf4n+bAC4T6s
-            4uUcuOTDm7vK+6fINoblSAGHlAfqHD7MJWDjRcr009EL6ilk+qO4Ea6Ihs1vU1Z6
-            B1AacQIy999PGs4WhRJ6A3PGsiRxtBcs6AUcIaslMqGHkgDNz+KBDK1GyyIy7CVh
-            Sbzk6i8oK/QRGoo7XC4v54rvJ6r9dHzNDMfCFMLhlYo2gdez40QPcyeSfhhovLc8
-            lPKnEUbCwFsC9fQT5At9lm1FXnhN003uG6MP+esrj6BZs5QrVlHguVyMRaFeJsnx
-            prqJ47Y+fECSLjiI15bzNl++iWKxgmcTVT9S4YQAeNwiLcnMzrnSWrlQ1mteZvkc
-            MT0K3dXXIo0D066Do3o9ZRyVrL5IrjZJSt4tj30wpqe+RghSzM+jNmJu3jUV4Nnm
-            2SU1P9jMm4BIdIcvYLgs7EfNg0xsTRTAre51hKl09lqfDKLeFGnAxkFvesCvHX7S
-            4AHkOywf8nmPyOQpqS7ICWYew+EYh+A44MDhpHjg5uI7uRx54DHlSjMxTiSm3MmK
-            XQRmoOkRJk+M6R4UYA0Gg8K7Rjx30KzgvORIYIyCfJErmEduPkODLOgF4tgu6yPh
-            0A0A
-            =XTLb
+            hQIMA1gbAjViyxWYARAAgvypd0qmNJCsvWh3Pd8W2ZviVMQZftVysdhtFrABZWJX
+            +YvJXOYYXS+csOlqzXXMvHZJJR4/DO4t++nSYbkfas/aVPk9ijax+7Y/h3L+vlxy
+            LWql4huuAlpOYg8mHqkm/KgDjJCpcNHUmfotJOmgTRHH5ToQwRFNVHNtyv/b/EsO
+            xeMrqwuUsiTPi+zhLVT5mnWw7H34D7ZaFiUTf2JLiRdtnJeky2CJdnosZCN2FXYM
+            imxw8sXnWzOT27pxeKinoKuSaCi4dLhuinkUp8Z8MDziSZHs92XSAKyAARFmj50T
+            ebBZHQiy0940S4FwDlUIglC/mJviFZgPwwaNFvQibGIgRX4b6vIRZGnTVC1+is3K
+            qzSpjZ4jGJKnAe5zQd5zchOczqaayzk1nu9BvKddj1hbIQt60/Ol0LI0rIeivb4e
+            6VI+eSRYN4OhlpF/SdEACtcMCaDkvK34OmQb8sOve+xoYJvhdppAuD7AZKisnmqY
+            MsXeFIDTZxQl7i4WT5xlacXkPSztKmEYCNPmVCIyegLbSJH/KEtvzoNJO/07Konb
+            4sJGFZQECGzzZfXaBW4QrtUo2Sy/qhxbTeRXa06vZ10MKwWv2/sACxMyHT5M15lE
+            hpWi9CI+FjuV/ghAbsGl0E8agO6YRoMIAJAIz9GlkzRlAhgSPY8+GCqpWVqwIsXS
+            XAGyAfCGXPUa6UFMaOTLaLD32r8E3RGTdXp5faToTNKab06aV7/m9dRWAX1T4/S4
+            LB2F8w+yCwHg5riUbSx+yOA9d+maY5xg++N+Z77ecBd5KNh6qOWz4fv96n22
+            =D70h
             -----END PGP MESSAGE-----
         fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
-    -   created_at: '2021-01-13T11:54:37Z'
+    -   created_at: '2021-01-26T17:02:28Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA+/WpawS9RPbAQgApHO4jJeCuIx7pQKlDb4xsm5XTQkLTbtC6Q0qOD2X7ZHO
-            1qTN8dQ7MhWSx6/Xk5LEUwzRmcAwTaUfYDguIrAcXalx2hvbY5ROt4pf7ghkXa/c
-            LIJ3ioXR2eyp9zzLUKvm6iSB8dMHKC++S/BrqLfHC3pJggQsHnzU33M5wrylTIF9
-            WdTaFeGg+es6GDrRWpWaSA0a9ohhyGve4slJ6ANKuh2q5pNYUS43kpGzAw5pyfio
-            3VgoCuTVMAKNuk8yirtY+tlOteVKVg8S9EcnfeXnK60rDb6t+5iKM9G+gBzd/XyN
-            GRXUlkCxjOIFDRH+Qobz0c9UAvshskQcdId77bScA9JeAdrbJiK3Cuwhshgtmnmc
-            5W74bNw6K0l+4XPMlzpyl/gN1L97+M6vWQn/QzyDauiw9EgZFlNuH8E1mo74wdtS
-            f7W/RZmz9IZMyVo9e0V2VKrQAZsbj5yR7/bIxiucGQ==
-            =VKTO
+            hQEMA+/WpawS9RPbAQf9FiYp1pBe9WXjaNK1i5NF9fxKDUIpAhi7kKGnbB1QSsVZ
+            Z6tUBTH+Um4d645O+7XSzvYgQeluBHIutqYinMp7aVQIbap9EeyKWwXnhHUT0UL4
+            Zl7s1ELGg1Hf6tdnlof9BZ62Tw1zDNwquObzahIRsrM+0CEBAvdNGSlSs1fS5Jcs
+            JTOcxXoRhg6OhX2D/wbp+0t32mjg30g7p3OhYC1ASaDRfsuwGnmUteCr/O/StKdi
+            R1uKoSlPlbid8VhHnfeDmJ7lPfpsA6SDPnf25IOfb1t6tI/WeV9QCTfEFvsI1Sr+
+            llIqCJprDxlWSkVa51jW3FuoiM0Z93A5AiJ9Fri8mNJcASa0GkUc9FKfhZn+Z7db
+            0mxSeDJ8/ZcVswZ4JkBafRWrD564gmGPjpWHAY6LeBHov7ixnoSNC+QgFHRVmlaP
+            swBWLW7iuFTESz/JtMHj48DUjWnamiwNe+kyTaE=
+            =txLK
             -----END PGP MESSAGE-----
         fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
-    -   created_at: '2021-01-13T11:54:37Z'
+    -   created_at: '2021-01-26T17:02:28Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQgAlZp1W8DOSXneqdVKejFsfVbYHnCKA0XRkXJZXAv7Xq8m
-            VlSsTVhRWS+e5/v7hMoyVHhNuCQifHIL7id3CqBoRO9pXM45CZ1S+B3eGGNuWDrQ
-            2V3U6Xf+l3V4Tb1zymEx+gQoCB71wWJRpEWepeXPilBUL9iBjEhXBuT7Q5Kp3ufQ
-            cIady836WRCoN0hvWuXtOb3whTC3Y/ap5WHAiXWAg05MafLeeGewVyyS/NXlumPe
-            RGfxxLFLK/D/p8WobL5AgA3YUBPcgDweu6EeKLl+uQ491SMeuoutA+c5xf1H46oo
-            cY2z7aZcRtcqvxeepF8stubn1GgrSRGpIgoC4E6879JeAa2mMjpoV4lq3Ejf489j
-            80zl1WQPvZmCNlsdSFztsZej0ufRyDFcGMwaAp/R2W9UdXdc+WnZyKgtIVCTPWvZ
-            Yo+Csdu5gn4IwKYoGUGIaxueCHu2PjG2/jZL9lIDIw==
-            =cYVj
+            hQEMA/irrHa183bxAQgAqSCm5VHIpVZZ1d4hUZBaugeLJsUANMtu81CCszqiDGe1
+            5Zzyb0bIMZ7cJEjq6lumhEl8nuqy4g53BsnkQxfE6VA7y8AZm1Ru310HeEAzSc1Q
+            bH/pCtTrTb36Pw3RTRopwU+87B3aperAVBUg2kijI1znAsQxu5CD/WtMBfPObRoO
+            2e8TBKJaNfdOezJE1w9iK9Ra9G/VQ56wovgQPni0+NSwQaTRud/PGBKGJVBDpVU/
+            tww+5wHtrvPYt5HJU0qQ1gX8a9Ppq1aaW9ylhkSDM/K6uUI9ygnDBu0BK/Q98yFV
+            qaa8OgqkC4u6C/R2fjIP33NoHuOZPBnT/p8D43KRT9JcAaQh4xLnBGuRCgfCdkWL
+            miOnGBfU/paVeNwRfY/OtxHEmzUQO1t6ofsuy6gDXYDJzXJp+hbp+7hym7zBn3Ey
+            iUbY1hlc4kVCcAVplMMfzI4+d+m4kove82QykBA=
+            =6hd7
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
-    -   created_at: '2021-01-13T11:54:37Z'
+    -   created_at: '2021-01-26T17:02:28Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA7vMDF1jUn3mARAAkG077uqYJiEZ5Qa1rkAx9YNes7h4iCyMnOGeIVJ+1vgL
-            ombXgFIwEjxncffVcBzDKd7EK535VhoVYrln4yGN+NXWVbEFE43Z+Zd84LmO/33M
-            2AGc71WddFg1aaXylbqyx4/zWIxoaPLF31ubFKiyfWO5c2h7UUiRBUEOYWW5n+5p
-            pUNhurQp6a2P0gOMKuxwfT21XlUeCCVq8AOU0e8rkfkc+6YYY+YDvO2PgL0+fRhE
-            3TX3j2VjmvAgXaSiU5DADHFaBBm6/NwhoFvpVwAaOKJVKc6APZA3pyxvxE0SVUBU
-            5rNhE2ieCBmAGZzAmzj4EnLPP24Z9izQyx4Hu2Y6IGCTb0ZNV0uRtMumNH5vyfRo
-            3i/QdpO2DnTAojC3Hwkp6FbLYRmRcsMRy9QUTKFLQCRw4towkKhRJlN1ePny4YUc
-            LW7jwzTZKaxOKuNLSc6HfWjPXle/fNqZ5jwGE39e2eUHd4IaDxbaAQbiR1tZN61o
-            dtapkDGZ17D+uuPtBvHZO1WgrM0HFAQC0axc7eFZz+RxbMmy+84HqZ4YRyx1V+nE
-            xOdMq0TGZgbsJJCEwN2H2hcbBvpz7jjM6GSIjkc8gRAKO7HrsyoONszVusYETk7/
-            S/+VkSmnyUaiKzPPKinFsNd6IP3emRAI3qZ6riXdSyGbPEHwzsf8bK4894p9UNbS
-            XgG0a/7tNaewygB6Mvq0ZErlSQBEcXq8rLNOdgbMtO72DeGPJwyv6dBZ7iqKkPoE
-            R9CoU1/cHYq0GtVD/Mej8Gam3QrlwT+R3XRA6G4OyWEDxjrMUHSfJW2V8ezHs/M=
-            =Gq0W
+            hQIMA7vMDF1jUn3mAQ//cef9l6PICzIf5N4ZX6FNFaHPno2tUX5WFfyIzRp4cXur
+            fpRp+dpub17jh4ZuzNOacuCLCeniMz+W3pByBy1KbAs/HuAwNz9Ds5n4N4YIdZtf
+            VTClACrcIxlyDE07E1F0JWqTr0scx/QoOPdLay3M5gnDKZw5ugMDfg3z4gej56Ck
+            nAUUaAAhBecB7NW+qfuAbAUXNvawNKigKdu2x7gK0Hs38Tm6vqYX4mvPYKP564iI
+            r47XEUHYWI/jVPhnqRh3auF5Ey2xRkLFTGGBYcycFRuQh5usQtVFFB7WAM4Rl9Df
+            Ka4+a+arVSbtuiGFEqxlB3AKrXXcB0DG8mV73F6ZDjNT1ZNLaHOj9dMm8ncoi1zz
+            lA8IRe2CmkRYHSoIb1kq86fuqqd9tlpqlsNOmS0me7d82tx7DcekC9a3g2ZxYFDx
+            OIXjEyJ+vOEtZpq6KgejIN1JTztoz6NbGiF2uds9UirjCdZML79AdqNgKkv5dTEW
+            Y0oZ3gDbvNMf4vRVZpH46RHSbjrbujuPdBZRGJaG7jx7saij6AnRu4oiJ7juCwSg
+            +j7JoHkjuLk8BuYRiUS8jsPUa65QrwSZo9uTtxYoH6rEfmHTVqfgzM2FTdGj68hU
+            s/cLdKZg5MXfaaczfhqfs1bkiKYdC2BXVzS8gIe89a8qA7C08A5Qj5Qni0MuD/rS
+            XAFB/Zir4w6Ozi9rL+exoZk1QMtJAi5wY7diOWuF+klXUjPxZmJB21qpQiel+jJ3
+            HmZ73/dmhuufcQeLM+XJn7u7t+2Z8hG1dYPy1zefu9q5OMxoZ/G2LBzbfxtx
+            =SK9A
             -----END PGP MESSAGE-----
         fp: 68BD1529A372C8BA561C9DDC377298152D08B95B
-    encrypted_regex: ^(data|stringData)$
+    -   created_at: '2021-01-26T17:02:28Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAAgwucjUTu/sjLzIOl9lXQH3xiqPMSRKc5C7/0DGHDQ0j/
+            WwLz/LcHXFzDRRBxGePt04GZLXwTTfhW8EcUHAZqzEWZbohrvA88h4vErus1qtNh
+            eWS1perZ+K45SJbJR5tXOh0gV38Yz6mMe8HGYK9m3pk+8m+1rNGM8KjckQZI7Ll9
+            3RjvLYF8TFRe4MiYABIqhFAUZF2HME1cS2JQShAyN4pNQ2vNurDwPFM7lwpaZJq2
+            QhJZnB+rxNlbOS6qTNQvQXG/nnFWSwuIeR8+yq/LN+CbkIr0JQpRmFthmBj0kRTD
+            2XBJKDWWtxCoedl5UWpRVXYBdYlB6fzlJ/BG2RxwV1E8OiOFgAw/Tjc9HS5Zt53E
+            6acZN6BEycPJWrOcH8jAfmLbWfKWznnpYVodmI2BQuVY9O5s9DnAk5FNaxeuiwz4
+            3EHPeThDzto6YdhGNGrr8/y+IPaB9xPeLW8TbT8Lu+O+eODahNSkQAKrsTrTS3GV
+            laL5vsU05sqCF73qRJD6hDnSBJaL2dqN66KMlm30RrwdpG5BLVoRLkVD8YEmOx8L
+            rSe7ZTjw4O8QvmPOUiamEIeknIRd1PbbPsL4WJPEDzuy7LgWmboRhICxm4cGk8vx
+            pNjrrLTckA0Q6nhB4+WjCtuVAm7Vp9CR6OUNwv2q5P6TopQhhOEAr2NvOluLzEzS
+            XAHLg9rGWb+zT1vHUCYVyYaHryxtS+YCK6fcfMKMTuj70TOv04D3qScafIq5YTAv
+            cXcFJrJGbJHQa9KyXJoyueZvqvfz1pbUbBqt4nOvqbpbWp+/HlEMATdxp4Kv
+            =MyS9
+            -----END PGP MESSAGE-----
+        fp: 4DC4116D360E3276
+    encrypted_regex: ^(data|stringData|tls)$
     version: 3.5.0


### PR DESCRIPTION
re-encrypt sefkhet secrets with updates sops
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #800 

## Description

as moc argocd deploys the cnv-prod overlays, the encryption must be done along with there gpg keys.