### PR TITLE
Add max number of workflows limit

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   serviceAccountName: argo
   entrypoint: mi-workflow
+  parallelism: 2
   templates:
     - name: mi-workflow
       resubmitPendingPods: true


### PR DESCRIPTION
## Related Issues and Dependencies
Currently, the workflows are failing because of the reaching GH API rate limit, due to high number of parallel workflows.

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
Limit parallel workflows to only 2 

