### PR TITLE
allow cyborg to simple merge pr instead of squash for aiops

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -123,7 +123,7 @@ tide:
     "*": https://prow.operate-first.cloud/pr
 
   merge_method:
-    aicoe-aiops: squash
+    aicoe-aiops: merge
     AICoE: squash
     b4mad: squash
     operate-first: squash


### PR DESCRIPTION
allow cyborg to simple merge pr instead of squash for aiops
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/1110

## Description

This would make the cyborg simply merge the pr instead of squash.