### PR TITLE
Bump User API to v0.19.0 in stage environments

### DIFF
--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.18.0
+        name: quay.io/thoth-station/user-api:v0.19.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/stage/imagestreamtag.yaml
+++ b/user-api/overlays/stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.18.0
+        name: quay.io/thoth-station/user-api:v0.19.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Related: https://github.com/thoth-station/user-api/pull/1258

## This introduces a breaking change

- [x] No
