### PR TITLE
Enable prescription sync job in prod environment

### DIFF
--- a/prescription-sync-job/overlays/cnv-prod/cronjob.yaml
+++ b/prescription-sync-job/overlays/cnv-prod/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: prescription-sync
 spec:
-  suspend: true
+  suspend: false


### PR DESCRIPTION
## Related Issues and Dependencies

Requires `thoth-adviser>0.27.0` available in deployment.

## This introduces a breaking change

- [x] No
