### PR TITLE
Bump integration-tests to v0.8.0 in stage environment

### DIFF
--- a/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.7.1
+        name: quay.io/thoth-station/integration-tests:v0.8.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## This introduces a breaking change

- [x] No
