### PR TITLE
Bump user-api to v0.20.2 in prod environment

### DIFF
--- a/user-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/user-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.19.3
+        name: quay.io/thoth-station/user-api:v0.20.2
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/pull/985
Related: https://github.com/thoth-station/thoth-application/pull/982/

## This introduces a breaking change

- [x] No
