### PR TITLE
Bump adviser to v0.25.1 in stage environment

### DIFF
--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.24.1
+        name: quay.io/thoth-station/adviser:v0.25.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/adviser/pull/1703

## This introduces a breaking change

- [x] No
