### PR TITLE
Run integration tests that use backend namespace

### DIFF
--- a/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
@@ -8,4 +8,4 @@ data:
   user-api: "api.moc.thoth-station.ninja"
   management-api: "management.moc.thoth-station.ninja"
   amun-api: "amun.moc.thoth-station.ninja"
-  tags: "~@seizes_middletier_namespace,~@seizes_amun_inspection_namespace"
+  tags: "@seizes_backend_namespace"


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## This Pull Request implements

For now, we can run only integration-tests triggering workload in backend namespace. This way, only advise scenarios will be triggered (to trigger demo stacks).