### PR TITLE
Bump graph-sync to v0.10.1 to address solver syncing issues

### DIFF
--- a/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.0
+        name: quay.io/thoth-station/graph-sync-job:v0.10.1
       importPolicy: {}

--- a/graph-sync/overlays/stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.0
+        name: quay.io/thoth-station/graph-sync-job:v0.10.1
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/storages/issues/2205

## This introduces a breaking change

- [x] No
