### PR TITLE
set the role for argo-admin and argo for workflows

### DIFF
--- a/core/overlays/zero-test/argo-role.yaml
+++ b/core/overlays/zero-test/argo-role.yaml
@@ -1,0 +1,95 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argo-admin
+rules:
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - argoproj.io
+    resources:
+      - cronworkflows
+      - cronworkflows/finalizers
+      - workflows
+      - workflows/finalizers
+      - workflowtemplates
+      - workflowtemplates/finalizers
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argo
+rules:
+  - verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/exec
+  - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - create
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+  - verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+    apiGroups:
+      - argoproj.io
+    resources:
+      - workflows
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argo-ui
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/exec
+      - pods/log
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - argoproj.io
+    resources:
+      - workflows

--- a/core/overlays/zero-test/kustomization.yaml
+++ b/core/overlays/zero-test/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - argo-role.yaml
   - argo-namespace-install.yaml
   - argo-ui-route.yaml
   - argo-workflow-controller-metrics.yaml


### PR DESCRIPTION
set the role for argo-admin and argo for workflows
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

```
 Forbidden: workflows.argoproj.io is forbidden: User "system:serviceaccount:thoth-test-core:argo-server" cannot list resource "workflows" in API group "argoproj.io" in the namespace "thoth-test-core": RBAC: [role.rbac.authorization.k8s.io "argo-admin" not found, role.rbac.authorization.k8s.io "argo" not found]:  Reloa
```

