### PR TITLE
all the roles and rolebindungs to use the test-pods namespace

### DIFF
--- a/prow/overlays/cnv-prod-test-prods/crier_rbac.yaml
+++ b/prow/overlays/cnv-prod-test-prods/crier_rbac.yaml
@@ -1,0 +1,33 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "events"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "patch"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: crier-namespaced
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crier
+subjects:
+  - kind: ServiceAccount
+    name: crier
+    namespace: opf-ci-prow

--- a/prow/overlays/cnv-prod-test-prods/deck_rbac.yaml
+++ b/prow/overlays/cnv-prod-test-prods/deck_rbac.yaml
@@ -1,0 +1,25 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: deck
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: deck
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deck
+subjects:
+  - kind: ServiceAccount
+    name: deck
+    namespace: opf-ci-prow

--- a/prow/overlays/cnv-prod-test-prods/kustomization.yaml
+++ b/prow/overlays/cnv-prod-test-prods/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - crier_rbac.yaml
+  - deck_rbac.yaml
+  - sinker_rbac.yaml

--- a/prow/overlays/cnv-prod-test-prods/sinker_rbac.yaml
+++ b/prow/overlays/cnv-prod-test-prods/sinker_rbac.yaml
@@ -1,0 +1,30 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "sinker"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+      - get
+      - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "sinker"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "sinker"
+subjects:
+  - kind: ServiceAccount
+    name: "sinker"
+    namespace: opf-ci-prow


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies

This should be deployed via a separate argocd app, target namespace: opf-ci-test-pods

It does not include any changes to Prow config, this is for a later PR

## This introduces a breaking change

- [ ] Yes
- [x] No
