### PR TITLE
Rename environment variable for sending integration test reports

### DIFF
--- a/integration-tests/base/configmap.yaml
+++ b/integration-tests/base/configmap.yaml
@@ -4,4 +4,4 @@ apiVersion: v1
 metadata:
   name: integration-tests
 data:
-  send-mail: "1"
+  mail-report: "1"

--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -26,10 +26,10 @@ spec:
             - image: "integration-tests:latest"
               name: integration-tests
               env:
-                - name: SEND_EMAIL
+                - name: MAIL_REPORT
                   valueFrom:
                     configMapKeyRef:
-                      key: send-mail
+                      key: mail-report
                       name: integration-tests
                 - name: THOTH_DEPLOYMENT_NAME
                   valueFrom:


### PR DESCRIPTION
Credits go to @harshad16, thanks for spotting this.

## This introduces a breaking change

- [x] No

The environment variable is called `MAIL_REPORT`: https://github.com/thoth-station/integration-tests/blob/3e6cd68c48023d24858e46fed4caebaa7c5881bf/app.py#L32