### PR TITLE
update secrets based on the zero prod cluster

### DIFF
--- a/slo-reporter/overlays/zero-prod-ocp4-stage/secrets.enc.yaml
+++ b/slo-reporter/overlays/zero-prod-ocp4-stage/secrets.enc.yaml
@@ -3,8 +3,8 @@ items:
 -   apiVersion: v1
     data:
         token: ""
-        key-id: ENC[AES256_GCM,data:vtKhrdXOLCUQLVtVyjCfYPvGXdk6D1/r9RlUCQ==,iv:ob11gceV/mpMt8rPLcdQgKkIm+GRzCPZnC1+cOU62Ho=,tag:81XO/nFRpgcxRJ3hZralbw==,type:str]
-        secret-key: ENC[AES256_GCM,data:BST1yykFGcQ/iarRq8Xr7AYS3dzwZz3p/kdk1tLQHO/wl1PHnvir1yeC/yAbEuqdvRiYCO5G7lo=,iv:DpjkMxWK3E6POf9JH+uhGPfWhJv1qgfnR+PQK/kt8fA=,tag:WYZRebDSlGdrGi+is7lpDQ==,type:str]
+        key-id: ENC[AES256_GCM,data:DmtUmJAk0EZ+Q5IH+OF9+FauLGWChk/qq9TExg==,iv:n+eOMMkrYSMBzkDSvT8KfuynM2BLXd7SKnnTkCIUiOs=,tag:ck28h9iBReON3KLufl3N8w==,type:str]
+        secret-key: ENC[AES256_GCM,data:QoyIa3uMVgDmXz3MZPQnq7V8f9kHLeYivFpTUFvgyi/bIhV21h8M32jRsodQ1sNB+gSvHHaEUC8=,iv:7zUe0CSWPAxPq3ZeajrtoDk7NfKR8Z5XiAzu2LwRHO0=,tag:ucH0swVYsF+RhYjQ4azJ9A==,type:str]
     kind: Secret
     metadata:
         name: slo-reporter
@@ -17,77 +17,57 @@ sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-03-10T18:51:48Z'
-    mac: ENC[AES256_GCM,data:YfPw8pKRit1OPvhZfFPRIeD33XVjUBdOVL+ZZEm6f3UdGh2Vn00bVREaXcIlc9/eOPoUgJ6hwzpFga8n9f8KIT1cJs2mJuCxr1pzUa9PhbZg4yMRHpMBwCxf71ImEfoQWS2O+WKTEiIEKzoU7AVFzmuQXVWd6ZX09PJGp4azEGE=,iv:QOueN96rIb7s4MMNxOpmaK7SuhxAPGKyMQpiFe9z81Y=,tag:QU/eRLV0LPurY+fJmIMchA==,type:str]
+    lastmodified: '2021-04-20T18:44:47Z'
+    mac: ENC[AES256_GCM,data:aiBwJpB0iPsZUPZ7UJHMjv+TQmeHg4ZHBiL53PhlHNI3R06zSwnPVc3d9jRC5knldVyIO6lzebEFDMbIFSGBn3+o38PPkCLzTe6BoQDf9lCU8F++C5hBYBMYF6jhlrwFfqHqFBjHmd1L4NFDwzYkPUalQBhap5fu0DyKhCwxVuM=,iv:nWV7XKteSBv0qSPTacg927fzlEbM5IEYtOkNi4huOVU=,tag:4lyzNp9zw87Wnn4ZNZF+zg==,type:str]
     pgp:
