### PR TITLE
Remove branch protection for operate-first org

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -29,16 +29,6 @@ in_repo_config:
 branch-protection:
   allow_disabled_policies: true
   orgs:
-    operate-first:
-      protect: true
-      allow_force_pushes: false
-      required_status_checks:
-        contexts:
-          - aicoe-ci/prow/pre-commit
-      exclude:
-        - "^revert-"
-        - "^kebechet-"
-        - "^dependabot/"
     thoth-station:
       protect: true
       allow_force_pushes: false


### PR DESCRIPTION
Remove branch protection for operate-first org
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

operate-first admins would create branch protection for individual repos if necessary. 