### PR TITLE
use argo v2.12.5 in prod deployment

### DIFF
--- a/amun/overlays/cnv-prod/amun-inspection/argo-namespace-install.yaml
+++ b/amun/overlays/cnv-prod/amun-inspection/argo-namespace-install.yaml
@@ -67,7 +67,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argocli:v2.11.0
+      name: quay.io/argoproj/argocli:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -83,7 +83,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-controller:v2.11.0
+      name: quay.io/argoproj/workflow-controller:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -99,7 +99,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argoexec:v2.11.0
+      name: quay.io/argoproj/argoexec:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/amun/overlays/ocp4-stage/amun-inspection/argo-namespace-install.yaml
+++ b/amun/overlays/ocp4-stage/amun-inspection/argo-namespace-install.yaml
@@ -67,7 +67,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argocli:v2.11.0
+      name: quay.io/argoproj/argocli:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -83,7 +83,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-controller:v2.11.0
+      name: quay.io/argoproj/workflow-controller:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -99,7 +99,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argoexec:v2.11.0
+      name: quay.io/argoproj/argoexec:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/amun/overlays/prod/amun-inspection/argo-namespace-install.yaml
+++ b/amun/overlays/prod/amun-inspection/argo-namespace-install.yaml
@@ -73,7 +73,7 @@ spec:
         - args:
             - server
             - --namespaced
-          image: quay.io/thoth-station/argocli:v2.11.0
+          image: quay.io/argoproj/argocli:v2.12.5
           name: argo-server
           ports:
             - containerPort: 2746
@@ -104,11 +104,11 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - quay.io/thoth-station/argoexec:v2.11.0
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller
-          image: quay.io/thoth-station/workflow-controller:v2.11.0
+          image: quay.io/argoproj/workflow-controller:v2.12.5
           name: workflow-controller
           resources:
             requests:

--- a/core/overlays/cnv-prod/backend-prod/argo-namespace-install.yaml
+++ b/core/overlays/cnv-prod/backend-prod/argo-namespace-install.yaml
@@ -69,7 +69,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argocli:v2.11.0
+      name: quay.io/argoproj/argocli:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -85,7 +85,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-controller:v2.11.0
+      name: quay.io/argoproj/workflow-controller:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -101,7 +101,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argoexec:v2.11.0
+      name: quay.io/argoproj/argoexec:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/cnv-prod/middletier-prod/argo-namespace-install.yaml
+++ b/core/overlays/cnv-prod/middletier-prod/argo-namespace-install.yaml
@@ -69,7 +69,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argocli:v2.11.0
+      name: quay.io/argoproj/argocli:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -85,7 +85,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-controller:v2.11.0
+      name: quay.io/argoproj/workflow-controller:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -101,7 +101,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/argoexec:v2.11.0
+      name: quay.io/argoproj/argoexec:v2.12.5
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
use argo v2.12.5 in prod deployment
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

The argo versom v2.12.5 works well in the stage , upgrading it to the prod.