### PR TITLE
using latest release of integration-tests

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -302,7 +302,7 @@ periodics:
     decorate: true
     spec:
       containers:
-        - image: quay.io/thoth-station/integration-tests:v0.3.1
+        - image: quay.io/thoth-station/integration-tests:v0.3.0
           imagePullPolicy: Always
           command:
             - ./e2e-test.sh

--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -302,7 +302,7 @@ periodics:
     decorate: true
     spec:
       containers:
-        - image: quay.io/thoth-station/integration-tests:v0.1.6
+        - image: quay.io/thoth-station/integration-tests:v0.3.1
           imagePullPolicy: Always
           command:
             - ./e2e-test.sh


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies

https://github.com/thoth-station/integration-tests/issues/95

## This introduces a breaking change

- [ ] Yes
- [x] No

/hold until v0.3.1 is available at https://quay.io/repository/thoth-station/integration-tests?tag=latest&tab=tags
/sig devops
