### PR TITLE
Fix incorrect name of mi-scheduler in logging envvar

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -54,7 +54,7 @@ spec:
                 - name: SCHEDULE_GH_REPO_ANALYSIS
                   value: "1"
                 - name: THOTH_ADJUST_LOGGING
-                  value: 'mi_scheduler:INFO'
+                  value: 'thoth.mi-scheduler:INFO'
           restartPolicy: OnFailure
 ---
 kind: CronJob
@@ -136,5 +136,5 @@ spec:
                 - name: SCHEDULE_GH_REPO_ANALYSIS
                   value: "0"
                 - name: THOTH_ADJUST_LOGGING
-                  value: 'mi_scheduler:INFO'
+                  value: 'thoth.mi-scheduler:INFO'
           restartPolicy: OnFailure


### PR DESCRIPTION
## Related Issues and Dependencies
The component name was invalid (https://github.com/thoth-station/mi-scheduler/blob/edbd39c0940457332e6dc95c783746947689a543/app.py#L30)

srry my mistake!

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


