### PR TITLE
enable max time for prow jobs via sinker

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -14,6 +14,13 @@ plank:
         entrypoint: gcr.io/k8s-prow/entrypoint:v20210319-be35a198b9
         initupload: gcr.io/k8s-prow/initupload:v20210319-be35a198b9
         sidecar: gcr.io/k8s-prow/sidecar:v20210319-be35a198b9
+sinker:
+    # MaxPodAge is how old a Pod can be before it is garbage-collected.
+    # Defaults to one day.
+    max_pod_age: 6h
+    # MaxProwJobAge is how old a ProwJob can be before it is garbage-collected.
+    # Defaults to one week.
+    max_prowjob_age: 12h
 
 prowjob_namespace: opf-ci-prow
 pod_namespace: opf-ci-prow


### PR DESCRIPTION
enable max time for prow jobs via sinker
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/operate-first/support/issues/159
