### PR TITLE
add cronjob to sync all the labels

### DIFF
--- a/prow/base/imagestreams.yaml
+++ b/prow/base/imagestreams.yaml
@@ -70,3 +70,11 @@ metadata:
 spec:
   lookupPolicy:
     local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: label-sync
+spec:
+  lookupPolicy:
+    local: true

--- a/prow/base/label_sync_job.yaml
+++ b/prow/base/label_sync_job.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: label-sync
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        name: label-sync
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: label-sync
+          image: label-sync:latest
+          args:
+            - --config=/etc/config/labels.yaml
+            - --confirm=true
+            - --orgs=thoth-station
+            - --token=/etc/github/oauth
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: config
+          configMap:
+            name: label-config

--- a/prow/overlays/cnv-prod/imagestreamtags.yaml
+++ b/prow/overlays/cnv-prod/imagestreamtags.yaml
@@ -130,3 +130,23 @@ spec:
       importPolicy: {}
       referencePolicy:
         type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: label-sync
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      from:
+        kind: ImageStreamTag
+        name: v20210127-5fd357428d
+    - name: v20210127-5fd357428
+      from:
+        kind: DockerImage
+        name: gcr.io/k8s-prow/label_sync:v20210127-5fd357428d
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/prow/overlays/cnv-prod/kustomization.yaml
+++ b/prow/overlays/cnv-prod/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - roles.yaml
   - rolebindings.yaml
   - s3-bucket-claim.yaml
+  - label-sync-cronjob.yaml
 patchesStrategicMerge:
   - imagestreamtags.yaml
 configMapGenerator:
@@ -14,6 +15,9 @@ configMapGenerator:
   - name: plugins
     files:
       - plugins.yaml
+  - name: labels
+    files:
+      - labels.yaml
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/prow/overlays/cnv-prod/label-sync-cronjob.yaml
+++ b/prow/overlays/cnv-prod/label-sync-cronjob.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: label-sync
+spec:
+  schedule: "17 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      labels:
+        app: label-sync
+    spec:
+      template:
+        spec:
+          containers:
+            - name: label-sync
+              image: label-sync:latest
+              args:
+                - --config=/etc/config/labels.yaml
+                - --confirm=true
+                - --orgs=thoth-station
+                - --token=/etc/github/oauth
+              volumeMounts:
+                - name: oauth
+                  mountPath: /etc/github
+                  readOnly: true
+                - name: config
+                  mountPath: /etc/config
+                  readOnly: true
+          restartPolicy: Never
+          volumes:
+            - name: oauth
+              secret:
+                secretName: oauth-token
+            - name: config
+              configMap:
+                name: label-config

--- a/prow/overlays/cnv-prod/labels.yaml
+++ b/prow/overlays/cnv-prod/labels.yaml
@@ -249,7 +249,6282 @@ default:
       addedBy: anyone
     - color: fef2c0
       description: Categorizes an issue or PR as relevant to SIG Documentation.
-      name: sig/documentation
+      name: sig/docs
       target: both
       prowPlugin: label
+      previously:
+        - name: sig/documentation
       addedBy: anyone
