### PR TITLE
Fix syncing condition for package-extract

### DIFF
--- a/package-extract/base/openshift-templates/package-extract.yaml
+++ b/package-extract/base/openshift-templates/package-extract.yaml
@@ -142,4 +142,4 @@ objects:
                       value: "{{workflow.parameters.THOTH_DOCUMENT_ID}}"
                     - name: "THOTH_FORCE_SYNC"
                       value: "1"
-                when: "{{workflow.parameters.THOTH_SYNC_PACKAGE_EXTRACT}} == '1'"
+                when: "{{workflow.parameters.THOTH_SYNC_PACKAGE_EXTRACT}} == 1"


### PR DESCRIPTION
## Related Issues and Dependencies

```
when '1 == '1'' evaluated false
```

## This introduces a breaking change

- [x] No
