### PR TITLE
Add missing knowledge_path parameter

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -17,6 +17,7 @@ spec:
         parameters:
           - name: REPOSITORY
           - name: ENTITIES
+          - name: KNOWLEDGE_PATH
       steps:
         - - name: collect-knowledge
             template: analyse

--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -17,6 +17,10 @@ parameters:
     description: Entities according to MI which will be analysed in REPOSITORY
     displayName: Meta-information Indicator Entities
 
+  - name: KNOWLEDGE_PATH
+    description: Knowledge path where data is stored
+    displayName: Data path
+
   - name: WORKFLOW_ID
     required: true
     description: ID for MI Workflow


### PR DESCRIPTION
## Related Issues and Dependencies
Adding missing `KNOWLEDGE_PATH` parameter specifications.

## This introduces a breaking change

- [ ] Yes
- [X] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description
This probably caused issue of workfows not launching.
```
{"name": "thoth.common.openshift", "levelname": "WARNING", "module": "openshift", "lineno": 292, "funcname": "set_template_parameters", "created": 1616148911.1132526, "asctime": "2021-03-19 10:15:11,113", "msecs": 113.25263977050781, "relative_created": 34725.74305534363, "process": 1, "message": "Requested to assign parameter 'KNOWLEDGE_PATH' (value 'thoth-test-core/thoth-sli-metrics/kebechet-update-manager/thoth-station/source-management') to template but template does not provide the given parameter, forcing..."}
```

