### PR TITLE
Pass constraints.txt as an input to adviser

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -143,6 +143,8 @@ spec:
             value: "input/Pipfile"
           - name: THOTH_ADVISER_REQUIREMENTS_LOCKED
             value: "input/Pipfile.lock"
+          - name: THOTH_ADVISER_CONSTRAINTS
+            value: "input/constraints.txt"
           - name: THOTH_ADVISER_REQUIREMENTS_FORMAT
             value: "pipenv"
           - name: THOTH_ADVISER_RECOMMENDATION_TYPE


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/pull/1826
Related: https://github.com/thoth-station/thoth-application/issues/1182

## Description

Pass `constraints.txt` file to the adviser container. This can be safely merged, will be picked only once the adviser is bumped in the deployment (backwards compatible change).
