### PR TITLE
Fix logging to use THOTH_ADJUST_LOGGING

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -18,7 +18,7 @@ spec:
           - name: REPOSITORY
           - name: ENTITIES
           - name: KNOWLEDGE_PATH
-          - name: THOTH_LOG_MI
+          - name: THOTH_ADJUST_LOGGING
       steps:
         - - name: collect-knowledge
             template: analyse
@@ -30,8 +30,8 @@ spec:
                   value: "{{inputs.parameters.ENTITIES}}"
                 - name: KNOWLEDGE_PATH
                   value: "{{inputs.parameters.KNOWLEDGE_PATH}}"
-                - name: THOTH_LOG_MI
-                  value: "${inputs.parameters.THOTH_LOG_MI}"
+                - name: THOTH_ADJUST_LOGGING
+                  value: "${inputs.parameters.THOTH_ADJUST_LOGGING}"
 
     - name: analyse
       resubmitPendingPods: true
@@ -40,7 +40,7 @@ spec:
           - name: REPOSITORY
           - name: ENTITIES
           - name: KNOWLEDGE_PATH
-          - name: THOTH_LOG_MI
+          - name: THOTH_ADJUST_LOGGING
       container:
         image: "mi"
         command: ["srcopsmetrics/cli.py"]
@@ -81,5 +81,5 @@ spec:
                 key: key-id
           - name: PYTHONPATH
             value: "."
-          - name: THOTH_LOG_MI
-            value: "${inputs.parameters.THOTH_LOG_MI}"
+          - name: THOTH_ADJUST_LOGGING
+            value: "${inputs.parameters.THOTH_ADJUST_LOGGING}"

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -7,11 +7,11 @@ metadata:
     app: mi-scheduler-gh
 
 parameters:
-  - name: THOTH_LOG_MI_SCHEDULER
+  - name: THOTH_ADJUST_LOGGING
     displayName: mi-scheduler log level
     description: Log level of mi-scheduler
     required: true
-    value: 'INFO'
+    value: 'mi_scheduler:INFO'
 
 spec:
   schedule: "@daily"
@@ -60,8 +60,8 @@ spec:
                   value: "0"
                 - name: SCHEDULE_GH_REPO_ANALYSIS
                   value: "1"
-                - name: THOTH_LOG_MI_SCHEDULER
-                  value: ${THOTH_LOG_MI_SCHEDULER}
+                - name: THOTH_ADJUST_LOGGING
+                  value: ${THOTH_ADJUST_LOGGING}
           restartPolicy: OnFailure
 ---
 kind: CronJob
@@ -72,11 +72,11 @@ metadata:
     app: mi-scheduler-kebechet
 
 parameters:
-  - name: THOTH_LOG_MI_SCHEDULER
+  - name: THOTH_ADJUST_LOGGING
     displayName: mi-scheduler log level
     description: Log level of mi-scheduler
     required: true
-    value: 'INFO'
+    value: 'mi_scheduler:INFO'
 
 spec:
   schedule: "@daily"
@@ -149,6 +149,6 @@ spec:
                   value: "1"
                 - name: SCHEDULE_GH_REPO_ANALYSIS
                   value: "0"
-                - name: THOTH_LOG_MI_SCHEDULER
-                  value: "${THOTH_LOG_MI_SCHEDULER}"
+                - name: THOTH_ADJUST_LOGGING
+                  value: "${THOTH_ADJUST_LOGGING}"
           restartPolicy: OnFailure

--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -26,11 +26,11 @@ parameters:
     description: ID for MI Workflow
     displayName: ID for MI Workflow
 
-  - name: THOTH_LOG_MI
+  - name: THOTH_ADJUST_LOGGING
     displayName: mi log level
     description: Log level of mi
     required: true
-    value: 'INFPO'
+    value: 'srcopsmetrics:INFO'
 
 objects:
   - apiVersion: argoproj.io/v1alpha1
@@ -54,8 +54,8 @@ objects:
             value: ${ENTITIES}
           - name: KNOWLEDGE_PATH
             value: ${KNOWLEDGE_PATH}
-          - name: THOTH_LOG_MI
-            value: ${THOTH_LOG_MI}
+          - name: THOTH_ADJUST_LOGGING
+            value: ${THOTH_ADJUST_LOGGING}
       templates:
         - name: "mi"
           dag:
@@ -72,5 +72,5 @@ objects:
                       value: ${ENTITIES}
                     - name: KNOWLEDGE_PATH
                       value: ${KNOWLEDGE_PATH}
-                    - name: THOTH_LOG_MI
-                      value: ${THOTH_LOG_MI}
+                    - name: THOTH_ADJUST_LOGGING
+                      value: ${THOTH_ADJUST_LOGGING}


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes thoth-logging within `mi` and `mi-scheduler` in accordance to https://github.com/thoth-station/common#logging-setup

## This introduces a breaking change

- [ ] Yes
- [X] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
