### PR TITLE
Bump workflow helpers to v0.4.1

### DIFF
--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.4.0
+      name: quay.io/thoth-station/workflow-helpers:v0.4.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/stage/common/imagestreamtags.yaml
+++ b/core/overlays/stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.4.0
+      name: quay.io/thoth-station/workflow-helpers:v0.4.1
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

In this way we can update schema in stage! Test schema is already updated: https://grafana.datahub.redhat.com/dashboard/db/thoth-service-metrics?refresh=30s&orgId=1&var-env=ocp4-test
