### PR TITLE
Use prepared files in adviser container runs

### DIFF
--- a/adviser/overlays/test/argo-workflows/advise.yaml
+++ b/adviser/overlays/test/argo-workflows/advise.yaml
@@ -1,0 +1,215 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: advise
+spec:
+  templates:
+    - name: advise
+
+      metrics:
+        prometheus:
+          - name: task_status_counter
+            help: "Count of workflow task by status"
+            labels:
+              - key: name
+                value: adviser
+              - key: status
+                value: "{{status}}"
+            counter:
+              value: "1"
+
+          - name: task_duration_seconds_histogram
+            help: "Duration of workflow task when succeded"
+            when: "{{status}} == Succeeded"
+            labels:
+              - key: name
+                value: adviser
+            histogram:
+              buckets:
+                - 5
+                - 10
+                - 30
+                - 60
+                - 120
+                - 180
+                - 300
+                - 600
+                - 900
+              value: "{{duration}}"
+
+      resubmitPendingPods: true
+      inputs:
+        parameters:
+          - name: THOTH_ADVISER_JOB_ID
+          - name: THOTH_DOCUMENT_ID
+          - name: THOTH_ADVISER_REQUIREMENTS
+          - name: THOTH_ADVISER_REQUIREMENTS_LOCKED
+          - name: THOTH_ADVISER_LIBRARY_USAGE
+          - name: THOTH_ADVISER_REQUIREMENTS_FORMAT
+          - name: THOTH_ADVISER_RECOMMENDATION_TYPE
+          - name: THOTH_ADVISER_RUNTIME_ENVIRONMENT
+          - name: THOTH_ADVISER_PREDICTOR_CONFIG
+            value: "{}"
+          - name: THOTH_ADVISER_METADATA
+          - name: THOTH_ADVISER_SEED
+            value: "42"
+          - name: THOTH_ADVISER_DEV
+            value: "0"
+          - name: THOTH_ADVISER_BEAM_WIDTH
+            value: "25000"
+          - name: THOTH_LOG_ADVISER
+          - name: THOTH_ADVISER_LIMIT
+            value: "100000"
+          - name: THOTH_ADVISER_COUNT
+            value: "1"
+          - name: "THOTH_S3_ENDPOINT_URL"
+          - name: "THOTH_CEPH_BUCKET_NAME"
+          - name: "THOTH_CEPH_BUCKET_PREFIX"
+          - name: "THOTH_DEPLOYMENT_NAME"
+        artifacts:
+          - name: inputdocument
+            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
+            archive:
+              none: {}
+            s3:
+              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
+                {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/\
+                adviser/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
+              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+              insecure: true
+              accessKeySecret:
+                name: argo-artifact-repository-secrets
+                key: accessKey
+              secretKeySecret:
+                name: argo-artifact-repository-secrets
+                key: secretKey
+      outputs:
+        artifacts:
+          - name: outputdocument
+            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+            archive:
+              none: {}
+            s3:
+              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
+                {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/\
+                adviser/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+              insecure: true
+              accessKeySecret:
+                name: argo-artifact-repository-secrets
+                key: accessKey
+              secretKeySecret:
+                name: argo-artifact-repository-secrets
+                key: secretKey
+      container:
+        name: advise
+        image: adviser
+        env:
+          - name: THOTH_DOCUMENT_ID
+            value: "{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: THOTH_ADVISER_OUTPUT
+            value: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: THOTH_ADVISER_FORK
+            value: "1"
+          - name: THOTH_ADVISER_ENABLE_PREPARE
+            value: "1"
+          - name: THOTH_LOG_ADVISER
+            value: "{{inputs.parameters.THOTH_LOG_ADVISER}}"
+          - name: THOTH_ADJUST_LOGGING
+            value: "alembic.runtime.migration:WARNING,thoth.common:WARNING,thoth.analyzer.cli:WARNING,sentry_sdk.errors:WARNING"
+          - name: THOTH_SENTRY_IGNORE_LOGGER
+            value: "thoth.adviser.run"
+          - name: THOTH_ADVISER_COUNT
+            value: "{{inputs.parameters.THOTH_ADVISER_COUNT}}"
+          - name: THOTH_ADVISER_LIMIT
+            value: "{{inputs.parameters.THOTH_ADVISER_LIMIT}}"
+          - name: THOTH_ADVISER_REQUIREMENTS
+            value: "input/Pipfile"
+          - name: THOTH_ADVISER_REQUIREMENTS_LOCKED
+            value: "input/Pipfile.lock"
+          - name: THOTH_ADVISER_REQUIREMENTS_FORMAT
+            value: "{{inputs.parameters.THOTH_ADVISER_REQUIREMENTS_FORMAT}}"
+          - name: THOTH_ADVISER_RECOMMENDATION_TYPE
+            value: "{{inputs.parameters.THOTH_ADVISER_RECOMMENDATION_TYPE}}"
+          - name: THOTH_ADVISER_RUNTIME_ENVIRONMENT
+            value: "input/runtime_environment.json"
+          - name: THOTH_ADVISER_PREDICTOR_CONFIG
+            value: "{{inputs.parameters.THOTH_ADVISER_PREDICTOR_CONFIG}}"
+          - name: THOTH_ADVISER_METADATA
+            value: "{{inputs.parameters.THOTH_ADVISER_METADATA}}"
+          - name: THOTH_ADVISER_SEED
+            value: "{{inputs.parameters.THOTH_ADVISER_SEED}}"
+          - name: THOTH_ADVISER_DEV
+            value: "{{inputs.parameters.THOTH_ADVISER_DEV}}"
+          - name: THOTH_ADVISER_BEAM_WIDTH
+            value: "{{inputs.parameters.THOTH_ADVISER_BEAM_WIDTH}}"
+          - name: THOTH_ADVISER_SUBCOMMAND
+            value: "advise"
+          - name: THOTH_ADVISER_LIBRARY_USAGE
+            value: "input/library_usage.json"
+          - name: PROMETHEUS_PUSHGATEWAY_HOST
+            valueFrom:
+              configMapKeyRef:
+                key: pushgateway-host
+                name: prometheus
+          - name: PROMETHEUS_PUSHGATEWAY_PORT
+            valueFrom:
+              configMapKeyRef:
+                key: pushgateway-port
+                name: prometheus
+          - name: THOTH_DEPLOYMENT_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: deployment-name
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: thoth
+                key: sentry-dsn
+          - name: KNOWLEDGE_GRAPH_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: postgresql-host
+          - name: KNOWLEDGE_GRAPH_PORT
+            value: "5432"
+          - name: KNOWLEDGE_GRAPH_SSL_DISABLED
+            value: "1"
+          - name: KNOWLEDGE_GRAPH_USER
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-user
+          - name: KNOWLEDGE_GRAPH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-password
+          - name: KNOWLEDGE_GRAPH_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-name
+        volumeMounts:
+          - name: workdir
+            mountPath: /mnt/workdir
+        resources:
+          limits:
+            cpu: 1.1
+            memory: 6Gi
+          requests:
+            cpu: 1.1
+            memory: 6Gi
+        livenessProbe:
+          exec:
+            command:
+              - python3
+              - liveness.py
+          failureThreshold: 3
+          initialDelaySeconds: 900
+          timeoutSeconds: 600
+          periodSeconds: 120

--- a/adviser/overlays/test/argo-workflows/dependency-monkey.yaml
+++ b/adviser/overlays/test/argo-workflows/dependency-monkey.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: dm
+  annotations:
+    thoth-station.ninja/template-version: 0.0.1
+  labels:
+    app: thoth
+    component: dependency-monkey
+spec:
+  templates:
+    - name: dm
+      resubmitPendingPods: true
+      inputs:
+        parameters:
+          - name: THOTH_DEPENDENCY_MONKEY_JOB_ID
+          - name: THOTH_DOCUMENT_ID
+          - name: THOTH_ADVISER_REQUIREMENTS
+          - name: THOTH_LOG_ADVISER
+          - name: THOTH_ADVISER_RUNTIME_ENVIRONMENT
+          - name: THOTH_ADVISER_PLOT
+          - name: THOTH_ADVISER_BEAM_WIDTH
+          - name: THOTH_DEPENDENCY_MONKEY_STACK_OUTPUT
+          - name: THOTH_DEPENDENCY_MONKEY_SEED
+          - name: THOTH_ADVISER_DEV
+          - name: THOTH_ADVISER_PIPELINE
+          - name: THOTH_ADVISER_PREDICTOR
+            value: "AUTO"
+          - name: THOTH_ADVISER_PREDICTOR_CONFIG
+          - name: THOTH_DEPENDENCY_MONKEY_DECISION_TYPE
+          - name: THOTH_DEPENDENCY_MONKEY_DRY_RUN
+          - name: THOTH_AMUN_CONTEXT
+          - name: THOTH_DEPENDENCY_MONKEY_COUNT
+          - name: THOTH_ADVISER_LIMIT_LATEST_VERSIONS
+          - name: THOTH_DEPLOYMENT_NAME
+          - name: THOTH_S3_ENDPOINT_URL
+          - name: THOTH_CEPH_BUCKET_NAME
+          - name: THOTH_CEPH_BUCKET_PREFIX
+        artifacts:
+          - name: inputdocument
+            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
+            archive:
+              none: {}
+            s3:
+              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
+              {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/\
+              dependency-monkey-requests/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
+              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+              insecure: true
+              accessKeySecret:
+                name: argo-artifact-repository-secrets
+                key: accessKey
+              secretKeySecret:
+                name: argo-artifact-repository-secrets
+                key: secretKey
+      outputs:
+        artifacts:
+          - name: outputdocument
+            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+            archive:
+              none: {}
+            s3:
+              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
+              {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/\
+              dependency-monkey-reports/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+              insecure: true
+              accessKeySecret:
+                name: argo-artifact-repository-secrets
+                key: accessKey
+              secretKeySecret:
+                name: argo-artifact-repository-secrets
+                key: secretKey
+      container:
+        name: dm
+        image: adviser
+        env:
+          - name: THOTH_DEPENDENCY_MONKEY_JOB_ID
+            value: "{{inputs.parameters.THOTH_DEPENDENCY_MONKEY_JOB_ID}}"
+          - name: THOTH_DOCUMENT_ID
+            value: "{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: THOTH_ADVISER_ENABLE_PREPARE
+            value: "1"
+          - name: THOTH_ADVISER_REQUIREMENTS
+            value: "input/Pipfle"
+          - name: THOTH_LOG_ADVISER
+            value: "{{inputs.parameters.THOTH_LOG_ADVISER}}"
+          - name: THOTH_ADVISER_RUNTIME_ENVIRONMENT
+            value: "input/runtime_environment.json"
+          - name: THOTH_ADVISER_PLOT
+            value: "{{inputs.parameters.THOTH_ADVISER_PLOT}}"
+          - name: THOTH_ADVISER_BEAM_WIDTH
+            value: "{{inputs.parameters.THOTH_ADVISER_BEAM_WIDTH}}"
+          - name: THOTH_DEPENDENCY_MONKEY_STACK_OUTPUT
+            value: "{{inputs.parameters.THOTH_DEPENDENCY_MONKEY_STACK_OUTPUT}}"
+          - name: THOTH_DEPENDENCY_MONKEY_SEED
+            value: "{{inputs.parameters.THOTH_DEPENDENCY_MONKEY_SEED}}"
+          - name: THOTH_ADVISER_DEV
+            value: "{{inputs.parameters.THOTH_ADVISER_DEV}}"
+          - name: THOTH_DEPENDENCY_MONKEY_DECISION_TYPE
+            value: "{{inputs.parameters.THOTH_DEPENDENCY_MONKEY_DECISION_TYPE}}"
+          - name: THOTH_DEPENDENCY_MONKEY_DRY_RUN
+            value: "{{inputs.parameters.THOTH_DEPENDENCY_MONKEY_DRY_RUN}}"
+          - name: THOTH_ADVISER_PIPELINE
+            value: "input/pipeline.json"
+          - name: THOTH_ADVISER_PREDICTOR
+            value: "{{inputs.parameters.THOTH_ADVISER_PREDICTOR}}"
+          - name: THOTH_ADVISER_PREDICTOR_CONFIG
+            value: "{{inputs.parameters.THOTH_ADVISER_PREDICTOR_CONFIG}}"
+          - name: THOTH_AMUN_CONTEXT
+            value: "input/context.json"
+          - name: THOTH_DEPENDENCY_MONKEY_COUNT
+            value: "{{inputs.parameters.THOTH_DEPENDENCY_MONKEY_COUNT}}"
+          - name: THOTH_ADVISER_LIMIT_LATEST_VERSIONS
+            value: "{{inputs.parameters.THOTH_ADVISER_LIMIT_LATEST_VERSIONS}}"
+          - name: THOTH_S3_ENDPOINT_URL
+            value: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+          - name: THOTH_CEPH_BUCKET_NAME
+            value: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+          - name: THOTH_CEPH_BUCKET_PREFIX
+            value: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}"
+          - name: THOTH_DEPLOYMENT_NAME
+            value: "{{inputs.parameters.THOTH_DEPLOYMENT_NAME}}"
+          - name: THOTH_ADVISER_SUBCOMMAND
+            value: "dependency-monkey"
+          - name: THOTH_DEPENDENCY_MONKEY_REPORT_OUTPUT
+            value: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: PROMETHEUS_PUSHGATEWAY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: prometheus
+                key: pushgateway-url
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: thoth
+                key: sentry-dsn
+          - name: KNOWLEDGE_GRAPH_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: postgresql-host
+          - name: KNOWLEDGE_GRAPH_PORT
+            value: "5432"
+          - name: KNOWLEDGE_GRAPH_SSL_DISABLED
+            value: "1"
+          - name: KNOWLEDGE_GRAPH_USER
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-user
+          - name: KNOWLEDGE_GRAPH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-password
+          - name: KNOWLEDGE_GRAPH_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-name
+        volumeMounts:
+          - name: workdir
+            mountPath: /mnt/workdir
+        resources:
+          limits:
+            cpu: 1.1
+            memory: 8Gi
+          requests:
+            cpu: 1.1
+            memory: 8Gi
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 3600
+          periodSeconds: 1

--- a/adviser/overlays/test/argo-workflows/provenance-check.yaml
+++ b/adviser/overlays/test/argo-workflows/provenance-check.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: provenance-check
+  labels:
+    app: thoth
+    component: provenance-check
+spec:
+  templates:
+    - name: provenance-check
+      resubmitPendingPods: true
+      inputs:
+        parameters:
+          - name: THOTH_PROVENANCE_CHECKER_JOB_ID
+          - name: THOTH_DOCUMENT_ID
+          - name: THOTH_WHITELISTED_SOURCES
+          - name: THOTH_ADVISER_REQUIREMENTS
+          - name: THOTH_ADVISER_REQUIREMENTS_LOCKED
+          - name: THOTH_ADVISER_METADATA
+          - name: THOTH_LOG_ADVISER
+          - name: THOTH_S3_ENDPOINT_URL
+          - name: THOTH_CEPH_BUCKET_NAME
+          - name: THOTH_CEPH_BUCKET_PREFIX
+          - name: THOTH_DEPLOYMENT_NAME
+        artifacts:
+          - name: inputdocument
+            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
+            archive:
+              none: {}
+            s3:
+              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
+              {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/\
+              provenance-checker/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
+              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+              insecure: true
+              accessKeySecret:
+                name: argo-artifact-repository-secrets
+                key: accessKey
+              secretKeySecret:
+                name: argo-artifact-repository-secrets
+                key: secretKey
+      outputs:
+        artifacts:
+          - name: outputdocument
+            path: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+            archive:
+              none: {}
+            s3:
+              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
+              {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/\
+              provenance-checker/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+              insecure: true
+              accessKeySecret:
+                name: argo-artifact-repository-secrets
+                key: accessKey
+              secretKeySecret:
+                name: argo-artifact-repository-secrets
+                key: secretKey
+      container:
+        name: provenance-check
+        image: adviser
+        env:
+          - name: THOTH_PROVENANCE_CHECKER_JOB_ID
+            value: "{{inputs.parameters.THOTH_PROVENANCE_CHECKER_JOB_ID}}"
+          - name: THOTH_DOCUMENT_ID
+            value: "{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: THOTH_ADVISER_ENABLE_PREPARE
+            value: "1"
+          - name: THOTH_WHITELISTED_SOURCES
+            value: "{{inputs.parameters.THOTH_WHITELISTED_SOURCES}}"
+          - name: THOTH_ADVISER_REQUIREMENTS
+            value: "input/Pipfile"
+          - name: THOTH_ADVISER_REQUIREMENTS_LOCKED
+            value: "input/Pipfile.lock"
+          - name: THOTH_ADVISER_METADATA
+            value: "{{inputs.parameters.THOTH_ADVISER_METADATA}}"
+          - name: THOTH_LOG_ADVISER
+            value: "{{inputs.parameters.THOTH_LOG_ADVISER}}"
+          - name: THOTH_ADVISER_OUTPUT
+            value: "/mnt/workdir/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: THOTH_S3_ENDPOINT_URL
+            value: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+          - name: THOTH_CEPH_BUCKET_NAME
+            value: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+          - name: THOTH_CEPH_BUCKET_PREFIX
+            value: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}"
+          - name: THOTH_DEPLOYMENT_NAME
+            value: "{{inputs.parameters.THOTH_DEPLOYMENT_NAME}}"
+          - name: THOTH_ADVISER_SUBCOMMAND
+            value: "provenance"
+          - name: PROMETHEUS_PUSHGATEWAY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: prometheus
+                key: pushgateway-url
+          - name: THOTH_DEPLOYMENT_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: storage-bucket-name
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: thoth
+                key: sentry-dsn
+          - name: KNOWLEDGE_GRAPH_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: postgresql-host
+          - name: KNOWLEDGE_GRAPH_PORT
+            value: "5432"
+          - name: KNOWLEDGE_GRAPH_SSL_DISABLED
+            value: "1"
+          - name: KNOWLEDGE_GRAPH_USER
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-user
+          - name: KNOWLEDGE_GRAPH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-password
+          - name: KNOWLEDGE_GRAPH_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: database-name
+        volumeMounts:
+          - name: output
+            mountPath: /mnt/workdir
+        resources:
+          limits:
+            cpu: 1.1
+            memory: 8Gi
+          requests:
+            cpu: 1.1
+            memory: 8Gi
+        livenessProbe:
+          # Give adviser some seconds to compute results
+          exec:
+            command:
+              - python3
+              - liveness.py
+          failureThreshold: 1
+          initialDelaySeconds: 1500
+          # Give main process some time to finish scoring and submit results.
+          timeoutSeconds: 600

--- a/adviser/overlays/test/kustomization.yaml
+++ b/adviser/overlays/test/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+  - argo-workflows/advise.yaml
+  - argo-workflows/dependency-monkey.yaml
+  - argo-workflows/provenance-check.yaml
 patchesJson6902:
   - path: job-generate-name.yaml
     target:


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/pull/912
Related: https://github.com/thoth-station/thoth-application/issues/902

## This introduces a breaking change

- [x] No

This PR will enable using prepared input files downloaded from Ceph in test environment.