### PR TITLE
allow cyborg to simple merge pr instead of squash for thoth-station

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -127,7 +127,7 @@ tide:
     AICoE: squash
     b4mad: squash
     operate-first: squash
-    thoth-station: squash
+    thoth-station: merge
 
   queries:
     - orgs:


### PR DESCRIPTION
allow cyborg to simple merge pr instead of squash for thoth-station
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description


During scrum we spoke about having pull requests being merged by simple and not being squashed as lot of pull request in thoth-station captures multiple features.