### PR TITLE
Remove mi-scheduler env from run-mi template

### DIFF
--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -54,8 +54,6 @@ objects:
             value: ${ENTITIES}
           - name: KNOWLEDGE_PATH
             value: ${KNOWLEDGE_PATH}
-          - name: THOTH_LOG_MI_SCHEDULER
-            value: ${THOTH_LOG_MI_SCHEDULER}
           - name: THOTH_LOG_MI
             value: ${THOTH_LOG_MI}
       templates:


### PR DESCRIPTION
## Related Issues and Dependencies
Removes unnecessary env var from `mi` openshift template.
See #1090 

## This introduces a breaking change

- [ ] Yes
- [X] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

