### PR TITLE
migrate dependency monkey run in amun-inspection

### DIFF
--- a/adviser/overlays/ocp4-stage/kustomization.yaml
+++ b/adviser/overlays/ocp4-stage/kustomization.yaml
@@ -40,7 +40,7 @@ patchesJson6902:
       version: v1
       kind: Template
       name: provenance-checker
-  - path: put-into-middletier-namespace.yaml
+  - path: put-into-amun-inspection-namespace.yaml
     target:
       group: argoproj.io
       version: v1alpha1

--- a/adviser/overlays/ocp4-stage/put-into-amun-inspection-namespace.yaml
+++ b/adviser/overlays/ocp4-stage/put-into-amun-inspection-namespace.yaml
@@ -1,3 +1,3 @@
 - op: add
   path: /metadata/namespace
-  value: thoth-middletier-stage
+  value: thoth-amun-inspection-stage

--- a/management-api/overlays/ocp4-stage/role-binding.yaml
+++ b/management-api/overlays/ocp4-stage/role-binding.yaml
@@ -40,3 +40,17 @@ subjects:
   - kind: ServiceAccount
     name: management-api
     namespace: thoth-frontend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: management-api-argo-admin
+  namespace: thoth-amun-inspection-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-admin
+subjects:
+  - kind: ServiceAccount
+    name: management-api
+    namespace: thoth-frontend-stage


### PR DESCRIPTION
## Related Issues and Dependencies

**Depends-On**: 
https://github.com/thoth-station/common/pull/1104
https://github.com/thoth-station/management-api/pull/695

Related-to: https://github.com/thoth-station/thoth-application/issues/629

## This Pull Request implements

migrate dependency monkey run in amun-inspection
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

moving dependency moneky execution from middletier to amun-inspection for our resource consumption needs.