### PR TITLE
Revert "Run integration tests that use backend namespace"

### DIFF
--- a/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/configmap.yaml
@@ -8,4 +8,4 @@ data:
   user-api: "api.moc.thoth-station.ninja"
   management-api: "management.moc.thoth-station.ninja"
   amun-api: "amun.moc.thoth-station.ninja"
-  tags: "@seizes_backend_namespace"
+  tags: "~@seizes_middletier_namespace,~@seizes_amun_inspection_namespace"


### PR DESCRIPTION
Reverts thoth-station/thoth-application#967

We can revert this after Francesco's demo.