### PR TITLE
set prow ssh cerds for private repo support

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -9,6 +9,8 @@ plank:
         bucket: s3://ci-prow-artifacts--36f9ca3b-f5af-4432-bef8-af42508b403e/prow-logs
         path_strategy: explicit
       s3_credentials_secret: s3-credentials
+      ssh_key_secrets:
+        - ssh-secret
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20210319-be35a198b9
         entrypoint: gcr.io/k8s-prow/entrypoint:v20210319-be35a198b9

--- a/prow/overlays/cnv-prod/secrets.enc.yaml
+++ b/prow/overlays/cnv-prod/secrets.enc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 items:
 -   apiVersion: v1
     data:
-        oauth: ENC[AES256_GCM,data:a9or5nwyRnjZF22UhFhcrqPksl1g+xuewSD4kLWasyUAg7aKIASZ/K7074Vjcacnps2CPRiSCYs=,iv:7wPT8lOgGPVNyFQdsdYscts2FqjA2em7uXEeOmNlLkc=,tag:B2tta8NcQMQoAoOztHuWLA==,type:str]
+        oauth: ENC[AES256_GCM,data:P8biB2W8iJUgAPSYlO5AUr1gGIqwFqFLJdOg1DBFVf/KCfqMAIJUOPIM9/A2vCKj/YyZaG4goWk=,iv:o6/4iwLcOefptxGXfULWdBZF3PcVxgS/xC3yCSQhD90=,tag:ZwEvs/SIeTl5JTDWWKaVxw==,type:str]
     kind: Secret
     metadata:
         name: oauth-token
@@ -12,24 +12,24 @@ items:
     metadata:
         name: github-token
     stringData:
-        token: ENC[AES256_GCM,data:KexgyDzwymPjWnRxL9yIR/bMO6i+sbYBzLbGOTHEqnjrue3BEvlQRja/G4b51qUXMS5bMwwMyRo=,iv:1YP05EQk8szjv1mUS2Wf4WsFUGLOhHYgMHx/aJ6Ixk0=,tag:8iCDvdoxMJTl9Iwtd1cuSw==,type:str]
+        token: ENC[AES256_GCM,data:XoZRZ3+ijifybjHacBEMyOd45i5C81msGGq9JCIgF8KwnUWcTO3Hqf4DK9Lv3WGiXtkBTvvuplg=,iv:Ww7yBHUXwmewDhvnBz8e5Wn8C4ltb/G3rfvGh+vEKPk=,tag:B1/pbyYR3QpI2OXF7ankbw==,type:str]
 -   apiVersion: v1
     data:
