### PR TITLE
Bump adviser to v0.24.1 in stage environments

### DIFF
--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.23.0
+        name: quay.io/thoth-station/adviser:v0.24.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/stage/imagestreamtag.yaml
+++ b/adviser/overlays/stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.23.0
+        name: quay.io/thoth-station/adviser:v0.24.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

This change will bring the selective pre-releases feature to stage environments. See [docs for more info](https://thoth-station.ninja/docs/developers/adviser/experimental_features.html#selectively-enabling-pre-releases).

## This introduces a breaking change

- [x] No
