### PR TITLE
Suspend prescription-sync-job in prod and stage

### DIFF
--- a/prescription-sync-job/overlays/cnv-prod/cronjob.yaml
+++ b/prescription-sync-job/overlays/cnv-prod/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: prescription-sync
 spec:
-  suspend: false
+  suspend: true

--- a/prescription-sync-job/overlays/ocp4-stage/cronjob.yaml
+++ b/prescription-sync-job/overlays/ocp4-stage/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: prescription-sync
 spec:
-  suspend: false
+  suspend: true


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/prescriptions/pull/16/
Related: https://github.com/thoth-station/adviser/pull/1806

## This introduces a breaking change

- [x] Yes

## This Pull Request implements

Let's suspend prescription-sync-job in stage and prod environments. We will move to a new schema that introduces breaking change. I will enable the cronjob once the new adviser version will be available in stage/prod environments.