### PR TITLE
Bump graph-sync to v0.10.0 in stage

### DIFF
--- a/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.9.0
+        name: quay.io/thoth-station/graph-sync-job:v0.10.0
       importPolicy: {}

--- a/graph-sync/overlays/stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.9.0
+        name: quay.io/thoth-station/graph-sync-job:v0.10.0
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

This is needed for Thoth S2I scenario to properly work.

## This introduces a breaking change

- [x] No
