### PR TITLE
setting lgtm_acts_as_approve: false for all our repos

### DIFF
--- a/prow/overlays/cnv-prod/plugins.yaml
+++ b/prow/overlays/cnv-prod/plugins.yaml
@@ -87,6 +87,7 @@ approve:
       - thoth-station
     require_self_approval: true
     ignore_review_state: false
+    lgtm_acts_as_approve: false
 
 repo_milestone:
   "":


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## This introduces a breaking change

- [x] Yes
- [ ] No

@HumairAK @tumido @harshad16 

/sig devops