### PR TITLE
add keb metadata for internal trigger context

### DIFF
--- a/kebechet/base/argo-workflows/kebechet-run-url.yaml
+++ b/kebechet/base/argo-workflows/kebechet-run-url.yaml
@@ -14,6 +14,7 @@ spec:
         parameters:
         - name: KEBECHET_REPO_URL
         - name: KEBECHET_SERVICE_NAME
+        - name: KEBECHET_METADATA
       container:
         image: kebechet
         env:
@@ -31,6 +32,8 @@ spec:
             value: "{{inputs.parameters.KEBECHET_REPO_URL}}"
           - name: KEBECHET_SERVICE_NAME
             value: "{{inputs.parameters.KEBECHET_SERVICE_NAME}}"
+          - name: KEBECHET_METADATA
+            value: "{{inputs.parameters.KEBECHET_METADATA}}"
           - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:

--- a/kebechet/base/openshift-templates/kebechet-run-url.yaml
+++ b/kebechet/base/openshift-templates/kebechet-run-url.yaml
@@ -29,6 +29,11 @@ parameters:
     description: "The service name for kebechet run, it defaults to github."
     displayName: "Service Name"
     required: true
+  - name: KEBECHET_METADATA
+    description: "Metadata which is passed to Kebechet that Kebechet can use when opening PRs and Issues."
+    displayName: "Kebechet Metadata"
+    required: true
+    value: 'null'
 
 objects:
   - apiVersion: argoproj.io/v1alpha1
@@ -84,6 +89,8 @@ objects:
             value: "${KEBECHET_REPO_URL}"
           - name: "KEBECHET_SERVICE_NAME"
             value: "${KEBECHET_SERVICE_NAME}"
+          - name: "KEBECHET_METADATA"
+            value: "${KEBECHET_METADATA}"
       volumes:
         - name: ssh-config
           secret:
@@ -114,3 +121,5 @@ objects:
                       value: "{{workflow.parameters.KEBECHET_REPO_URL}}"
                     - name: "KEBECHET_SERVICE_NAME"
                       value: "{{workflow.parameters.KEBECHET_SERVICE_NAME}}"
+                    - name: "KEBECHET_METADATA"
+                      value: "{{workflow.parameters.KEBECHET_METADATA}}"


### PR DESCRIPTION
## Related Issues and Dependencies

thoth-station/kebechet#584

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [x] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Add param to templates for kebechet metadata.

This should be okay to add to base because old versions of Kebechet won't be looking for it and a default value was provided so it shouldn't fail
