### PR TITLE
Fix parameter setup from ${..} to {{..}}

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -33,9 +33,9 @@ spec:
                 - name: KNOWLEDGE_PATH
                   value: "{{inputs.parameters.KNOWLEDGE_PATH}}"
                 - name: THOTH_ADJUST_LOGGING
-                  value: "${inputs.parameters.THOTH_ADJUST_LOGGING}"
+                  value: "{{inputs.parameters.THOTH_ADJUST_LOGGING}}"
                 - name: MI_THOTH
-                  value: "${inputs.parameters.MI_THOTH}"
+                  value: "{{inputs.parameters.MI_THOTH}}"
 
     - name: analyse
       resubmitPendingPods: true


### PR DESCRIPTION
## Related Issues and Dependencies
When running `mi-analysis` workflows, I observed this error
```
Usage: cli.py [OPTIONS]
Try 'cli.py --help' for help.

Error: Invalid value for '--thoth' / '-t': ${inputs.parameters.mi_thoth} is not a valid boolean
```
Which was probably due to incorrect parameter extraction used in template. 


## This introduces a breaking change

- [ ] Yes
- [x] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
