### PR TITLE
Bump management-api to v0.14.0 in prod

### DIFF
--- a/management-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/management-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.11.1
+      name: quay.io/thoth-station/management-api:v0.14.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/prod/imagestreamtag.yaml
+++ b/management-api/overlays/prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.7.1
+      name: quay.io/thoth-station/management-api:v0.14.0
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/pull/953
Related: #949

## This introduces a breaking change

- [x] No