+repos:
+  thoth-station/advise-reporter:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/adviser:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/amun-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/amun-client:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/amun-hwinfo:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/analyzer:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/ash-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/build-analyzers:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/build-watcher:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/buildlog-parser:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/cleanup-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/cli-examples:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/common:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/core:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/cuda:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/cve-update-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/datasets:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/dependency-monkey:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/dependency-monkey-zoo:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/elyra-aidevsecops-tutorial:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/fext:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/glyph:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/graph-backup-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/graph-refresh-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/graph-sync-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/graph-sync-scheduler:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/image-pusher:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/init-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/integration-tests:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/invectio:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/investigator:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/isis-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/jupyter-nbrequirements:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/jupyter-nbtemplates:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/jupyter-notebook:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/jupyter-notebook-s2i:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/jupyter-notebooks:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/jupyterlab-requirements:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/jupyternb-build-pipeline:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/kebechet:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/lab:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/management-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/messaging:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/metrics-exporter:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/mi:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/mi-scheduler:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/microbenchmarks:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/micropipenv:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/misc:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/nefertem:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/nepthys:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/notebooks:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/observations:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/openblas:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/package-analyzer:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/package-build-controller:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/package-extract:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/package-releases-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/package-update-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/performance:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/postgresql-thoth-config:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/python:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/qeb-hwt:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/report-processing:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/report-visualization:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/result-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/revsolver:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-example:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-example-flask:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-example-migration:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-minimal-notebook:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-pytorch-notebook:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-scipy-notebook:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-tensorflow-gpu-notebook:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-tensorflow-notebook:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/s2i-thoth:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/selinon-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/selinon-worker:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/si-aggregator:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/si-bandit:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/si-cloc:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/slo-reporter:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/socrates:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/solver:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/solver-error-classfier:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/solver-errors-reporter:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/source-management:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/srcops-testing:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/storages:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/stub-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/sync-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/talks:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/template-project:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/tensorflow-release-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/tensorflow-release-job:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/tensorflow-serving-build:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/tensorflow-symbols:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/termial-random:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thamos:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thoth:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thoth-application:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thoth-ops:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thoth-ops-infra:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thoth-pybench:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thoth-station.github.io:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/thoth-toolbox:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/user-api:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/website:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/workflow-controller:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/workflow-helpers:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both
+  thoth-station/workflows:
+    labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
+        name: sig/investigator
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to {meta|performance|security} indicators.
+        name: sig/indicators
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/8
+        name: sig/knowledge-graph
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to Solvers
+        name: sig/solvers
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to Service Level Indicators and Objectives
+          and their reporting
+        name: sig/slo
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/4
+        name: sig/advisor
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to building and continuous delivery of build
+          artifacts.
+        name: sig/build
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
+        description:
+          Issues or PRs related to the User Experience of our Services, Tools,
+          and Libraries.
+        name: sig/user-experience
+        prowPlugin: label
+        target: both

--- a/prow/overlays/cnv-prod/labels.yaml
+++ b/prow/overlays/cnv-prod/labels.yaml
@@ -988,6 +988,12 @@ repos:
     labels:
       - addedBy: human
         color: 0ffa16
+        description: Issues or PRs related to release engineering work.
+        name: release-eng
+        prowPlugin: label
+        target: both
+      - addedBy: human
+        color: 0ffa16
         description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14
         name: sig/investigator
         prowPlugin: label
@@ -5914,6 +5920,12 @@ repos:
         target: both
   thoth-station/thoth-application:
     labels:
+      - addedBy: human
+        color: 0ffa16
+        description: Issues or PRs related to release engineering work.
+        name: release-eng
+        prowPlugin: label
+        target: both
       - addedBy: human
         color: 0ffa16
         description: Issues or PRs related to https://github.com/orgs/thoth-station/projects/14

