### PR TITLE
Revert "add kustomize-build presubmit job to op1st/apps repo ʕʘ̅͜ʘ̅ʔ"

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -362,35 +362,3 @@ presubmits:
               requests:
                 memory: "2Gi"
                 cpu: "2"
-
-  operate-first/apps:
-    - name: kustomize-build
-      decorate: true
-      max_concurrency: 1
-      run_if_changed: ".*yaml"
-      skip_report: false
-      context: aicoe-ci/kustomize-build
-      spec:
-        containers:
-          - image: quay.io/operate-first/opf-toolbox:v0.2.0
-            command:
-              - "./test-kustomize-build" # this is contained in the thoth-application/ repo not the opf-toolbox
-            resources:
-              requests:
-                memory: "256Mi"
-    - name: pre-commit
-      decorate: true
-      skip_report: false
-      always_run: true
-      context: aicoe-ci/prowjob-pre-commit
-      spec:
-        containers:
-          - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.4
-            command:
-              - "pre-commit"
-              - "run"
-              - "--all-files"
-            resources:
-              requests:
-                memory: "2Gi"
-                cpu: "2"


### PR DESCRIPTION
Reverts thoth-station/thoth-application#867
This pull request depended upon https://github.com/operate-first/apps/pull/217 , which isn't merged.