### PR TITLE
Bump up version for management-api v0.15.1

### DIFF
--- a/management-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/management-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.15.0
+      name: quay.io/thoth-station/management-api:v0.15.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.15.0
+      name: quay.io/thoth-station/management-api:v0.15.1
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Bump up version for management-api v0.15.1
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

This one has updated storage which has a new alembic version.