-        secret: ENC[AES256_GCM,data:8teG7eo3w9jT4Rzh68wiR6xunf5tZYXPGxGZqxf6kicqAQ3tOERb4UUlG64cYbKL0CI7wC/bL9fUUwBVb4hKf0YGpXDezaxiRjYhbl4pXrFUYMuLEjLjgBMQdprbJx+oKJ4AqTtRfFEj8arlEh64NMRnMQUKSSmtZdSdlyz49KyTvisGBds6P2BdvVYW8jxdQwzBoc7UDv/6hrpnp0YZ2bSvYmD47ZwHA8vUlHkkm6X1HRrJ9apHDwyYROmXABgInvw4fYw09V+CQ4UGe5JIyNoz7qmz0t/NlMaWjWcUn9EgfTFNJYwDgprMDQNe5KVExgBn6O2vx89fHmbFJgkP+n4DNtiVIK8QAiSs5sg9QLQgaIWIsbKuNu09hIyfnRd92GGGznBC///nsPVwu57IGQ==,iv:TV0Mc1zY3q79RzLSKQyV6qnxhjsZnv72FTmnQBRxEgI=,tag:P7/KjkuQi+rULlx4saH/Cw==,type:str]
+        secret: ENC[AES256_GCM,data:+8F5gh3DLUoL880MTatTCQ8ypBtOP8N11L577gCpl/9dDr52M4LuLn72HcGkazC33OfyPSWsuzfrSSWwPy8JPGdr3tDu9xZ8HfDR7/58N7EmWyom95rKGezr0Vomh5JAQ3TPGUjrhjDY4+82BVTzHx7qEFCpe6tJsuZyV5vXA19X1gw/H+PZTSTnZ4vJ/kMfoKi/jEWrThAAslq7ixjbkYdhpa43yrziZZ1K8kH+jN4sok0M0WEb7y1taWk8OWDz+yK2DrOU9NiM9nC/w/Ldsy+H6LaI9ojXE3mMp6RCKOUunDPbf38frLzQ4Qxv+HmE7VxQk2jIO63qp3SK444Lnom9WHjfLwsPvheCspYrvnwLp3t79XcO+H5O9ARSXtGzB1YdEyYHiU/h4ZOtbxdBsg==,iv:U6id9roA42H1yRy/TS0GPaGZbrPXUUhjZYqyDSFQm8w=,tag:Ax8MNGpBeScGIKTJbJsuPg==,type:str]
     kind: Secret
     metadata:
         name: github-oauth-config
     type: Opaque
 -   apiVersion: v1
     data:
-        hmac: ENC[AES256_GCM,data:FBhKf7eux4QtEC+XeCtDEGdq0Au2yIJoD29+O04Oqzgvq7yVpsEAy5nRRj29VTH6OUQ8q027sSo=,iv:6QKoWcSesE6FRuGyGJ1i28SRhn64BLook4VLtbW4ahE=,tag:1yS/s7bpVOWMSC7PIMBEsw==,type:str]
+        hmac: ENC[AES256_GCM,data:HXZvVVanmzOsMBaVtWjxB7Z/rbVSRCea46fMF1a/3y2PsUyackkB6amposwa2zXn3/Pun1S/0/8=,iv:TXZeQsHAdhWg/RCVDD3mDvfl2DbCrTm/evhWX8t748c=,tag:muEqqXWeUBEiISoQhjOgSw==,type:str]
     kind: Secret
     metadata:
         name: hmac-token
     type: Opaque
 -   apiVersion: v1
     data:
-        secret: ENC[AES256_GCM,data:8AonhPKUMd7tnIQ5eofT5a8z1Ev/mWvPOHOGetJZ5uXoPyBFybGuJcAffSuybCxyGhcD6mavc/DiNDqO,iv:nJW2TqR/VL8X54+jyshDy6rKEbfU/nXEYcKiq+UMJW4=,tag:knXZ5Ngf9pB6puaPis0/qg==,type:str]
+        secret: ENC[AES256_GCM,data:KhJ7Y6Y6fI3zeinpcdaSrMzN+3fF1N8hTYFpUVpQihnb3yGM71ly9fYcNSYLEAYxAwtc+3nvxubk8ISN,iv:PZQXizu/kzGVCjlmOwSTyr3cYCv4xBR2EbRvKEUGBzU=,tag:I3t3ESwsOMN4rwJ13eMRmg==,type:str]
     kind: Secret
     metadata:
         name: cookie
@@ -39,7 +39,14 @@ items:
     metadata:
         name: s3-credentials
     stringData:
-        service-account.json: ENC[AES256_GCM,data:NVYDHa/7sQI3YxVGzIEpNLV/5iH3hZ5XoBNj1CEiL3VYlDLg8kGW76Y1bL5VJv454r1420hIjAF1Y08fArLTltGgwYWpDX5zENxrPtPozPqqsrOh6xcWY10XefiRow2nZnVRGgFyPo0q3lJvRU+GY1aDfLjYwG1hiXoHg6NEv/NSv1eCmMswW5xKRyjqAyof/YfsqTzBrpjIeDRag+f4nPK4orw9QgCdM/5SyRQilzcWDcvauD06jivzPfxgeBfH5H1wAinHuKQ0klqf6W2kqpRlf60YiuqKwV5drT2bvo1wBOUOw3QYslVeg/EhZa7KkFBOUVZet1jWD1WA0KDv0uJQo8uAW2CPuT87QJC3Mtro1FDFOdY3TFr/2wmGDMpVqA==,iv:r4iNz6aKCKk20w9R1uAma5LHzF8OyWdmJLIhIqwTjtg=,tag:QvHgbI/h6pNLDZotOrMArA==,type:str]
+        service-account.json: ENC[AES256_GCM,data:SoCc7ny+4YT8h4hNgXBLd3bo2+k6vcIRQPSYA0cbspdLdxThk2VKVkoi9M6uX6WtbAiPO7LBdfPrFttelEkY8Yh1raeQFzTOAajgM21Bnbj0k3HRI8NWa4ik2Luwq+sa/PCqaxZgg3+IKyxgb+xPrYCh+wfw0grMJg4AOitccsf9y8NxPdzykdvXQGBZtRAP56o8SVMDVSoZpl/rQwuKTgga46snFVV/9ysq92lvPtcwwH7nLJ3bhw9PicilhnHXE57zo8TFyXNjDLAzHooThO6QjAhy3T8kkOCpIounoA76xhRyzRMZKATbfMMQETUWQ8RVCIAExVcv5m34FV8lCGToJtTLioMrjn+pnM8QETELQ9qjvQA/kYPYN4eHC1zW8A==,iv:WTFKfHisyCNrZGn7VlKjZod0Fx5j2MPHWK8D8HRkQo4=,tag:x+6oMDz4lZ3Sh3Qo9OgbDA==,type:str]
+-   apiVersion: v1
+    data:
+        ssh-privatekey: ENC[AES256_GCM,data:95JrCP6aUp1MeZOIDytzjSehigzvmJnuQ9aKEhyrs2++/4M971Mu79IWfNta9ntOowu4rJMpFX9SySsZRsgJIVOjKoZfkA23IhBQpa6+AlTPVkBU5VZMMITM8v1/ecOBSXuiElYEIIHhoqAZ049GcgLhPXFrlr/3z+1XedjCLs3IwOKNEBMHMRt9rXs+tb91zZGOq58MIWJHElM/+ju8PihBfW24wWkIj5HOrI/O+a7ORlm3T9NT6vnmdB8DVfliheOCtcx0yVp1K7eGJuAn9law8piXapP2tZ8T6wfFLnaMr9y4G1YkZFQcrwqmGkjkiVa9i6WXuoCs+cGkbFshacRrUwdfSLw2Eh3kOq8vF7SequLKKobaPB56/27dbtie3VzUVx/okUrMSqTDUSG+X4XkHUpzQdTluIhJjRwwWh6HwISLTkbzhc6mjxdqI1hs8zk/4ZqsKGZFfPampvV07fDIiWiV8qGq27sEwO4+kK2Z79zqzLS5b2OvnYb3G0+Uz2QTjOLmlL+3HA4Pb2E5MQKFl1SS7et9MqesO+g6onwrnxhdhd0m6JVpGWUmlHcaD58tuc4qbNU9m9H/+t7nm4FEa08LJJwqU7heWMxf8H4ComDDuovMw/5K624w4TDMSxmiovO06fSsrapiTjswEmjqFSNJ+cx3sVRHKrLhH0uSeHzFcE8VVV0NoCfHZ0yts2MeXosk0rYd6wFUvNt77awtQLf5snYCjXFBTq0IUiQ5W8EIOBdthfRW26BmvoRDQp/gCU9SYn69mlYssW5Mz80KjZrwIvlX40viXCL2zsTvfGEIEt53OLq74XuBXOfxUbQE8hOLiTMH4cvAsJRQk4m3ukccguvhUcQefgQXI4chbQ6FjJ4mSEkOw5vrmSnB8St2dpf3H/LsiY4uLMHU9HQ+2YmFZDMnVrMB2HzRXFbA9iZ09Jzbg0upcYYn0BdxiJJc2S9QDWJ/JRjD6HigsBN53ZBQyXbiQHfkaCkdjpljhgFhBVWL/F1+mN9/NiRmDHeaj/2OMQpGkTF8fzG3Gz4X3cY5IwbzrGwi8x21FH9OOc7WiQ+UroHY/TldVwbcXl9uOp96i1a7QrGf9WjyRcyr0m+8BQIGStY1/KXhlW3EXelzrmgdBZgQ+fSxdpYwlOnFG6sMyUj4EXchdEIFeJouhCUwCQpbrdgCJVbibBjOgR5U52AmIS5KwHCurBUS1J7KmRsXZV15CsXuJAN2y474C1vwC3p2V4AQsaFtREJyYYApTPg9c9QJVAXovOyCD9hnu2t9lDwCjSstPdljxd1L+fhWDNvxBvGsICVD1A5OkKG1KDUF8WdJfj/jdKz4A/QmJWyrubzaYFJSL6gtkatEtE9g5+RyX7wQFgnWNjsuAMEyQ8Ni+Pi532Tju3+vBqvTjEMThQTqokrnlpe7x1sZ9eaKEPHeFAx35uVgLKkmbsESh/MFeNhQqzhdC8v/L+/T23q6Z0e6faAnC9BHEQpPy9pVp44wgo9biTOb2bftV5xtG5JVoluAGmljDj04QlJeKNGU2l7qGMP9JKoJw0sElz/3esvXaq12YbK/ipuBAvfzxKUvixMKQCQZQqE1mt3B4VxXO9LgahCixWTpqp5gW07yN0ZR4+0N92ErIuW6Ha4ovJRcyMLtd4ekh36re1t1Fxc6p4zFJAeK7MtIuzOxq6WuRv6xkeK0Lr/a/SqAWuzLZpdcaSlz9cSlJuVFP9LAXjD+Edoe7sEYTpbATHyJxzqWunxeeYtYVsiP8gK3pOPcRbSAnhDQ7IFR2URrMFL9GeCXjKd/iJ0AbOxMwAFv9eOQ6xlKRoltr5D7lFFEd5o+wTisBBrWcn27C52WKOFGl0/hUTlENw9lXc7tvo1oDOGS8Q3Vb0BAr4gh0TxZ1lb1efZcoaW8RET80gb4mGZepgD4dG3hvNV/5r7fkNA7Sd/f4B0u2vd/AiW6uOXOqH74K36T4egoXCZU4y0kvLoJDXEoq+96707SVnxGH33YpQVRP03qm1KhYCmcVvcFSdZVrKhbu8p100OQU/wq0SV5l3sxKba6IETNxtZbSi7lpNq7hxuSxtW+QK38jr8XZ/2mFdfsNjgn3kUO5zN4RScuPWvwJD1gCoGKlKIMe0z/p5ssUKMfhtW20zJLif04+B5/uUJ2/Wp6QjK+tl5QyJtYFjEGrR22+JQe6/wggRETLqGa8JJm+1L3f3/LkC+kF4MKvqxr4ElJE78St92gL8bw3N1HJIwONSkIec6n7jqC9TchrNP30/IG/gCe+NyJ2tSsE2yMhp29d/tHt1+tThB/Telq2m5q67zrGIx+2+cgWe96ptiITNbylYnP9XFZuc5vQXIKLOPqhsIgJj2995JFfhAetKliTRz3xkjNwPDDWMyYEygchi173EB+TwBSRroDFehSwIjhLLU0JcWv7G2OPpE28LgHhLpbeFurV7YFHGv+n3qz7sXeD7lfeTR30IdwU9Vev3D2MYrbslpNagF4FjRaea6y0aIwsbv3PKqi07Bm2eV81ARxMV8+uSVvuLWduVJQVlHnvC8wyHpq5ZuuGWCO4VQ+cN8dgbmHMVxcUUUt1GR2p63m2Y36YKIX82L5mFmi+RNb2EYY/+7xXykc7nYqLJ0r70FUUszazFHKhRe0WpnUHfm52OaxJZSNaifE++S5+9MQBwslKoa4pickEpuAZlSPggMqpeLfvrE9Y77uEh6AAgtIc9HyJDlQUeVaSQBFxT/W3rdDMxZgPiJIaVQHEjMpM/BhDwvph4OGtOM93hee28PoIlrG5aEEWCbwDIWkQkBmmeJiLJ7GgMzeogaUcN9/jKlLOQX+FIzUTo95GrzV9fm6YySvs92NoGH2UUH7v5SzN7zvUR9dnDlnh4CRHm/+pqtCml3FbNKCNcUpF9PoM9qoCvDEHE6qeaRgMmzBm7J2GVQObszD2IXNgVM3XWwLXrewLhjcECBJbR2XQ7McOb9WLxIkVyhDuacrV6EOidi8v2/g5HjgHgulPgmuaOWhqwHz53Mif07PFgqtTN/FlLNUV5wRR7RnMIQHXpeXsm0rHso46jjyi/60eRjAfuvtLOmjkqfwFuX7fRwzaq7OjtPjY+xHqXhtw8+5r7Xo33DrRksgtStXDbm49tq9xzyHhNpxpbFo6gLI/omgz6q7lqQam/0Ci5+ZLPHfDHHziY7h6RWBr+OVcBZx+Ja7yU27ImcFdQEKuYPpa5pWzIDzZCElpSAcTJKJQGOd2bSt7rJkf1QkWzCvyngigkhfqUcDx8NtLR5r3RS5sYaXQ8DJ+ktv7VereHQWioSvmcmMI+RB1J2jdC5kAXVwvsa6MWWdzj3PEGOLdGDOrJoVLHLSiywvQk5suR7LhzBltq+y/jHJR1SLeFwnHLzLWMWgWDRmjsDvFV9mKvHcty0Sgg4tvkICb8vr/LcjJ1ijO+3MsOdUdCFecPhlnFzGoNQ0ny2kCYj4v3m5FrJ0pKk4uWKPP92zXeq1gPcc1FbdyqsNACz3xTwSUNlxwgjrCNVn50CNthxxOQxbnyQebhBzZ16nyN0VytlkO/K8neG5AE/2x0Nwww9E9FxwY5xiKPfIWM3uuatPjgapPMXrHdTuikqdtngtNmsJSg2MVtiGdIwy0YjlKKyibIu72sDJyNcOsQiemtyrY48cYHooCxtNo/SZFutcoT43ztBziFXo9cJ5/zy0FCDfnjC+lVrdkg77MntDsRs7SGqjaJuP+kmXE4B5ibftqZu2pF5jKk3r1diAqCpKFtA9H35Nba3OjstmySkbNryB/rDKDzLdAzXE6zaYk2vrN01f3eWl7UB+4aheDFFqSROE5XXTXegjnZvEidgBMWSHwdvyslU29T1LRNqWWA3pZpaQsC8l4XrK7/oMPOAQ5OImuc3c1Z96o79FyKf7F80ndUWR9Ldygvli60m5JmF0zOWGUkbWp4qIq6zECU1FFHVrtQIu5E+lQ0e2nhSrwzgZQMpaOv2QJJRUAWML7ha7xF7nLReTj9vHsOP3WyEEeiud0NslaHOayqA6mDqxQKwk+EEATdUEjKlN8K0AES17UTNL1FoAS2E1lM+iS9jnQNQOzJyiE5Uy+rFjgU6GdKTLfJzVEDWp5coZ2VSBhRk44e+IrhyqKtdvl/KIvIzmS0QgJZE1+oRXgSjdpiOxZzUrenlK5WnNXM4kwYQEAxt44xu4PhP6z+NJ0ejFwjZFG5cYB1cwjlaqwh7Ys+0ldakf33JWpOVpTBJAlyq0Rf4Y3zYEeIhKjB/Z6ohx3UthAm9eVFmetptw+KLJedauyDTC9mCfhzVSkP18P3RVz5+68bj0jC+pGBRl6hUr5sBTRALeXA4r9Jpb02G8444C0O+tLJUQyHGNJezCR/Y2t5nwfuJZoejlyTsXMUdcDzikNYadurjOk19m+8DOXhzR1FQX1OxRrsO/Glg53VJ1mvkyJWwH9Cd3tLbH7jFyI2zCSSQN3B+xhUB3MyHxBTwPHmPRHHnTgc2vgqEFLW9HKEQXhuZpAGIvuSP6ZboDLHapERMpkw71dShgyRg2qRlRu73y+thJpI+KLnjPqedi/C7NMz3gS+BYD78jOH9J1z5veWGJL/SW4Bt8cON9kSGaezkjZK050cl+wJbIM1TS,iv:1J6MzgkR2EbDYBucVBHvhgh/wU8I7azQF8V44I2wk60=,tag:pmrF9NM5pE9BPkn5DwZYcQ==,type:str]
+    kind: Secret
+    metadata:
+        name: ssh-secret
+    type: kubernetes.io/ssh-auth
 kind: List
 metadata:
     resourceVersion: ""
@@ -48,77 +55,77 @@ sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-03-09T20:32:17Z'
-    mac: ENC[AES256_GCM,data:rUSup0DArmF53dKqz6zy7gP0AJrYToFAbA4zlFPHa7P7SrjFZ5UvaiuKo/C/gDfnSz78evHYhwn78WIKPjvMydaTl9xUIM70hz7j06T4eSikZF25zNpCEf+nH82AmZN+Tcj5Dqy6zrcqyPOpMbjc578haATbxp8812pmXfCbkO4=,iv:ETxvAx5W8OTobS8/vVL9YytMjHi+YbuUYsAlWKmfq0U=,tag:UHKFrI6+qPk+JbljT5zo7w==,type:str]
+    lastmodified: '2021-04-12T16:02:07Z'
+    mac: ENC[AES256_GCM,data:A01MDhJB/LIl24Ptf+AwtKDzHEVBRJUA4QIrJJVXx6hdPp2wV3Q2tP4GmDFAqkiFKwJi8/XMWe4T8bQYA0L2bVmcSkKXc8jZTxYvr/LFwW6MvjonLPrFBQfXNtKuZv7JxCs3UevrIP6wPYIIreY8LMKwbC+iHH4j2z43uCwPXFs=,iv:14nxOOdpcpGp5jupGbhShRIxemLpQNtSJh+9vYxoolo=,tag:L1zdnmRUMDNhmKs8z63QHQ==,type:str]
     pgp:
-    -   created_at: '2021-03-09T20:32:17Z'
+    -   created_at: '2021-04-12T16:02:06Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA1gbAjViyxWYAQ/+NSPNIIVxaU1runVxBNA3HnICA9p9a/kvzaXd/zOnQaMu
-            nXv0zrkKHVU+9CVYevZzFTuqongRn0zhELg+LXkEll9JKPKd1ATzc4/ngjOGoTM3
-            Mpm4mSlr76aDIoiGcfS7b7CURStKy6lau16qg97AdiNdn3/1u0SedCOxg5ZFzbQs
-            qNygGM5JJeT8/ZGuO7LBkahetHePkUeIcUdhwN7u7xregUeTpO0Xja8IUdne6+WH
-            9jmCFyy9FIREnTa131/uJhFHEdB9u6dLU5mIIYRzBe41LBViKxl+za7oox2u4bkj
-            M3Wjeh/kERA1SQvhA36qZmuuj0nUFsyCKN3xYG+jxXCA0yhdeo52bw9msHC3EFgH
-            uPHMRXOU5YrAKduncmF9GoLjiB8HzcZZCoBLwfBH57OTs1Zd2fRtmi5cEOL4lIUx
-            q5JlhrqhaZKLVpTM9n/02J2UA8fu4qvU2eNcrOEW/EZaLqsQQr8ErqggbJDr03JZ
-            FYclSqBWOBi5sgme+cQjxxe8OQchYOpO1Bg3fHnWH/Q+PFWWQ3BHPw+w9216RKZ8
-            KCwZMbrniV90SMKz1edgtYQ77CklHTOmFy7c5b8YAx31lc7rfDBUrtJb/IHUNEYM
-            9ce0qJK+8ELOy2qT3ROGO/Gu8MX/TOgd0IquIAMtRyykBhgfLlAGxBTBitdfzxrS
-            XgFmTaG2QtaXwdu35pGydZY1iUAPQSD0L/zhO0QYjJsv5Ikcswt3ptUQ9f+Va4il
-            mnS8O0o/tyxI4j6JOwhY7JSOvzzUPRdr4hwwfi0drQdlijqdHO7Im2/f1w2Swdg=
-            =raTx
+            hQIMA1gbAjViyxWYAQ//S35kQv4Xh3IvHiCM8RSm88oqD+FEfocsbAbcZuIUq/y9
+            8wD3zSwSj7d6l2OE2wxlm7K4dF0+DbvmtFe1ivAnupBCrmnfU9XHHSK1all3jpUG
+            zw9Mlf+Mva85iNbq/tNlNP7Rf4MRAVio66//F+l9XsDhd9s2ongEG79ww0fCDtyJ
+            Ed9DeMppNDqQPYRQle4yxFrYay2oJJ/tkXpth3IRNHyqvj1/HkM51YNKMz5RilJ5
+            xDky/oQmMIv4T2AVseY5rBvAEdph9No95HP3vlwaRsainzDs0N7sWV71t8Ql+fDS
+            /dA9sNjHaieYE99iRhxDV2EKARrvqDrMtfHKzjzIWTwqFEkOsr5fEnoPjxIyTuRZ
+            copfbTot8XS01frOb2AuegatsJaBZs6/BpjH9EppGNs+7iS75tPd15R/8xe8K24y
+            bifNV1r5UUiW9QXn/BXstrEtP+RFzt1JxCid2tIAuqQDEwYuRcMf5qpRVy1uSFoe
+            u4LK2ARCJh0J6aLjS5S4QemsENDC8nkiEFVK4kPrpmHzJb2jFY5I1L/DB/qUostz
+            3NLdyFlvZ+1kzIzAwt6/Ko9xiBgPMgpi+auRAIOMOba+o8+eoUb20elk737Rb1Zc
+            FiboVGIlEcKZiWZ9m3pw6ng2PSraaoA7FOO9zQGAGYuVSGPLBZ59ivshV6jtW7LS
+            XAGjmxxKfFEXlr2Q8h3h+WUnkvz2UPcwojKSmq0AC5sc4lTCJ2lTvsGPJG+HJy/f
+            pWgPXuqMtzoBE9p2GO/R/EOerx8Rrnbu+I3tyNoxoe7PJdRY1xEIfM+tTDWZ
+            =1kGL
             -----END PGP MESSAGE-----
         fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
-    -   created_at: '2021-03-09T20:32:17Z'
+    -   created_at: '2021-04-12T16:02:06Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA+/WpawS9RPbAQf/bA8n5qPgpSo6VsjiqmOBdTsm/vMR4xJypIS+7hx67fV+
-            qAXgcuFnzoxs5g3Cd3RxrJ/tUG31o+Jqtmp8N95oG2i/ubSrquN+ohflLNFKfmIl
-            w/pIbHQg/CYHJtpejnr/R5rEN0Vg1swA6+xyMWf4Vv7s4OSiXiqOxrqZn9mv7QJf
-            zRc477rCBfcmr755tpH0JiX5HkQtZNse/hXCFK/WumgxKfDdag9VuPxgkMjdQuSd
-            EO9+MEa4A3B7n+DqgwdI5Cnrx5AuWZtym9cQGuJ6WumljIWlj620F4yd7cZlhQpA
-            bsBGn99scWX3q+am0bUkVue7e6Yt5zZqXxerQXJYhdJeAWyVncmeDbKeCDtdVW0/
-            LE+MHJJVTJvuzdYt0ajKV5zdhK0/KsV5LdxvJq3ZXvSl6+K4ed88+B7lSKIjZ0II
-            W5xBBGf1R5Z2IZJUsq54C56XC1tAw7qpdPJQ7VmVwA==
-            =Fldc
+            hQEMA+/WpawS9RPbAQgAjx1+iBuEydOrydkTFnFoH8HJCUKkfOWy8pGDlSV12aCF
+            DSvjzuHC9xI7z8ysu4gL3nxsPMDjcsthk3eQqYtlazR4U3aq2vx9LjdeBE0Rpf/d
+            NFKqAe+iPQT+gYyyLS0VO5EgRvCBMyeyp0h7MdSco0su+WKRWtHCDcsxz3qkRRfk
+            ROOctPqpfJZfsS82SrkJ+UmN2+JEjBmNpnULcAtB8qvRv5r/gfzeJVOuCW7ddJuJ
+            vThQCWBsmQExWBj/RZE/3IIzocGQLiwI0V+QSe2FbEVTiN4Dag8m7zJnOCMa5HyM
+            5okQdd/DNxPrU/FZTAAvOhbAzgSg8kgLNwz3g2aPVNJcAZ/FJ8N9PGH8j6zR/rHo
+            RES7U1Z6u2DYa7wMbuZKw39cjrW6wkikDApOABBhIWVjwpr+sMLSBaZIIs67FaS+
+            W5Lxjbiaqmm7pPuqz+tpm3DGj+p7+PIGD2JU6p0=
+            =CbI+
             -----END PGP MESSAGE-----
         fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
-    -   created_at: '2021-03-09T20:32:17Z'
+    -   created_at: '2021-04-12T16:02:06Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf8Cvf41JW+4IuZIgdgHPT2hi41NxHLfA+dD9E08wxNq5fE
-            9p5xsfjwIYeu/miQ2ifhlF9U0L0fLnMV55lRa2e7txTbLwafqNp4x2Umkszpc5pa
-            dNjLVlsLooW46zrfED0w/ZF5y/A+0z1FwTBTo1nLlg1DryO3gK0xDp1iHNTB6R44
-            LXqVBvNjjUyly2/whpSyXT0zOH1JjfdARQXjKkuYnlTdp3ebBPxut3WOp+WIV/HS
-            nZMhbL40LrLO0XAdFQJsHu5AyJqUcePxbxFeA+T/dB/lUv5F0iQUboCV+LSOsCOG
-            o6rc3MAQqrqkYTJ5UK64FTDbTSixxG/5eYZpLTeaUdJeAR6VBw0zt2tP3xKoIIsm
-            wj3bU0WrRMZUtfRSC0YNHQnJKPQ1q1WTD4v01+fTLcORErSbKH3BhSFGE2krVuZh
-            mEDHt07xQXzuNnsUhL5EXJMkkWjByvz8k2hQOnZ9Vw==
-            =t59F
+            hQEMA/irrHa183bxAQf/UgMfQ5N++wqKLWtvgfvEpwX53EV2pkQi02+KMDN2LPFt
+            eUidSFtbbyilW7XlGhiNHlunqpvJplCuRz4XsPhgUcMFvXq1OmJLrZcSR/XtTUXe
+            ekY+yMCKMDVlrutoDJw7vT5diUykzy/c+frIaHuOCAqx0Uj7E1uv8zgJQABqfXcA
+            6/BTvHgxdRpx9gTnPXUOODm2nPUhJmqVUyzokOj/ikvHh2CwMeeIocUb/46gWEOi
+            QvXttlkiJbcTHM3RIJrBvM3GbKRGs7HTYfejlPphKxHbnPV/wpdQ5N3nkZO3mV6Z
+            5ATQ4EaYvUXOPYsEI9HVY3CIA9/6E5SWnrB/9zXhtNJcAa+jwtV9NRi8olYmZ0MR
+            6b6WaLgAvspGsECxPyzYAJbw65oVcAPyrrcSYkl0MJV58Ws30qRTovVaN1rupnu2
+            +QXrTnGzy3DOpRmNnGAaz0ww0z62dxAjahVN5eQ=
+            =KDYM
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
-    -   created_at: '2021-03-09T20:32:17Z'
+    -   created_at: '2021-04-12T16:02:06Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA9aKBcudqifiAQ//RfVccwGsl+LmNvd4kBswHNgeO4XIBlxjPy484TVB+RBj
-            XMsuLAv1q5qOO3+ydv+pNujVJkD7bWP9Ho5O+X4k5MFbuJmgZigu682Tv9z2KlKe
-            r1Wdfb0UkZaiA1yf8/BiKMpwLAg2xmoUyZTSTzPP+szgmyaacrLNhueV+AuPdGHE
-            c6Yz23XiserhpgMHNA3xwniVUwD3E/YpNwb50Sd2rwhoRynbRTaruUkWWllZ9xvM
-            K6aE9IzWb4TqPdugF7ovLp0Vc98VZyC1pSoHobnRU+hBVTO4yjD7Dz2hNMyDUPhJ
-            qO5jHvSWug607jKn0rylKzWbXsa8zitfIl8rh64TylLJbVXydO6jPm6gviIonpru
-            lCeZoIqNEKiztLAEyo6Z7LHTMfr7wVoP+IxyG5TgftRFyaKM2KHef5a5VHWYYYsU
-            57OqI874hx7JHDsOBRlnQPjWZaY7YWtPObLwDCc1jkApIxpflcJpz3HuXA6MRNYh
-            xdcE8GFrVSlNnWD+zrYuZD1h83Rw7NJMO4jfTZ8OSIIxd5TvsgDSrvusYV6/uugD
-            wyCuUtR5X1Bu5u7ld8xLWqJ+hCAo9n9bHT0+HHWyHB8Q4GLzQQy7lOCS2GK5VdFL
-            KFvnGhlM4PKNKZZfstP8LXVm3uwb+EA79SwDkKZ0CsPOOx9klHVOaQKBIxn6qN3S
-            XgFlSTgWI+mwTyzyknTQ6lxoTWITF+rJthHQzkaOv6T3WMdj1KAKiR/j5+0WWCh7
-            HqYFElsnEVeMq2LxZQrmQYozMC5Lwz1iETaXfLrrCV73yQQPv7dblV8fi76FiF8=
-            =HkWw
+            hQIMA9aKBcudqifiARAAvXm3YHgeEvgPhlTt/JdoiVzOKIiRL+tuUt/h6JiI+Q7n
+            a8+D2E9vTuDd3+rD/ki30P7Rc7hDD6wqFjNcZPFEviJEC3I+EpCL8NLzxkhtP9xp
+            KhpGCZID5ue/+rv4XcKi9QbCUA9Du9Hqz58PwLrGMluzmfxzvGGWl/9xawSDqauk
+            IvxrqNyQnZ9BYagjffb94rR9m5Ss1AnSRDiyByf2hVC+qVixTDXNrCQl37/V7HiX
+            hHuhKtKmQxHVjxxfdocYqdvirgXbzJJMUVGiCyaGFV5djeHEsqo2w5rwLUsM3dX0
+            f7KcIWvnWrXcfJToZosD+WXZfwEBPgqaWqVl6vW9LEpk9StaeEXONAqCzxPAHqGN
+            8Tf0SdQuFwgUq6e3itVcGD73Ltk9aI6cJ80QxNzwt8HaJvG6R2Ucg7t/2Wd0H0QU
+            WT8MO5yguCwSVCLKb5Rp2PzQHGt1UKT8cmkp5U0ol2B06nnN/QTDIuZDimTrvJ5P
+            kRaUoaJhINFzoX0rv7vrRCOxMCsHS8zK2Xyq1FImp2alUD0XbBcecN09mqvzwA3V
+            X8O5Hkvglb4AyZayh+f9j+wBg2igwrYKO+zhBf+0gv5Lbnr5AuPLfj2XFFiT/4OK
+            vp7HpHrUIrKeWHCIWFAeioeeU6FmY40EFenwIEpYUr84bItvVXcfFf6elULEiS7S
+            XAEsDLmEdixh16qfTJI/eJWbpz9v4Hy1wsKSiQVuKhauwcACR44SQU5FdcSYFUZn
+            kQKweCR6RZwotGxbsInlQ9xPj+xcCiDaULcEyIL7qAZY8UiHu/anOzKmH9Qk
+            =nEj9
             -----END PGP MESSAGE-----
         fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(data|stringData|tls)$


### PR DESCRIPTION
set prow ssh cerds for private repo support
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/aicoe-aiops/vulnerability-analysis/pull/40

## Description

This would enable prow to use the ssh method when necessary, like serving the private repos.