### PR TITLE
allow metrics-exporter to check Kafka connection

### DIFF
--- a/metrics-exporter/base/deploymentconfig.yaml
+++ b/metrics-exporter/base/deploymentconfig.yaml
@@ -175,6 +175,22 @@ spec:
                   key: instance-metrics-management-api
             - name: WEB_CONCURRENCY
               value: "1"
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              valueFrom:
+                configMapKeyRef:
+                  name: kafka
+                  key: kafka-bootstrap-servers
+            - name: KAFKA_SECURITY_PROTOCOL
+              valueFrom:
+                configMapKeyRef:
+                  key: kafka-protocol
+                  name: kafka
+            - name: KAFKA_SSL_CA_LOCATION
+              value: "/mnt/secrets/kafka_ca.crt"
+          volumeMounts:
+            - name: secrets
+              mountPath: /mnt/secrets
+              readOnly: true
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -201,4 +217,11 @@ spec:
             initialDelaySeconds: 45
             periodSeconds: 10
             timeoutSeconds: 10
+      volumes:
+        - name: secrets
+          secret:
+            secretName: "kafka"
+            items:
+              - key: kafka_ca.crt
+                path: kafka_ca.crt
   test: false


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

```
172.22.2.1 - - [16/Mar/2021:18:56:09 +0000] "GET /metrics HTTP/1.1" 200 16048 "-" "kube-probe/1.19"
KafkaError{code=_TRANSPORT,val=-195,str="Failed to get metadata: Local: Broker transport failure"}
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/thoth/messaging/admin_client.py", line 81, in check_connection
    a.list_topics(timeout=timeout)
cimpl.KafkaException: KafkaError{code=_TRANSPORT,val=-195,str="Failed to get metadata: Local: Broker transport failure"}

```