--- a/prow/overlays/cnv-prod/labels.yaml
+++ b/prow/overlays/cnv-prod/labels.yaml
@@ -1,0 +1,242 @@
+# default: global configuration to be applied to all repos
+# repos: list of repos with specific configuration to be applied in addition to default
+#   labels: list of labels - keys for each item: color, description, name, target, deleteAfter, previously
+#     deleteAfter: 2006-01-02T15:04:05Z (rfc3339)
+#     previously: list of previous labels (color name deleteAfter, previously)
+#     target: one of issues, prs, or both (also TBD)
+#     addedBy: human? prow plugin? other?
+---
+default:
+  labels:
+    - color: 0ffa16
+      description: Indicates a PR has been approved by an approver from all required OWNERS files.
+      name: approved
+      target: prs
+      prowPlugin: approve
+      addedBy: approvers
+    - color: e11d21
+      description: Indicates that a PR should not merge because it touches files in blocked paths.
+      name: do-not-merge/blocked-paths
+      target: prs
+      prowPlugin: blockade
+      addedBy: prow
+    - color: e11d21
+      description: Indicates that a PR should not merge because someone has issued a /hold command.
+      name: do-not-merge/hold
+      target: prs
+      prowPlugin: hold
+      addedBy: anyone
+    - color: e11d21
+      description: Indicates that a PR should not merge because it has an invalid OWNERS file in it.
+      name: do-not-merge/invalid-owners-file
+      target: prs
+      prowPlugin: verify-owners
+      addedBy: prow
+    - color: e11d21
+      description: Indicates that a PR should not merge because it is a work in progress.
+      name: do-not-merge/work-in-progress
+      target: prs
+      prowPlugin: wip
+      addedBy: prow
+    - color: e11d21
+      description: Categorizes issue or PR as related to a bug.
+      name: kind/bug
+      previously:
+        - name: bug
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
+      name: kind/cleanup
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Categorizes issue or PR as related to a feature/enhancement marked for deprecation.
+      name: kind/deprecation
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to documentation.
+      name: kind/documentation
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: c7def8
+      description: Categorizes issue or PR as related to a new feature.
+      name: kind/feature
+      previously:
+        - name: enhancement
+        - name: kind/enhancement
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: d455d0
+      description: Categorizes issue or PR as a support question.
+      name: kind/question
+      previously:
+        - name: close/support
+        - name: question
+        - name: triage/support
+      target: both
+      addedBy: humans
+    - color: 15dd18
+      description: Indicates that a PR is ready to be merged.
+      name: lgtm
+      target: prs
+      prowPlugin: lgtm
+      addedBy: reviewers or members
+    - color: d3e2f0
+      description: Indicates that an issue or PR should not be auto-closed due to staleness.
+      name: lifecycle/frozen
+      previously:
+        - name: keep-open
+      target: both
+      prowPlugin: lifecycle
+      addedBy: anyone
+    - color: 8fc951
+      description: Indicates that an issue or PR is actively being worked on by a contributor.
+      name: lifecycle/active
+      previously:
+        - name: active
+      target: both
+      prowPlugin: lifecycle
+      addedBy: anyone
+    - color: "604460"
+      description: Denotes an issue or PR that has aged beyond stale and will be auto-closed.
+      name: lifecycle/rotten
+      target: both
+      prowPlugin: lifecycle
+      addedBy: anyone
+    - color: "795548"
+      description: Denotes an issue or PR has remained open with no activity and has become stale.
+      name: lifecycle/stale
+      previously:
+        - name: stale
+      target: both
+      prowPlugin: lifecycle
+      addedBy: anyone
+    - color: e11d21
+      description: Indicates a PR cannot be merged because it has merge conflicts with HEAD.
+      name: needs-rebase
+      target: prs
+      prowPlugin: needs-rebase
+      isExternalPlugin: true
+      addedBy: prow
+    - color: fef2c0
+      description: Lowest priority. Possibly useful, but not yet enough support to actually get it done. # These are mostly place-holders for potentially good ideas, so that they don't get completely forgotten, and can be referenced /deduped every time they come up.
+      name: priority/awaiting-more-evidence
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: fbca04
+      description: Higher priority than priority/awaiting-more-evidence. # There appears to be general agreement that this would be good to have, but we may not have anyone available to work on it right now or in the immediate future. Community contributions would be most welcome in the mean time (although it might take a while to get them reviewed if reviewers are fully occupied with higher priority issues, for example immediately before a release).
+      name: priority/backlog
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: e11d21
+      description: Highest priority. Must be actively worked on as someone's top priority right now. # Stuff is burning. If it's not being actively worked on, someone is expected to drop what they're doing immediately to work on it. Team leaders are responsible for making sure that all the issues, labeled with this priority, in their area are being actively worked on. Examples include user-visible bugs in core features, broken builds or tests and critical security issues.
+      name: priority/critical-urgent
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: eb6420
+      description: Important over the long term, but may not be staffed and/or may need multiple releases to complete.
+      name: priority/important-longterm
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: eb6420
+      description: Must be staffed and worked on either currently, or very soon, ideally in time for the next release.
+      name: priority/important-soon
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: ee9900
+      description: Denotes a PR that changes 100-499 lines, ignoring generated files.
+      name: size/L
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: eebb00
+      description: Denotes a PR that changes 30-99 lines, ignoring generated files.
+      name: size/M
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: 77bb00
+      description: Denotes a PR that changes 10-29 lines, ignoring generated files.
+      name: size/S
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: ee5500
+      description: Denotes a PR that changes 500-999 lines, ignoring generated files.
+      name: size/XL
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: "009900"
+      description: Denotes a PR that changes 0-9 lines, ignoring generated files.
+      name: size/XS
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: ee0000
+      description: Denotes a PR that changes 1000+ lines, ignoring generated files.
+      name: size/XXL
+      target: prs
+      prowPlugin: size
+      addedBy: prow
+    - color: ffaa00
+      description: Denotes a PR that should be squashed by tide when it merges.
+      name: tide/merge-method-squash
+      target: prs
+      addedBy: humans
+      previously:
+        - name: tide/squash
+    - color: ffaa00
+      description: Denotes a PR that should be rebased by tide when it merges.
+      name: tide/merge-method-rebase
+      target: prs
+      addedBy: humans
+    - color: ffaa00
+      description: Denotes a PR that should use a standard merge by tide when it merges.
+      name: tide/merge-method-merge
+      target: prs
+      addedBy: humans
+    - color: e11d21
+      description: Denotes an issue that blocks the tide merge queue for a branch while it is open.
+      name: tide/merge-blocker
+      target: issues
+      addedBy: humans
+      previously:
+        - name: merge-blocker
+    - color: f9d0c4
+      description: ¯\\\_(ツ)_/¯
+      name: "¯\\_(ツ)_/¯"
+      target: both
+      prowPlugin: shrug
+      addedBy: humans
+
+    - color: fef2c0
+      description: Categorizes an issue or PR as relevant to SIG Cyborgs and Bots.
+      name: sig/cyborgs
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: fef2c0
+      description: Categorizes an issue or PR as relevant to SIG DevOps.
+      name: sig/devops
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - color: fef2c0
+      description: Categorizes an issue or PR as relevant to SIG Documentation.
+      name: sig/documentation
+      target: both
+      prowPlugin: label
+      addedBy: anyone