-    -   created_at: '2021-03-10T18:51:47Z'
+    -   created_at: '2021-04-20T18:44:47Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA1gbAjViyxWYARAAmiYR9sAoKWSuI8DFIIG2ckHjAbx024nZ6mawKWom7lCH
-            1bIfw+8WGiplt5+KXN0hCZU9nRFQkNVWhDmd70yATsdatfehZ1o9Zu0br5g6sx4p
-            y5fxR/O7E85JT0iwLZVYvTQxgZb/Ag019gQCC/XUjXbRZ56zQNTEIXpIAPmjFJzq
-            6sG7IZizDGYbRJuleCUgxh33/0h4qlueJfJM8DE39/OfaI1Vmomdyktztj2Kn84n
-            ceLAT9cIrpMqzX8npYxpBL1wS3DKNSDCKm6JL+8eIM/Piv/AaQqmGKT2AygATWl2
-            EIJya5DrOMpiTKo5KqdcuMO6RXC9jQAE7b6gVaVRupnAbWKOl0wnzJq2AAAgg9AJ
-            QEYqDxArrzL98fkk4Fy0kCkJqU9hgpQYm5BQBSRUVUPETO66vhNygiXZ351RK3qB
-            2Go4uRmsMz0H8tlJhGD0Qs8ByM1wgL9Q7WKJCdsic0G6idyuFrysP3an3fsrW8gg
-            o7Zys9AWLoaYP3BorOiy7sjzMcO+qsxF/IrQnA3e5+rS4OLlvtorZaHZ860m+IGc
-            Bkqhcvze2oYEeCYwJKVLdQjw1wAQsC5YZSl8wer57cIMlVz3kW34hwGD0/UGy8wX
-            VKuMajWo8gyBMEd/e+5EVIGMmLgnpjxfLx42HEFdR/PM4e9HC9INcivCT3Gi49zS
-            XAF4v1PDlS4lyO/7gono57Nar7biCi/Q10+1G2MazRyJZQctWXG1w9cXkrN7xUjy
-            7Yk9v+RKVWH2L2S0LAWV8CM4cwl0vZCvpHklZuW7IGMYIReG2QRFUdMHrkhu
-            =aB4I
-            -----END PGP MESSAGE-----
-        fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
-    -   created_at: '2021-03-10T18:51:47Z'
-        enc: |
-            -----BEGIN PGP MESSAGE-----
-
-            hQEMA+/WpawS9RPbAQgAmByY/eBQ1IKQMVcVHKSoQf+Cm56FKwYqaF9EhibWr+I2
-            PVl1wIXYLULOyrP/70mR4kjOTwzrrqE4SUJ/J/NqMnEjjEzfJo9NaN15nef5w/AC
-            znscRQ2HoTl3nP3Gxg9rVmzsVK2F1Vt0Scynh0ZDdXqO+G5+pfb/AW1o4CG76gJE
-            +eD25P6L1kk7QzDWGIrUv/qFGbXuHAPcT3qR54GyCpAdAJaFg56y/qs/wzP603Nm
-            uCtejx+6kxAN+zxdoPxja1AEFRslJTuU+5CNwMRPhh6I8BLifMWK8+RU3FzdYlqP
-            sH2siVt85/AMx7i2f7DdAqUL7TFMJgH+k4yU+mNtjNJcATRtVjupaMXj4GqxnJWe
-            jm3habgBQSXW39zs5+qLJCwiXcuzDCWkgchgonGIBM0Y0T95a9n6fMjn6vrnXFMo
-            ey3jw1eD33MNjL07kKbV3LCDR1N7Qha4eoxKG7k=
-            =ZjNa
+            hQEMA+/WpawS9RPbAQf+JIqDIeEGCafZEb2sshnx8Be0j/iiSsG+cFMWHHDNF8/O
+            QHrLoqvrTXOjSR9jUPqOYkCjpgRLw/Wc5lKn/OlLfCeHnxV4TuiqkmFn+bvIepfu
+            eS30eM6rmrrbQAVdLF4jo9yFlByWbXpqhQlEbJjcjuLgJodrecPJ8wN/bpmKMy9c
+            SSYuy3Vxx3nATEiBqtoliLu3bcNhb8YKW6Cu2bnJAXnGeawNVTJiu+BavYo3nDOt
+            stUhejMNx923zqE8g1IvqmAbgEMDa00xCBsRN9DMf4kikyT/3C+7/0Qew+4O/rTz
+            CDuTXRVQwtwfhLflLdHEhMGAyEFScE/kHl2L8aoxGNJeAeEaIaYgUPY+VuBYqR+q
+            mAC3hmN+O4N3l7kek4B64IOVnLP6WQdVng7CWwg9zkSFhhgNBycgxBIycZhijZDy
+            vqn99RlixMHLqoD7JV0u/KEfpHE1Ma2Q/Vy5xY0fzQ==
+            =6Sdt
             -----END PGP MESSAGE-----
         fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
