### PR TITLE
Bump user-api to v0.20.2 in stage environment

### DIFF
--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.20.1
+        name: quay.io/thoth-station/user-api:v0.20.2
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
