### PR TITLE
Add ADDITIONAL_CONFIGURATION to passed parameters

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -20,6 +20,7 @@ spec:
           - name: ENTITIES
           - name: KNOWLEDGE_PATH
           - name: THOTH_ADJUST_LOGGING
+          - name: ADDITIONAL_CONFIGURATION
       steps:
         - - name: collect-knowledge
             template: analyse
@@ -33,6 +34,8 @@ spec:
                   value: "{{inputs.parameters.KNOWLEDGE_PATH}}"
                 - name: THOTH_ADJUST_LOGGING
                   value: "${inputs.parameters.THOTH_ADJUST_LOGGING}"
+                - name: ADDITIONAL_CONFIGURATION
+                  value: "${inputs.parameters.ADDITIONAL_CONFIGURATION}"
 
     - name: analyse
       resubmitPendingPods: true
@@ -42,13 +45,15 @@ spec:
           - name: ENTITIES
           - name: KNOWLEDGE_PATH
           - name: THOTH_ADJUST_LOGGING
+          - name: ADDITIONAL_CONFIGURATION
       container:
         image: "mi"
         command: ["srcopsmetrics/cli.py"]
         args: ["--create-knowledge",
                "--repository", "{{inputs.parameters.REPOSITORY}}",
                "--entities", "{{inputs.parameters.ENTITIES}}",
-               "--knowledge-path", "{{inputs.parameters.KNOWLEDGE_PATH}}"]
+               "--knowledge-path", "{{inputs.parameters.KNOWLEDGE_PATH}}",
+               "{{inputs.parameters.ADDITIONAL_CONFIGURATION}}",]
         env:
           - name: GITHUB_ACCESS_TOKEN
             valueFrom:

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -54,7 +54,7 @@ spec:
                 - name: SCHEDULE_GH_REPO_ANALYSIS
                   value: "1"
                 - name: THOTH_ADJUST_LOGGING
-                  value: 'thoth.mi-scheduler:INFO'
+                  value: 'srcopsmetrics:INFO'
           restartPolicy: OnFailure
 ---
 kind: CronJob

--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -32,6 +32,10 @@ parameters:
     required: true
     value: 'srcopsmetrics:INFO'
 
+  - name: ADDITIONAL_CONFIGURATION
+    displayName: mi cli additional configuration
+    description: Any other argument specification that is needed to cli
+
 objects:
   - apiVersion: argoproj.io/v1alpha1
     kind: Workflow
@@ -56,6 +60,9 @@ objects:
             value: ${KNOWLEDGE_PATH}
           - name: THOTH_ADJUST_LOGGING
             value: ${THOTH_ADJUST_LOGGING}
+          - name: ADDITIONAL_CONFIGURATION
+            value: "${ADDITIONAL_CONFIGURATION}"
+
       templates:
         - name: "mi"
           dag:
@@ -74,3 +81,5 @@ objects:
                       value: ${KNOWLEDGE_PATH}
                     - name: THOTH_ADJUST_LOGGING
                       value: ${THOTH_ADJUST_LOGGING}
+                    - name: ADDITIONAL_CONFIGURATION
+                      value: "${ADDITIONAL_CONFIGURATION}"


### PR DESCRIPTION
## Related Issues and Dependencies
Other parameters can be specified to mi cli as well (e.g. boolean flags like `-t` or `-m`).
I suggest using passed string as additional configuration, so for analysis that includes basic `mi` statistics with also `kebechet` ones,  you would e.g. have:
`ADDITIONAL_CONFIGURATION="-tm"`

## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description

<!--- Describe your changes in detail -->
