### PR TITLE
access the logs in different namespace than api

### DIFF
--- a/management-api/overlays/cnv-prod/role-binding.yaml
+++ b/management-api/overlays/cnv-prod/role-binding.yaml
@@ -68,3 +68,17 @@ subjects:
   - kind: ServiceAccount
     name: management-api
     namespace: thoth-frontend-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: management-api-pods-info
+  namespace: thoth-middletier-prod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: management-api-pods-info
+subjects:
+  - kind: ServiceAccount
+    name: management-api
+    namespace: thoth-frontend-prod

--- a/management-api/overlays/ocp4-stage/role-binding.yaml
+++ b/management-api/overlays/ocp4-stage/role-binding.yaml
@@ -68,3 +68,17 @@ subjects:
   - kind: ServiceAccount
     name: management-api
     namespace: thoth-frontend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: management-api-pods-info
+  namespace: thoth-middletier-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: management-api-pods-info
+subjects:
+  - kind: ServiceAccount
+    name: management-api
+    namespace: thoth-frontend-stage

--- a/user-api/overlays/cnv-prod/role-binding.yaml
+++ b/user-api/overlays/cnv-prod/role-binding.yaml
@@ -30,6 +30,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
+  name: user-api-pods-info
+  namespace: thoth-middletier-prod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: user-api-pods-info
+subjects:
+  - kind: ServiceAccount
+    name: user-api
+    namespace: thoth-frontend-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
   name: user-api-argo
   namespace: thoth-middletier-prod
 roleRef:

--- a/user-api/overlays/ocp4-stage/role-binding.yaml
+++ b/user-api/overlays/ocp4-stage/role-binding.yaml
@@ -30,6 +30,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
+  name: user-api-pods-info
+  namespace: thoth-middletier-stage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: user-api-pods-info
+subjects:
+  - kind: ServiceAccount
+    name: user-api
+    namespace: thoth-frontend-stage
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
   name: user-api-argo
   namespace: thoth-middletier-stage
 roleRef:


### PR DESCRIPTION
access the logs in different namespace than api
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #1126 

## This introduces a breaking change

- [x] Yes

## Description

Use the role binding to allow API to access log of the pods in different namespace.