### PR TITLE
:sparkles: add the #B4mad Minecraft project

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -29,6 +29,18 @@ in_repo_config:
 branch-protection:
   allow_disabled_policies: true
   orgs:
+    b4mad:
+      repos:
+        minecraft:
+          protect: true
+          allow_force_pushes: false
+          required_status_checks:
+            contexts:
+              - aicoe-ci/prow/pre-commit
+          exclude:
+            - "^revert-"
+            - "^kebechet-"
+            - "^dependabot/"
     thoth-station:
       protect: true
       allow_force_pushes: false
@@ -108,12 +120,14 @@ tide:
   merge_method:
     aicoe-aiops: squash
     AICoE: squash
+    b4mad: squash
     operate-first: squash
     thoth-station: squash
 
   queries:
     - orgs:
         - aicoe-aiops
+        - b4mad
         - operate-first
         - thoth-station
       excludedRepos:
@@ -138,6 +152,9 @@ tide:
         - thoth-station/nvidia-usage-dashboard
         - thoth-station/pipelines-catalog
         - thoth-station/bz1816214-example
+        - b4mad/sirius
+        - b4mad/airdata
+        - b4mad/auddress
       labels:
         - approved
       missingLabels:
@@ -199,7 +216,6 @@ tide:
               - aicoe-ci/build-check
           amun-api:
             required-contexts:
-              - aicoe-ci/pre-commit-check
               - aicoe-ci/build-check
           buildlog-parser:
             required-contexts:

--- a/prow/overlays/cnv-prod/plugins.yaml
+++ b/prow/overlays/cnv-prod/plugins.yaml
@@ -32,6 +32,11 @@ label:
     - tide/merge-method-squash
 
 external_plugins:
+  b4mad:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
   thoth-station:
     - name: needs-rebase
       events:
@@ -55,6 +60,7 @@ external_plugins:
 
 welcome:
   - repos:
+      - b4mad
       - AICoE
       - aicoe-aiops
       - operate-first
@@ -63,6 +69,7 @@ welcome:
 
 lgtm:
   - repos:
+      - b4mad
       - AICoE
       - aicoe-aiops
       - operate-first
@@ -70,6 +77,7 @@ lgtm:
 
 approve:
   - repos:
+      - b4mad
       - AICoE
       - aicoe-aiops
       - operate-first
@@ -91,6 +99,20 @@ project_config:
         thoth-deployment: New
 
 plugins:
+  b4mad:
+    - approve
+    - assign
+    - blockade
+    - blunderbuss
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - shrug
+    - size
+    - trigger
+    - verify-owners
+    - wip
   operate-first:
     - approve
     - assign


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## Related Issues and Dependencies

n/a

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

this sets up CI for Minecraft project on op1st

<!--- Describe your changes in detail -->
