### PR TITLE
Bump user-api to v0.19.2 in production

### DIFF
--- a/user-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/user-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.18.0
+        name: quay.io/thoth-station/user-api:v0.19.2
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/user-api/pull/1274

## This introduces a breaking change

- [x] No
