### PR TITLE
Removed thoth-adviser-requirments params as required for dm

### DIFF
--- a/adviser/base/openshift-templates/dependency-monkey.yaml
+++ b/adviser/base/openshift-templates/dependency-monkey.yaml
@@ -25,7 +25,6 @@ parameters:
     displayName: "Document identifier"
     required: true
   - name: THOTH_ADVISER_REQUIREMENTS
-    required: true
     description: Raw stack requirements.
   - name: THOTH_LOG_ADVISER
     description: Log Dependency Mokney actions.


### PR DESCRIPTION
Removed thoth-adviser-requirments params as required for dm
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #1005 


not listed in https://github.com/thoth-station/common/blob/f7f70fafebe6f8e77b587419acd92c29aa87b208/thoth/common/openshift.py#L1117