### PR TITLE
Bump integration tests to v0.5.0

### DIFF
--- a/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.4.0
+        name: quay.io/thoth-station/integration-tests:v0.5.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
