### PR TITLE
Enable management-api to query back logs of dependency-monkey

### DIFF
--- a/management-api/base/role.yaml
+++ b/management-api/base/role.yaml
@@ -50,3 +50,18 @@ rules:
       - patch
       - update
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: management-api-pods-info
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+      - pods/status
+    verbs:
+      - get
+      - list
+      - watch

--- a/management-api/overlays/cnv-prod/role-binding.yaml
+++ b/management-api/overlays/cnv-prod/role-binding.yaml
@@ -40,3 +40,17 @@ subjects:
   - kind: ServiceAccount
     name: management-api
     namespace: thoth-frontend-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: management-api-pods-info
+  namespace: thoth-amun-inspection-prod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: management-api-pods-info
+subjects:
+  - kind: ServiceAccount
+    name: management-api
+    namespace: thoth-frontend-prod

--- a/management-api/overlays/ocp4-stage/role-binding.yaml
+++ b/management-api/overlays/ocp4-stage/role-binding.yaml
@@ -54,3 +54,17 @@ subjects:
   - kind: ServiceAccount
     name: management-api
     namespace: thoth-frontend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: management-api-pods-info
+  namespace: thoth-amun-inspection-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: management-api-pods-info
+subjects:
+  - kind: ServiceAccount
+    name: management-api
+    namespace: thoth-frontend-stage


### PR DESCRIPTION
Enable management-api to query back logs of dependency-monkey
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/management-api/issues/725

