### PR TITLE
bump up adviser to 0.27.0 for zero-prod

### DIFF
--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.26.0
+        name: quay.io/thoth-station/adviser:v0.27.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
bump up adviser to 0.27.0 for zero-prod
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