--- a/prow/overlays/cnv-prod/labels.yaml
+++ b/prow/overlays/cnv-prod/labels.yaml
@@ -222,6 +222,19 @@ default:
       prowPlugin: shrug
       addedBy: humans
 
+    - color: 99cdf8
+      description: Issues targeting the hacktoberfest participants.
+      name: hacktoberfest
+      target: issue
+      prowPlugin: label
+      addedBy: anyone
+    - color: 99cdf8
+      description: PR that has been accepted for hacktoberfest!
+      name: hacktoberfest-accepted
+      target: prs
+      prowPlugin: label
+      addedBy: humans
+
     - color: fef2c0
       description: Categorizes an issue or PR as relevant to SIG Cyborgs and Bots.
       name: sig/cyborgs

--- a/prow/overlays/cnv-prod/plugins.yaml
+++ b/prow/overlays/cnv-prod/plugins.yaml
@@ -1,29 +1,33 @@
 label:
   additional_labels:
+    - community/discussion
+    - community/group-programming
+    - community/maintenance
+    - community/question
+    - deployment_name/moc
+    - deployment_name/ocp-stage
+    - deployment_name/ocp-test
+    - kind/cleanup
+    - kind/deprecation
+    - kind/documentation
+    - kind/question
+    - kind/question
+    - sig/advisor
+    - sig/build
+    - sig/cyborgs
+    - sig/devops
+    - sig/documentation
+    - sig/indicators
+    - sig/investigator
+    - sig/knowledge-graph
+    - sig/slo
+    - sig/solvers
+    - thoth/group-programming
+    - thoth/human-intervention-required
+    - thoth/potential-observation
     - tide/merge-method-merge
     - tide/merge-method-rebase
     - tide/merge-method-squash
-    - deployment_name/ocp-test
-    - deployment_name/ocp-stage
-    - deployment_name/moc
-    - thoth/group-programming
-    - thoth/potential-observation
-    - thoth/human-intervention-required
-    - sig/documentation
-    - sig/cyborgs
-    - sig/investigator
-    - sig/indicators
-    - sig/knowledge-graph
-    - sig/solvers
-    - sig/slo
-    - sig/advisor
-    - sig/build
-    - sig/devops
-    - kind/question
-    - community/discussion
-    - community/maintenance
-    - community/question
-    - community/group-programming
 
 external_plugins:
   thoth-station:
@@ -81,11 +85,13 @@ plugins:
   operate-first:
     - approve
     - assign
+    - blockade
     - blunderbuss
     - hold
     - label
     - lgtm
     - lifecycle
+    - shrug
     - size
     - trigger
     - verify-owners
@@ -93,12 +99,14 @@ plugins:
   thoth-station:
     - approve
     - assign
+    - blockade
     - blunderbuss
     - hold
     - label
     - lgtm
     - lifecycle
     - milestone
+    - shrug
     - size
     - trigger
     - verify-owners
@@ -106,6 +114,7 @@ plugins:
   AICoE:
     - approve
     - assign
+    - blockade
     - blunderbuss
     - hold
     - label
@@ -118,6 +127,7 @@ plugins:
   aicoe-aiops:
     - approve
     - assign
+    - blockade
     - blunderbuss
     - hold
     - label


### PR DESCRIPTION
add cronjob to sync all the labels, this superseds new_label_normalizer from Sefkhet-Abwy

Signed-off-by: Christoph Görn <goern@redhat.com>

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
