### PR TITLE
Bump metrics-exporter stage to v0.10.2

### DIFF
--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.10.1
+        name: quay.io/thoth-station/metrics-exporter:v0.10.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.10.1
+        name: quay.io/thoth-station/metrics-exporter:v0.10.2
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/metrics-exporter/issues/529

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->
