### PR TITLE
Increase cache expiration on user-api

### DIFF
--- a/user-api/base/configmap.yaml
+++ b/user-api/base/configmap.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   api-https: "1"
   validate-responses: "0"
+  cache-expiration: "43200"  # 4 hours

--- a/user-api/base/deploymentconfig.yaml
+++ b/user-api/base/deploymentconfig.yaml
@@ -41,6 +41,11 @@ spec:
                 configMapKeyRef:
                   key: validate-responses
                   name: user-api
+            - name: THOTH_CACHE_EXPIRATION
+              valueFrom:
+                configMapKeyRef:
+                  key: cache-expiration
+                  name: user-api
             - name: THOTH_FRONTEND_NAMESPACE
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Related Issues and Dependencies

Increase cache expiration on user-api for Francesco's demo. We can eventually move this to to application configmap and expose as a metric.

## This introduces a breaking change

- [x] No
