### PR TITLE
Adjust restart policy for integration tests

### DIFF
--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             app: thoth
             component: integration-tests
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
             - image: "integration-tests:latest"
               name: integration-tests


### PR DESCRIPTION
## Related Issues and Dependencies

As integration tests return non-zero exit code if any scenario fails, the job keeps restarting. We can run integration tests just once.

## This introduces a breaking change

- [x] No
