### PR TITLE
Run graph-sync in provenance-check only when authenticated

### DIFF
--- a/adviser/base/openshift-templates/provenance-checker.yaml
+++ b/adviser/base/openshift-templates/provenance-checker.yaml
@@ -34,6 +34,10 @@ parameters:
     description: Log adviser actions.
     displayName: Log adviser actions
     value: INFO
+  - name: THOTH_AUTHENTICATED_PROVENANCE_CHECK
+    description: Provenance check performed with authentication.
+    displayName: Authenticated provenance-check
+    value: "0"
 
 objects:
   - apiVersion: argoproj.io/v1alpha1
@@ -158,6 +162,7 @@ objects:
                       value: "{{workflow.parameters.THOTH_DOCUMENT_ID}}"
                     - name: "THOTH_FORCE_SYNC"
                       value: "1"
+                when: "{{workflow.parameters.THOTH_AUTHENTICATED_PROVENANCE_CHECK}} == 1"
 
               - name: "parse-provenance-checker-output"
                 dependencies:
@@ -172,6 +177,7 @@ objects:
                   parameters:
                     - name: "THOTH_DOCUMENT_ID"
                       value: "{{workflow.parameters.THOTH_DOCUMENT_ID}}"
+                when: "{{workflow.parameters.THOTH_AUTHENTICATED_PROVENANCE_CHECK}} == 1"
 
               - name: "send-messages"
                 dependencies:


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/user-api/pull/1354

## This introduces a breaking change

- [x] No
