### PR TITLE
Change thoth flag to be setup with envvar

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -20,7 +20,7 @@ spec:
           - name: ENTITIES
           - name: KNOWLEDGE_PATH
           - name: THOTH_ADJUST_LOGGING
-          - name: ADDITIONAL_CONFIGURATION
+          - name: MI_THOTH
       steps:
         - - name: collect-knowledge
             template: analyse
@@ -34,8 +34,8 @@ spec:
                   value: "{{inputs.parameters.KNOWLEDGE_PATH}}"
                 - name: THOTH_ADJUST_LOGGING
                   value: "${inputs.parameters.THOTH_ADJUST_LOGGING}"
-                - name: ADDITIONAL_CONFIGURATION
-                  value: "${inputs.parameters.ADDITIONAL_CONFIGURATION}"
+                - name: MI_THOTH
+                  value: "${inputs.parameters.MI_THOTH}"
 
     - name: analyse
       resubmitPendingPods: true
@@ -45,16 +45,17 @@ spec:
           - name: ENTITIES
           - name: KNOWLEDGE_PATH
           - name: THOTH_ADJUST_LOGGING
-          - name: ADDITIONAL_CONFIGURATION
+          - name: MI_THOTH
       container:
         image: "mi"
         command: ["srcopsmetrics/cli.py"]
         args: ["--create-knowledge",
                "--repository", "{{inputs.parameters.REPOSITORY}}",
                "--entities", "{{inputs.parameters.ENTITIES}}",
-               "--knowledge-path", "{{inputs.parameters.KNOWLEDGE_PATH}}",
-               "{{inputs.parameters.ADDITIONAL_CONFIGURATION}}",]
+               "--knowledge-path", "{{inputs.parameters.KNOWLEDGE_PATH}}",]
         env:
+          - name: MI_THOTH
+            value: "{{inputs.parameters.MI_THOTH}}"
           - name: GITHUB_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -88,4 +89,4 @@ spec:
           - name: PYTHONPATH
             value: "."
           - name: THOTH_ADJUST_LOGGING
-            value: "${inputs.parameters.THOTH_ADJUST_LOGGING}"
+            value: "{{inputs.parameters.THOTH_ADJUST_LOGGING}}"

--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -32,9 +32,9 @@ parameters:
     required: true
     value: 'srcopsmetrics:INFO'
 
-  - name: ADDITIONAL_CONFIGURATION
-    displayName: mi cli additional configuration
-    description: Any other argument specification that is needed to cli
+  - name: MI_THOTH
+    displayName: mi cli kebechet inspection flag
+    description: Kebechet inspection flag
 
 objects:
   - apiVersion: argoproj.io/v1alpha1
@@ -60,8 +60,8 @@ objects:
             value: ${KNOWLEDGE_PATH}
           - name: THOTH_ADJUST_LOGGING
             value: ${THOTH_ADJUST_LOGGING}
-          - name: ADDITIONAL_CONFIGURATION
-            value: "${ADDITIONAL_CONFIGURATION}"
+          - name: MI_THOTH
+            value: ${MI_THOTH}
 
       templates:
         - name: "mi"
@@ -81,5 +81,5 @@ objects:
                       value: ${KNOWLEDGE_PATH}
                     - name: THOTH_ADJUST_LOGGING
                       value: ${THOTH_ADJUST_LOGGING}
-                    - name: ADDITIONAL_CONFIGURATION
-                      value: "${ADDITIONAL_CONFIGURATION}"
+                    - name: MI_THOTH
+                      value: ${MI_THOTH}


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/common/pull/1141#discussion_r600814175
and https://github.com/thoth-station/mi/pull/348

## This introduces a breaking change

- [ ] Yes
- [X] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
Kebechet inspection flag (`-t` or `--thoth`) can be now set using envvar, which is more explicit.