-    -   created_at: '2021-03-10T18:51:47Z'
+    -   created_at: '2021-04-20T18:44:47Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/irrHa183bxAQf+NnOs+HQ7VuPcrzor91IIY1grGlWWSvzSeYfQD575+ks/
-            kT2C0aJvZ3vyHWef5Ct3g6WPPXK30xA0xRtBROKY2enmomeZis1/bWd5SOIg9uI8
-            X13JKvIj1BdVP/e3a455jFoEyl9xEvFvG8GNPbrlajes2BW7hAAxkidGM4CdLlPH
-            ITlGkefaxaIwcB5rUJUKARJqbiUEkVmqSxOIM/3r8aHolCOtEOCeWYdY1DS7A3Mm
-            qUVYyX6GEmkIIHxjtvEXJDSPLcnQvwpqablwk5HxhP3vLWjfeOREpKp3yUbCXA4u
-            xU5Cc9LifHo5lhhx09iDM2Rkb4zuFi+V5CDNOWjWfdJcAR45pBkORHGcEQMsgUCf
-            mlF5nq8nFoqbBmAN3+3I62PBN68+DZhbTDnU0INbDXfA8OpcecADnqV5Qnrc75HP
-            esTF9YVM/ohYpr5RzRSbxKT1mzBP2PoU86D3w7s=
-            =wbXO
+            hQEMA/irrHa183bxAQf/Ti9U10PCYqluCHtV3nRCc0xHbUbNATbUMhTsRva3tIWh
+            DtU+Rj4xPn6BecLvW5USPG+H70EyaEIWyvOp2m/D2a0wvhhv2TGpZvg5nrWpjLBo
+            Lu0IQhDLV9DLCAniXG4gJSEM2xyZU1VEcXTO+x18N+EAu4zGu8oKEESpIr4ID9Tv
+            ALen63jPc5oYmoJDBkbRSVCj+KZsajA/TBd98CNDTteR3Ld2DXQEQJNxxc/oLBJn
+            GBIxwzdqvgNkxr7A6OoP0QrsG0ibJWpmxSTwN4R7mPtrSxr1IBWP37ZDWspm0aIW
+            MS/GlIEjjnBK28ofNGFMHadnP7qDioRWmStH8qmb89JeAZ6nZhuAV7qWn1uXJolx
+            O3RbSGGT4AqY4tr/jYFrJcqUNa0XuBpFOJc9OEewhZjSceN4Zwfo6CkA64DxUox+
+            DW1SbU2AUWBbzcX01Cd06qZAhS31MfOfsp1wom9zog==
+            =JStl
             -----END PGP MESSAGE-----
         fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
-    -   created_at: '2021-03-10T18:51:47Z'
+    -   created_at: '2021-04-20T18:44:47Z'
         enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA9aKBcudqifiAQ//dNLBW7k8+yvlQjuZhaTMfI+9WMjf7dEL6Fe82uY3TKER
