### PR TITLE
Bump management-api to v0.15.0 in stage environment

### DIFF
--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.14.0
+      name: quay.io/thoth-station/management-api:v0.15.0
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
