### PR TITLE
Enable generating report in integration-tests

### DIFF
--- a/integration-tests/base/configmap.yaml
+++ b/integration-tests/base/configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   name: integration-tests
 data:
   mail-report: "1"
+  generate-report: "1"

--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -31,6 +31,11 @@ spec:
                     configMapKeyRef:
                       key: mail-report
                       name: integration-tests
+                - name: GENERATE_REPORT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: generate-report
+                      name: integration-tests
                 - name: THOTH_DEPLOYMENT_NAME
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/integration-tests/pull/136/

## This introduces a breaking change

- [x] No
