### PR TITLE
smtp server information to be picked from configmap

### DIFF
--- a/slo-reporter/overlays/cnv-prod/configmap.yaml
+++ b/slo-reporter/overlays/cnv-prod/configmap.yaml
@@ -7,3 +7,4 @@ data:
   thanos-endpoint: "http://prometheus-portal-thoth-infra-prod.apps.cnv.massopen.cloud"   # TODO: Use Thanos endpoint when available and set correct secret
   sender-address: "aicoe-thoth-devops@redhat.com"
   email-recipients: "aicoe@redhat.com"
+  smtp-server: smtp-relay.sendinblue.com

--- a/slo-reporter/overlays/cnv-prod/cronjob.yaml
+++ b/slo-reporter/overlays/cnv-prod/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
                   value: "1"
                 - name: SMTP_SERVER
                   valueFrom:
-                    secretKeyRef:
+                    configMapKeyRef:
                       name: slo-reporter
                       key: smtp-server
                 - name: SMTP_SERVER_USERNAME


### PR DESCRIPTION
## Related Issues and Dependencies

Kustomize patch is causing a env var to be picked from two places, which shouldn't happen.
```
- name: SMTP_SERVER
  valueFrom:
    configMapKeyRef:
      key: smtp-server
      name: slo-reporter
    secretKeyRef:
      key: smtp-server
      name: slo-reporter
```

## This Pull Request implements

smtp server information to be picked from configmap
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
