### PR TITLE
Bump version v0.25.1 for adviser prod

### DIFF
--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.24.1
+        name: quay.io/thoth-station/adviser:v0.25.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump version v0.25.1 for adviser prod
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/924

