### PR TITLE
use a postsync hook job for deployment trigger

### DIFF
--- a/user-api/overlays/test/deployment-trigger.yaml
+++ b/user-api/overlays/test/deployment-trigger.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: deployment-trigger
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: deployment-trigger
+          image: quay.io/openshift/origin-cli:latest
+          command:
+            - "oc"
+            - "rollout"
+            - "latest"
+            - "user-api"
+      restartPolicy: Never
+  backoffLimit: 2


### PR DESCRIPTION
use a postsync hook job for deployment trigger
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

https://github.com/AICoE/aicoe-cd/issues/233#issuecomment-767672303
we can test if resource hook can help us with triggering deploymentconfig. 