### PR TITLE
Fix parallel limit to use semaphore instead of parallelism

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -10,7 +10,13 @@ metadata:
 spec:
   serviceAccountName: argo
   entrypoint: mi-workflow
-  parallelism: 1
+
+  synchronization:
+    semaphore:
+      configMapKeyRef:
+        name: mi-scheduler
+        key: parallel-workflows-limit
+
   templates:
     - name: mi-workflow
       resubmitPendingPods: true
@@ -38,6 +44,11 @@ spec:
                   value: "{{inputs.parameters.MI_THOTH}}"
 
     - name: analyse
+      synchronization:
+        semaphore:
+          configMapKeyRef:
+            name: mi-scheduler
+            key: parallel-workflows-limit
       resubmitPendingPods: true
       inputs:
         parameters:

--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -10,13 +10,6 @@ metadata:
 spec:
   serviceAccountName: argo
   entrypoint: mi-workflow
-
-  synchronization:
-    semaphore:
-      configMapKeyRef:
-        name: mi-scheduler
-        key: parallel-workflows-limit
-
   templates:
     - name: mi-workflow
       resubmitPendingPods: true

--- a/mi-scheduler/base/configmaps.yaml
+++ b/mi-scheduler/base/configmaps.yaml
@@ -5,4 +5,5 @@ metadata:
   name: mi-scheduler
 data:
   repositories: ""
-  organizations: "thoth-station,AICoE"
+  organizations: "AICoE"
+  parallel-workflows-limit: "1"


### PR DESCRIPTION
## Related Issues and Dependencies
Related to #1115 

## This introduces a breaking change

- [ ] Yes
- [X] No

## Test or Stage Environment

- [ ] Pull Requests added content to STAGE environment
- [ ] Pull Requests to `AICoE/aicoe-cd` has been opened: <!-- insert PR url here -->

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Description
The `parallelism` specification was indeed incorrect, and the right way to reduce number of parallel workflows that can run is to use `semaphore`
