### PR TITLE
Bump of version for prod release 15.02.2021

### DIFF
--- a/advise-reporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/advise-reporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.5.1
+      name: quay.io/thoth-station/advise-reporter:v0.6.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.22.0
+        name: quay.io/thoth-station/adviser:v0.24.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/cnv-prod/common/imagestreamtags.yaml
+++ b/core/overlays/cnv-prod/common/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.8.2
+      name: quay.io/thoth-station/investigator:v0.9.1
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -49,7 +49,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/messaging:v0.7.13
+      name: quay.io/thoth-station/messaging:v0.10.3
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/graph-refresh/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-refresh/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.2.9
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.3
       importPolicy: {}

--- a/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.8.4
+        name: quay.io/thoth-station/graph-sync-job:v0.10.3
       importPolicy: {}

--- a/kebechet/overlays/cnv-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.2.3
+        name: quay.io/thoth-station/kebechet-job:v1.2.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/management-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/management-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.10.1
+      name: quay.io/thoth-station/management-api:v0.11.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.9.1
+        name: quay.io/thoth-station/metrics-exporter:v0.11.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-extract/overlays/cnv-prod/imagestreamtag.yaml
+++ b/package-extract/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/package-extract:v0.6.0-dev"
+        name: "quay.io/thoth-station/package-extract:v1.1.2"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-update/overlays/cnv-prod/imagestreamtag.yaml
+++ b/package-update/overlays/cnv-prod/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.4
+        name: quay.io/thoth-station/package-update-job:v0.8.7
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/user-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.11.1
+        name: quay.io/thoth-station/user-api:v0.18.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## This Pull Request implements

Bump of version for prod release 15.02.2021
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

This is the production release for sprint cycle 15.02.2021
With this release, we would be updating thoth-components with the following feature updates and fixes.

[x]  **Advise-reporter**
  - Add metrics database(https://github.com/thoth-station/advise-reporter/pull/158)

[x]  **Adviser**
  - Do not enable cut pre-releases step if selective pre-releases are allowed(https://github.com/thoth-station/adviser/pull/1657)
 - Thoth's additional features can be None(https://github.com/thoth-station/adviser/pull/1660)
 - Add a pipeline unit recommending Thoth's s2i as a base (https://github.com/thoth-station/adviser/pull/1635)
 - Implement a pipeline unit which checks GPU and CUDA supplied (https://github.com/thoth-station/adviser/pull/1630)
 - Add a sieve to filter out packages based on ABI provided by s2i Thoth(https://github.com/thoth-station/adviser/pull/1632)
 - Fix S2I multiple include pipeline unit(https://github.com/thoth-station/adviser/pull/1639)
 - Invert inclusion logic, include if Thoth s2i is not used(https://github.com/thoth-station/adviser/pull/1640)
 - Add a wrap that adds information about Thoth s2i used(https://github.com/thoth-station/adviser/pull/1638)
 - Implement a pipeline unit for selective pre-release filtering (https://github.com/thoth-station/adviser/pull/1648)
 - Link Experimental features section from docs index (https://github.com/thoth-station/adviser/pull/1656)

[x]  **Investigator**
 - Standardize metrics for revision check (https://github.com/thoth-station/investigator/pull/434)
 - Add metric schema (https://github.com/thoth-station/investigator/pull/428)
 - retry on exceptions and other error handling(https://github.com/thoth-station/investigator/pull/389)
 - decs are applied inside-out (https://github.com/thoth-station/investigator/pull/424)

[x]  **Messaging**
 - Confluent rework (https://github.com/thoth-station/messaging/pull/300)
 - pass ca location for ssl alg(https://github.com/thoth-station/messaging/pull/317)
 - upgrade to python3.8(https://github.com/thoth-station/messaging/pull/321)

[x]  **Graph-refresh**
 - upgrade to python3.8(https://github.com/thoth-station/graph-refresh-job/pull/543)
 - Add schema metric (https://github.com/thoth-station/graph-refresh-job/pull/550)  

[x]  **Graph-sync**
 - Simplify sources, use just one module for component (https://github.com/thoth-station/graph-sync-job/pull/544)
 - Add metric to expose revision (https://github.com/thoth-station/graph-sync-job/pull/536)

[x]  **kebechet**
 - write outputs of pipenv lock -r to output file (https://github.com/thoth-station/kebechet/pull/686)
 - Thoth Labelmanager (https://github.com/thoth-station/kebechet/pull/656)

[x]  **Management-api**
 - Remove erase endpoint(https://github.com/thoth-station/management-api/pull/684)
 - Standardize metrics for database check(https://github.com/thoth-station/management-api/pull/680)

[x]  **Metrics-exporter**
 - Fix query used in get_user_python_software_stack_count method (https://github.com/thoth-station/metrics-exporter/pull/607)
 - Introduce metric for number of solvers from database table (https://github.com/thoth-station/metrics-exporter/pull/601)
 - Adjust condition to keep metrics (https://github.com/thoth-station/metrics-exporter/pull/593)
 - add job to check for db corruption (https://github.com/thoth-station/metrics-exporter/pull/547)
 - Introduce database revision metric checks (https://github.com/thoth-station/metrics-exporter/pull/577)

[x]  **Package-extract**
 - Bump skopeo version to support new features (https://github.com/thoth-station/package-extract/pull/430)
 - Gather image metadata during package-extract runs (https://github.com/thoth-station/package-extract/pull/431)
 - upgrade to python3.8 (https://github.com/thoth-station/package-extract/pull/425)

[x]  **Package-update**
 - Messaging v0.8 (https://github.com/thoth-station/package-update-job/pull/185)
 - upgrade to python3.8 (https://github.com/thoth-station/package-update-job/pull/176)

[x]  **User-api**
 - Allow nullable entries in the hardware section (https://github.com/thoth-station/user-api/pull/1240)
 - Move hardware endoint under Hardware section and adjust nullables (https://github.com/thoth-station/user-api/pull/1239)
 - Unify endpoint response with the remaining endpoints (https://github.com/thoth-station/user-api/pull/1233)
 - Remove obsolete endpoints (https://github.com/thoth-station/user-api/pull/1230)
 - Report an error if the given S2I container image analysis was not done (https://github.com/thoth-station/user-api/pull/1229)
 - Introduce endpoints for listing available Thoth s2i base container images (https://github.com/thoth-station/user-api/pull/1224)
 - Standardize metric for schema check (https://github.com/thoth-station/user-api/pull/1218)
 - Extend configuration to capture versions of other libraries (https://github.com/thoth-station/user-api/pull/1212)
 - Expose schema metric (https://github.com/thoth-station/user-api/pull/1206)