### PR TITLE
Enable prescription sync job in stage environment

### DIFF
--- a/prescription-sync-job/overlays/ocp4-stage/cronjob.yaml
+++ b/prescription-sync-job/overlays/ocp4-stage/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: prescription-sync
 spec:
-  suspend: true
+  suspend: false


### PR DESCRIPTION
## Related Issues and Dependencies

Requires `thoth-adviser>0.27.0` available in deployment.

## This introduces a breaking change

- [x] No
