### PR TITLE
Updated the image and remove required_context for optional arg

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -208,11 +208,6 @@ tide:
             required-contexts:
               - aicoe-ci/pre-commit-check
               - aicoe-ci/build-check
-      operate-first:
-        repos:
-          apps:
-            required-contexts:
-              - aicoe-ci/prow/kustomize-build
       thoth-station:
         repos:
           adviser:

--- a/prow/overlays/cnv-prod/imagestreamtags.yaml
+++ b/prow/overlays/cnv-prod/imagestreamtags.yaml
@@ -289,8 +289,13 @@ spec:
     - annotations: null
       from:
         kind: ImageStreamTag
-        name: v20210304-a61492beff
+        name: v20210310-26726f9bd5
       name: latest
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: gcr.io/k8s-prow/label_sync:v20210310-26726f9bd5
+      name: v20210310-26726f9bd5
     - annotations: null
       from:
         kind: DockerImage


### PR DESCRIPTION
Updated the image and remove required_context for optional arg
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/747

## Description

the issue seems to be here:
https://github.com/thoth-station/thoth-application/blob/75b26a11c8b2b0677df198c1c391c53ee081b7c5/prow/overlays/cnv-prod/config.yaml#L214
we have defined the `aicoe-ci/prow/kustomize-build` as a required context,
however the way it is declared to run as , only on changes of few yaml files. that mean it cant be required 
https://github.com/operate-first/apps/blob/4070832a9848898f529da0c0604cc1e1a61f9e2f/.prow.yaml#L5
Reference: https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/config.md#context-policy-options