### PR TITLE
Add kebechet cronjob

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -2,11 +2,11 @@
 kind: CronJob
 apiVersion: batch/v1beta1
 metadata:
-  name: mi-scheduler
+  name: mi-scheduler-gh
   labels:
-    app: mi-scheduler
+    app: mi-scheduler-gh
 spec:
-  schedule: "@hourly"
+  schedule: "@daily"
   suspend: false
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
@@ -15,7 +15,7 @@ spec:
     spec:
       template:
         metadata:
-          name: mi-scheduler
+          name: mi-scheduler-gh
         spec:
           serviceAccount: mi-scheduler
           containers:
@@ -48,6 +48,10 @@ spec:
                     secretKeyRef:
                       name: sesheta-srcops
                       key: github-access-token
+                - name: SCHEDULE_KEBECHET_ANALYSIS
+                  value: "0"
+                - name: SCHEDULE_GH_REPO_ANALYSIS
+                  value: "1"
           restartPolicy: OnFailure
 ---
 kind: CronJob

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -49,3 +49,58 @@ spec:
                       name: sesheta-srcops
                       key: github-access-token
           restartPolicy: OnFailure
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: mi-scheduler-kebechet
+  labels:
+    app: mi-scheduler-kebechet
+spec:
+  schedule: "@daily"
+  suspend: false
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 4
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: mi-scheduler-kebechet
+        spec:
+          serviceAccount: mi-scheduler
+          containers:
+            - image: mi-scheduler
+              name: mi-scheduler
+              resources:
+                limits:
+                  cpu: 256m
+                  memory: 500Mi
+                requests:
+                  cpu: 256m
+                  memory: 500Mi
+              env:
+                - name: KUBERNETES_VERIFY_TLS
+                  value: "0"
+                - name: APP_FILE
+                  value: "app.py"
+                - name: THOTH_MIDDLETIER_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: middletier-namespace
+                - name: THOTH_INFRA_NAMESPACE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: infra-namespace
+                - name: GITHUB_ACCESS_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: sesheta-srcops
+                      key: github-access-token
+                - name: SCHEDULE_KEBECHET_ANALYSIS
+                  value: "1"
+                - name: SCHEDULE_GH_REPO_ANALYSIS
+                  value: "0"
+          restartPolicy: OnFailure

--- a/mi-scheduler/overlays/cnv-prod/cronjob.yaml
+++ b/mi-scheduler/overlays/cnv-prod/cronjob.yaml
@@ -2,6 +2,13 @@
 kind: CronJob
 apiVersion: batch/v1beta1
 metadata:
-  name: mi-scheduler
+  name: mi-scheduler-gh
+spec:
+  suspend: true
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: mi-scheduler-kebechet
 spec:
   suspend: true

--- a/mi-scheduler/overlays/ocp4-stage/cronjob.yaml
+++ b/mi-scheduler/overlays/ocp4-stage/cronjob.yaml
@@ -2,6 +2,13 @@
 kind: CronJob
 apiVersion: batch/v1beta1
 metadata:
-  name: mi-scheduler
+  name: mi-scheduler-gh
+spec:
+  suspend: true
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: mi-scheduler-kebechet
 spec:
   suspend: true

--- a/mi-scheduler/overlays/test/cronjob.yaml
+++ b/mi-scheduler/overlays/test/cronjob.yaml
@@ -2,6 +2,13 @@
 kind: CronJob
 apiVersion: batch/v1beta1
 metadata:
-  name: mi-scheduler
+  name: mi-scheduler-gh
+spec:
+  suspend: true
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: mi-scheduler-kebechet
 spec:
   suspend: true


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes https://github.com/thoth-station/mi-scheduler/issues/59

## This introduces a breaking change

- [ ] Yes
- [X] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
This PR adds a new cronjob specific for kebechet repositories analysis.

## Description
There should be now two standalone cronjobs, one kebechet and other general GH repo analysis