-            Oj5VUNTK9N+/O/ee3vGLjq974TPF+QIufjYGZxQTTjAPE+4+BVvkajjXwkZklpfl
-            bExgPIinYZCMToEbcsn/f6c08ww6+9eurTx5vOvEll1Af4V7UuaNVHD40ElEwOG3
-            NoUoqQzDRnkbutznSox+UtYu4Vy15p5CTSvh7u+QkGGj8mZvNCZgMycLUmOfXIUC
-            4yDGco9F+R1dIfihtUTUcC3ytItHvK4sjnFJ79vGeYATDLdvpeIYwXw/BPy2owmr
-            On4+/rXU9mfoZ4TEqptnMwmdTl7mFykfs5uyMYyhhsLBy4RpH0p4QuBzeNagVDvY
-            VDC5osJcVsglFYzgMKjUHtxwz7V52PGLXWcpn2EMidf1XgmjeZ8FyfICsDVM7Zsh
-            jn8xiJH+FWLjsT942wKjQqlj46OuAJU7P0b2toArzKxOuV3NAvBFfh6KGfrPckXI
-            MKe+mCwwAYJsSiIqDO3sLVIT4rbxKKAZNsCq6RmYY9/9xGfUETjy7pRCTPI1b9n1
-            PLTO+ogc5rEJn6ZMZHifsX6GC6T2nxi58jQgEDDYxrZl16J+gQI01bVlmFowgpt9
-            m2R/pkj3+qaa4Ztj4vyW2260vcnVsRahmdNdEQ+SAbY6dicYcWHpzn4Q7/kgtTXS
-            XAF2UBqcWfjphpdfUItOMdA0gnkw8B4e1RtV0Ji47EQgieiFfPDHUKKFQTE4B9WZ
-            pH3RGYVxEHrM+qu0QK1iMJhu8Jorro7mlYODDS3YxwE1ZIdQKTJyrsVKL1xl
-            =+i73
+            hQIMA9aKBcudqifiAQ/+Nq13I2gvE+i1bAJjKSH9PYRjdJCVDXiONTGAH7mZKFCp
+            zwO8iCRGYytjcCNO2MRZUh6sV9KI4IVzDTcrbYY+7xd6BN3VqWtCYiftecaNXvv7
+            clsBgX/9LjVzC8WmazCNdr/q/LkkIs4WK9bH4d+SCO/tzb2ZlVw+ckdIGoNNcTqg
+            30gAJfEfrxo8EZXrK4TOHzw5FfCPnL94daoBEzYNMYICjM/H+tTohFmtD/eNqm1Q
+            ZtYHVTumxMEtSoAYg2/YSu3elC7kGk3pyC229MuigX2pqujN7T9rwjCMITu+IdFp
+            4fS6+8gWMHai7/aPGlap63H8Ext4T/01TAdVXhmJbrNUi7kbN3SsMlapAxt1kSDs
+            Q/jZw8QtNxyiF1vZfYTk0HCPnw8sPTYHZtkau9dhJhsyI0hVxcsb258VDGSGk4QO
+            h8iSKYlocfL1cwHzufOuYWuPVanP6PYVLTeZD8DJoyzvkbM4ZDVAjpPISoNmAwX+
+            WUJmG0LUUbmlinoHamrNkhUIWfe2BcQlPU8C2nPVKl0DvyicDvmNnxnctTy/B22X
+            npGCCTOsQ0PxwArcnGFXIc0wC5Q1ztCpOctQZ9o6eHfiszVhslrdD/pMu86bB0Rq
+            YMVpv36SkLCGf5Z8bjYaYtacusp/mQF60RHZ5jWT4KpBmx4U/Qd2NKa35cUIMvLS
+            XgE8Cgppd6TFOrXZgD022CCJkBUIwT/wsYXIV38qhrmgqTUdq/+r2Z/C0dU/8e2z
+            IHPXvJrQRML/5OaAXAIruYR2ESQx45MU5Ufv3x1jFwBj8eHE9WeimkoFYzYYrsE=
+            =08aY
             -----END PGP MESSAGE-----
         fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(data|stringData|tls)$


### PR DESCRIPTION
update secrets based on the zero prod cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #1184 

## Does this require new deployment ?

Not needed

## Description

As the slo-reporter runs in stage cluster, talking to the prod cluster, it requires the creds of the ceph of prod.
this might also fix the related issue.