### PR TITLE
Give full path to perscription file

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -138,7 +138,7 @@ spec:
           - name: THOTH_ADVISER_LIMIT
             value: "{{inputs.parameters.THOTH_ADVISER_LIMIT}}"
           - name: THOTH_ADVISER_PRESCRIPTION
-            value: "prescription.yaml"
+            value: "/mnt/workdir/prescription.yaml"
           - name: THOTH_ADVISER_REQUIREMENTS
             value: "input/Pipfile"
           - name: THOTH_ADVISER_REQUIREMENTS_LOCKED

--- a/adviser/base/argo-workflows/dependency-monkey.yaml
+++ b/adviser/base/argo-workflows/dependency-monkey.yaml
@@ -117,7 +117,7 @@ spec:
           - name: THOTH_ADVISER_PIPELINE
             value: "input/pipeline.json"
           - name: THOTH_ADVISER_PRESCRIPTION
-            value: "prescription.yaml"
+            value: "/mnt/workdir/prescription.yaml"
           - name: THOTH_ADVISER_PREDICTOR
             value: "{{inputs.parameters.THOTH_ADVISER_PREDICTOR}}"
           - name: THOTH_ADVISER_PREDICTOR_CONFIG


### PR DESCRIPTION
## Related Issues and Dependencies

```
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/opt/app-root/lib64/python3.8/site-packages/voluptuous/schema_builder.py", line 560, in validate_dict
    raise er.DictInvalid('expected a dictionary', path)
voluptuous.error.DictInvalid: expected a dictionary

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/src/thoth/adviser/prescription/v1/prescription.py", line 94, in validate
    PRESCRIPTION_SCHEMA(prescription)
  File "/opt/app-root/lib64/python3.8/site-packages/voluptuous/schema_builder.py", line 276, in __call__
    raise er.MultipleInvalid([e])
voluptuous.error.MultipleInvalid: expected a dictionary

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "thoth-adviser", line 865, in <module>
    __name__ == "__main__" and cli()
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "thoth-adviser", line 510, in advise
    prescription_instance = Prescription.load(*prescription[0].split(","))
  File "/opt/app-root/src/thoth/adviser/prescription/v1/prescription.py", line 259, in load
    instance = cls.from_dict(yaml.safe_load(prescription), prescription_instance=instance)
  File "/opt/app-root/src/thoth/adviser/prescription/v1/prescription.py", line 178, in from_dict
    cls.validate(prescription)
  File "/opt/app-root/src/thoth/adviser/prescription/v1/prescription.py", line 100, in validate
    raise PrescriptionSchemaError(str(exc))
thoth.adviser.exceptions.PrescriptionSchemaError: expected a dictionary
```

## This introduces a breaking change

- [x] No
