### PR TITLE
Do not run integration tests requiring middletier namespace

### DIFF
--- a/integration-tests/base/configmap.yaml
+++ b/integration-tests/base/configmap.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   mail-report: "1"
   generate-report: "1"
+  tags: ""

--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -61,6 +61,11 @@ spec:
                     secretKeyRef:
                       key: management-api-token
                       name: integration-tests
+                - name: THOTH_INTEGRATION_TESTS_TAGS
+                  valueFrom:
+                    configMapKeyRef:
+                      key: tags
+                      name: integration-tests
               resources:
                 requests:
                   memory: "256Mi"

--- a/integration-tests/overlays/ocp4-stage/configmap.yaml
+++ b/integration-tests/overlays/ocp4-stage/configmap.yaml
@@ -8,3 +8,4 @@ data:
   user-api: "stage.thoth-station.ninja"
   management-api: "management.stage.thoth-station.ninja"
   amun-api: "amun.stage.thoth-station.ninja"
+  tags: "~@seizes_middletier_namespace"


### PR DESCRIPTION
## Related Issues and Dependencies

With https://github.com/thoth-station/integration-tests/pull/137/ we are able to selectively run/disable selected tests based on tags. Let's do not run integration tests that require middletier resources in stage as stage is running ingestion in thoth-middletier-stage so tests fail. 

## This introduces a breaking change

- [x] No
