### PR TITLE
Add integration tests

### DIFF
--- a/integration-tests/base/configmap.yaml
+++ b/integration-tests/base/configmap.yaml
@@ -1,0 +1,7 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: integration-tests
+data:
+  send-mail: "1"

--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: integration-tests
+  labels:
+    app: thoth
+    component: integration-tests
+spec:
+  schedule: "@daily"
+  suspend: true
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 4
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: null
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: thoth
+            component: integration-tests
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - image: "integration-tests:latest"
+              name: integration-tests
+              env:
+                - name: SEND_EMAIL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: send-mail
+                      name: integration-tests
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      key: deployment-name
+                      name: integration-tests
+                - name: THOTH_USER_API_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: user-api
+                      name: integration-tests
+                - name: THOTH_MANAGEMENT_API_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: management-api
+                      name: integration-tests
+                - name: THOTH_AMUN_API_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: amun-api
+                      name: integration-tests
+                - name: THOTH_MANAGEMENT_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      key: management-api
+                      name: integration-tests
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "1"
+                limits:
+                  memory: "256Mi"
+                  cpu: "1"

--- a/integration-tests/base/imagestream.yaml
+++ b/integration-tests/base/imagestream.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: integration-tests
+spec:
+  lookupPolicy:
+    local: true

--- a/integration-tests/base/kustomization.yaml
+++ b/integration-tests/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml
+  - imagestream.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+commonLabels:
+  app: thoth
+  component: integration-tests

--- a/integration-tests/overlays/ocp4-stage/configmap.yaml
+++ b/integration-tests/overlays/ocp4-stage/configmap.yaml
@@ -1,0 +1,10 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: integration-tests
+data:
+  deployment-name: "ocp4-stage"
+  user-api: "stage.thoth-station.ninja"
+  management-api: "management.stage.thoth-station.ninja"
+  amun-api: "amun.stage.thoth-station.ninja"

--- a/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: integration-tests
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/integration-tests:v0.3.0
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/integration-tests/overlays/ocp4-stage/kustomization.yaml
+++ b/integration-tests/overlays/ocp4-stage/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+patchesJson6902:
+  - path: put-into-infra-namespace.yaml
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: user-api
+generatorOptions:
+  disableNameSuffixHash: true

--- a/integration-tests/overlays/ocp4-stage/put-into-infra-namespace.yaml
+++ b/integration-tests/overlays/ocp4-stage/put-into-infra-namespace.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/namespace
+  value: thoth-infra-stage

--- a/integration-tests/overlays/ocp4-stage/thoth-notification.yaml
+++ b/integration-tests/overlays/ocp4-stage/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-succeeded-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have successfully synchronized *integration-tests* components to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/stage-thoth-integration-tests|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-failed-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAILED* syncing *integration-tests* components to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/stage-thoth-integration-tests|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2

--- a/integration-tests/overlays/test/configmap.yaml
+++ b/integration-tests/overlays/test/configmap.yaml
@@ -1,0 +1,10 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: integration-tests
+data:
+  deployment-name: "ocp4-test"
+  user-api: "test.thoth-station.ninja"
+  management-api: "management.test.thoth-station.ninja"
+  amun-api: "amun.test.thoth-station.ninja"

--- a/integration-tests/overlays/test/imagestreamtag.yaml
+++ b/integration-tests/overlays/test/imagestreamtag.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: integration-tests
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/integration-tests:v0.3.0
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/integration-tests/overlays/test/kustomization.yaml
+++ b/integration-tests/overlays/test/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: thoth-test-core
+commonLabels:
+  app: thoth
+  component: integration-tests
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+  - configmap.yaml

--- a/integration-tests/overlays/test/thoth-notification.yaml
+++ b/integration-tests/overlays/test/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-succeeded-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have successfully synchronized *integration-tests* components to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/test-thoth-integration-tests|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-failed-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAILED* syncing *integration-tests* components to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/stage-thoth-integration-tests|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2


### PR DESCRIPTION
## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/integration-tests/pull/109

## This introduces a breaking change

- [x] No

## This Pull Request implements

With this change, we will be able to deploy integration tests as an s2i application run as a cronjob periodically. We can run it inside any namespace in the internal network (as integration tests send email to mailing lists) to verify the application works correctly. The cronjob can be run each per deployment we want to run integration tests against.