### PR TITLE
Select only relevant integration-tests in cnv-prod

### DIFF
--- a/integration-tests/overlays/cnv-prod-ocp4-stage/README.rst
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/README.rst
@@ -1,0 +1,5 @@
+Integration tests for cnv-prod
+------------------------------
+
+This overlay keeps manifests needed to run integration tests for cnv-prod. Note
+integration tests are executed in ocp4-stage.

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
@@ -1,0 +1,10 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: integration-tests
+data:
+  deployment-name: "cnv-prod"
+  user-api: "api.moc.thoth-station.ninja"
+  management-api: "management.moc.thoth-station.ninja"
+  amun-api: "amun.moc.thoth-station.ninja"

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
@@ -8,3 +8,4 @@ data:
   user-api: "api.moc.thoth-station.ninja"
   management-api: "management.moc.thoth-station.ninja"
   amun-api: "amun.moc.thoth-station.ninja"
+  tags: "~@seizes_middletier_namespace,~@seizes_amun_inspection_namespace"

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/cronjob.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/cronjob.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: integration-tests
+  labels:
+    app: thoth
+    component: integration-tests
+spec:
+  suspend: false

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/imagestreamtag.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: integration-tests
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/integration-tests:v0.6.0
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/job-generate-name.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/job-generate-name.yaml
@@ -1,0 +1,6 @@
+- op: move
+  from: /metadata/name
+  path: /metadata/generateName
+- op: add
+  path: /metadata/namespace
+  value: "thoth-frontend-stage"

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/kustomization.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+patchesStrategicMerge:
+  - configmap.yaml
+  - cronjob.yaml
+  - imagestreamtag.yaml
+generators:
+  - ./secret-generator.yaml
+patchesJson6902:
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-success-
+  - path: job-generate-name.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: chat-notification-fail-

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/secret-generator.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: thoth-secret-generator
+files:
+  - ./secrets.enc.yaml

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/secrets.enc.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/secrets.enc.yaml
@@ -1,0 +1,114 @@
+apiVersion: v1
+items:
+-   apiVersion: v1
+    data:
+        app-secret-key: ENC[AES256_GCM,data:TnIJ1DLC59sIEb2a,iv:ncVs9si2uIrFEJklBPgvC2rT8bDpze7eVQRBbEyqZlk=,tag:v3ZiY0nCmyU0jBpIBFSalg==,type:str]
+        management-api-token: ENC[AES256_GCM,data:SufFXfdBGdnsR7O0,iv:SbpFanITBNyL+zVk/fePMdZY+EC5FJLF+w0jWO1a/L4=,tag:ckuwumVnNbAGFZb9OQ9KKg==,type:str]
+        thoth-secret: ENC[AES256_GCM,data:u+FcMRR7+5Xa+FCq,iv:r0tetG8ux7QF/spVVdyl1FNexGhKbImHAXQpCIKNmbc=,tag:LuAvyAwYHedlfNm/+UI/Cw==,type:str]
+    kind: Secret
+    metadata:
+        name: integration-tests
+    type: Opaque
+kind: List
+metadata:
+    resourceVersion: ""
+    selfLink: ""
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2021-02-12T17:22:12Z'
+    mac: ENC[AES256_GCM,data:ttro0ifKAM7gqB60MSe/nQo72pJwS5k/2oS1Ja+83yd8retAwGTu2QTTXZZuQRUjZDhxEcEkBhiiXUlgEVMgxuXU8Af2j3Uba95vJ3QjgDwU+3pvKV6DkBDC1wFhoQicJ4vJClbVfBJGHOSePagxWNKHtdYdMIZ5f4DS6U0XlSY=,iv:Esi7ahnZ7bfZ/JKl80H04Iys476BYYk8jUGE6T+2TaQ=,tag:1WS2XckTHjTMn81TONzF3Q==,type:str]
+    pgp:
+    -   created_at: '2021-02-12T17:22:11Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA1gbAjViyxWYAQ//cclNfSd7MmgbPH/dYdu0IZmtWJzgv7S6eYBlpLB5xtQ9
+            xkNDv5CRW4K6lLCNKLIz1acsXf/OHKnIvHzSo4+fRbc9SH7AS3rdfdMYgKWrBngH
+            gUekH/UqYVvSPeWGz7xKwfpl8B3To0xOiwftP7K/18Uxf/Nca4MiZ3Qnrqx7U0dB
+            LhbtyEsWskHk8UmCqHAawLccXqwUQRmkVft0hy0d/sQ4IarHXrQc0uXJtSESX7Jz
+            2Teqsx960lcJR9kFbhna3FWIns6GMQRI4vi1yGZv0Y7u9Ia/F+G92XieR8sau4TV
+            EkAcSrvi1EXRN+9D4fGdQjHTn4eahftN61N2DEzvWsqNqMWWd1Nrj/TfjMIWyXiN
+            Wzo1JlLau4i1djHjZqDXrPJwMSFltQrCvXzoSPLCMyIU8p8nCo2n0Zaq78lkt1PW
+            nlOBkRTwjQc/pkf9ZjGfV2wL+nWhSQrR9aIA7xgkz0ar9lkDPg9qej37EtDpzSQU
+            XhfRZmEMC0KymE+ZnwvhCbXVw76y51r869iX/Gtg/Sh3zH43oOkMu/VDkWVzYWu9
+            6DJFYvIfg278BuAny6+Ck3v1cJeKCk2G/BRNNSvD9qV/E4JTfPE8OKzDMZlPFu0n
+            /seZODbyzlUhQRDFKLb3275uWE/5BRIjVcvCsJts0/ujoEkKgoOtxNZVgYt9FlTS
+            XAEBdItxGoq0B5oPklLceBPhdflU3wMnTtxBxs2OUy+5NExI5no36YhEE0mF67ES
+            TO3JPYRch9F41IcOzymam2Mnw5zpxx9e8ObokemffPwhF2gN7A8E2unnGmWL
+            =HtK7
+            -----END PGP MESSAGE-----
+        fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
+    -   created_at: '2021-02-12T17:22:11Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA+/WpawS9RPbAQf/QlJiuKQpyq2AxR5NVyeWMTLASFtU0AXz+uQpAN/7UxO+
+            ZYX69pGbtAbRP2wz2XOluGP3JXiN7EvioYQidIj7xFVpMrepUojThdR4QDN3erWN
+            ZjHyjWjlJBfUuc/8sQtj49wsfw4CjvdkfErPx9muEhmPFxxJW75UtvA/smPnytiW
+            K04+pmSGLJRwx5eDPrOqRG7u7PJB6s4dCNQXAFwlWZj2HoaI7Gf4bWx3WmTIKHag
+            MLRyxfzuuBtQ/6HfzUXfj1K9hJnGHaYPA9Jhm49qD9MN/sK5XpCmHuF2YLA9jUuI
+            Zf97oSXMeetnGVrmiLbuAmrGww+shJaKTwRo/7m8YdJcAavcz8W44X4aDD6p57q9
+            d5GRx2yPqFR8C1FhalojpsgDmPi1W7QG0NxGkL2oAVrXa0ZFLOnp5qE1/qKsOlgE
+            oPEJU3KC4hRt38JDfjcDxyZhXslrkoJTBeWFKXo=
+            =5Qz1
+            -----END PGP MESSAGE-----
+        fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
+    -   created_at: '2021-02-12T17:22:11Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQf/XRIepXpV3BAnJA+EhtU194ro0SCcoxUaqeV8i7CSQdXU
+            A5m1nuevXZy9wMDqMkmBigHn/vP3VtG0RFKjlUf0kBeGz7Pfjs5NNe26wnUNnBFP
+            WLCB6r4N1XRyWaI/+OxNdsPEa298q3DQtLCmbX3OgnUF03AwoGJFe0z0bM4GBN76
+            HzeqFtbEFByYSNridUmFXD9ziJzHZ3/luvWpSfXGp4aSgGSvBSsSO7tzqcnzT1m0
+            n1drImj21KX9OJ/mk8cEfyBnO6SSYlwpIaLLFjTT/i8q7Nk81OlyYNGBgj27BDTR
+            tfGGwjeG8hGWirCxt37XNopdsUroPhuIoUVFTP8QlNJcAaE8++JEBoPdiFaziAez
+            ezI5MaqpS7ikzc2RvsegpAdqIL2VVmjYNL3DG/UniUhlLS+HId7BpgyUA1TCjYlZ
+            PhBoortmYV3VJr6HFvtzmkI4xt3hMMka/o/zxoY=
+            =DhhC
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    -   created_at: '2021-02-12T17:22:11Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA7vMDF1jUn3mAQ//ag44wsFGyL+fFpNBRZWNpipyxoeG/SbE9zGfxt7bypDQ
+            bIDkRUEDkPoMrP0ksafhuUUThBOJSDkkGaAD97s0XMf7N+21RfstAW5TEInl/DBb
+            fZWSJYE2BdL6ZLUIcZ4KlW8kw5svoIAepcDf/aIXxKZQhJPpk6Hch2wxPOiNi3UL
+            fHfZ0lFJ0TPTo/qMRvE0lsM8YJvRps/qwB1zUAvKf/yMNYG7+sWqvPeAXftK/Syc
+            C+hkBEtK/hJaQiUrG8bh0EBOIpNlh3ozgvrphCtLkeHH7rwFib2WMfEGIz0TJYw1
+            FEQGg/32E/fj2gQ+s+V2OhnzKmXlvBbYGfvMk7tJTOZVhnIjfUD0ZX+YjYLFKCby
+            o7CC/kIasaZe4/yQg698HS/4/7uGhMNeQHFJclFenXfxKQSKwCvVXGtccVxzLTil
+            84aG+2Qm18xTRbICiLgyMOSLWDUbRAGpozn/N1Mu2ie3WrIbqrFaOuKORk4xyFg6
+            lzmMDQ2thDxlGPFs5F2rEwuyd9o3aUiibQHsjxN+EAtRwgZVTYwoLTekq4Wxh+b0
+            JRPEfCSaUx0HG0A5auEvhMBJoAS8yZc55tJAu2vEva78i6tclbeS0qvVDajtblL9
+            ub6OES64ntnrSSe2rvemeewt8U1vNt354/bqe5F8dF4jxaWpYR6K6TCzQSWLWr/S
+            XAFTE/E2TLiO6FE2i87hwS4+NTviOUsETq1GVDen4W+enn62sElYHlRvk2HR3Kjz
+            OoGj1d6p1aLmasEImF/ayn5LAaLhNxUarCuWlpATlk0h9CLQmUsLWIy5Pnec
+            =TqHu
+            -----END PGP MESSAGE-----
+        fp: 68BD1529A372C8BA561C9DDC377298152D08B95B
+    -   created_at: '2021-02-12T17:22:11Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAAss6YIE9pnHDCF6Oe/+D8Aq/tSuFzK/Ood7WOUe8DHDP0
+            YC/jnANeb1dPgERsy2qLmKvrr7jinZxy5deI7wgeF+zqDkhKOwzjNTsXrT+vHrJE
+            fBbwnfaDRw+3pXxnFayvNgTShkKnaLY+AFy94sird4oRDcUoyOqn7cC2XflvSkI/
+            ddaJ+fQGwlI/XNnntOq+bpi9ttpTSZ0cDpd6oPXIzyfvkbfdv5bAZJe/osNBEXwZ
+            YA611M9+fEEkWP3AwgR1SAR+ymA4n7l7S6wkY6TxlzZ+SbXJokiUjKT4rAr9LZQr
+            ZCh76nYUH4NFHnTMa0dBtnHFn+aP4fuIRbOFQCpn9FMdRPCIxYNF+Z6WsKdewfbO
+            LIrIax6tjMCtDRqGNYXI3eL7Ax+Qxlg1tqPe2kBoTIL/MV4b0Tnz7ma7leAcbfY/
+            UnVlf53gA24vWt0uRXDjs/TCreSSnS8aJLIo9BiZuC1cjw7djJGRNf+bCtOVVxus
+            0bR4fgavQ9yLU61zLIc+utTbJtrcIoWMJol+bySu8T+NmMX11ebq9T9WuGM148ap
+            YHz0kej8n0nBQ/r8mmjQ6QJTI6LUVtwKS88+FlrvTV+MQJ8F3SaXk0PnV/WxJjOr
+            ibvciV80MJzcFlELhr69siazZnXlHAfNFziYjDxmZ7GU9zfK8e5l4Aqh2r6aUfbS
+            XAHliCHBMSM8dofVKaVwqzpX9SW/2fNIPJWvSVXCoD+wWzTf9gON5u8i6LLDoZm+
+            sUS7H6wpr9M/gennZAPDxCVSLaA5KWj/fs2tvzVxUwWAMzoYxDvikfwlJZl0
+            =98Rn
+            -----END PGP MESSAGE-----
+        fp: 4DC4116D360E3276
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.5.0

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/thoth-notification.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/thoth-notification.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-succeeded-
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'I have successfully synchronized *integration-tests* components to *CNV-PROD*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/prod-thoth-integration-tests|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chat-notification-failed-
+  annotations:
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAILED* syncing *integration-tests* components to *CNV-PROD*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/prod-thoth-integration-tests|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+  backoffLimit: 2


### PR DESCRIPTION
## Related Issues and Dependencies

Depends-On: https://github.com/thoth-station/thoth-application/pull/944
Related: https://github.com/thoth-station/integration-tests/pull/137/
Related: https://github.com/thoth-station/thoth-application/pull/947

## This introduces a breaking change

- [x] No

## Description

This pull request depends on https://github.com/thoth-station/thoth-application/pull/944. I will rebase once #944 gets in or will be adjusted.

WIth this change we will not run integration tests that require amun-inspection namespace or middletier namespace as these are occupied by workflows running in these namespaces.