### PR TITLE
Bump graph-backup-job stage to v0.8.0 to have metrics

### DIFF
--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.7.0
+        name: quay.io/thoth-station/graph-backup-job:v0.8.0
       importPolicy: {}

--- a/graph-backup-job/overlays/stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.7.0
+        name: quay.io/thoth-station/graph-backup-job:v0.8.0
       importPolicy: {}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related-To: https://github.com/thoth-station/metrics-exporter/issues/529