### PR TITLE
Bump user-api to v0.19.4 in stage

### DIFF
--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.19.3
+        name: quay.io/thoth-station/user-api:v0.19.4
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
