### PR TITLE
add Kebechet slug to openshift templates (default null)

### DIFF
--- a/kebechet/base/openshift-templates/kebechet.yaml
+++ b/kebechet/base/openshift-templates/kebechet.yaml
@@ -25,6 +25,10 @@ parameters:
     description: "The webhook payload for kebecher run."
     displayName: "Webhook Payload"
     required: true
+  - name: KEBECHET_SLUG
+    description: "Git slug of project being worked on."
+    displayName: "Kebechet Slug"
+    value: "null"
 
 objects:
   - apiVersion: argoproj.io/v1alpha1

--- a/kebechet/overlays/test/kebechet.yaml
+++ b/kebechet/overlays/test/kebechet.yaml
@@ -25,6 +25,10 @@ parameters:
     description: "The webhook payload for kebecher run."
     displayName: "Webhook Payload"
     required: true
+  - name: KEBECHET_SLUG
+    description: "Slug of GitHub repo which needs to be updated."
+    displayName: "Kebechet slug"
+    value: "null"
 
 objects:
   - apiVersion: argoproj.io/v1alpha1
@@ -78,6 +82,8 @@ objects:
         parameters:
           - name: "WEBHOOK_PAYLOAD"
             value: "${WEBHOOK_PAYLOAD}"
+          - name: "KEBECHET_SLUG"
+            value: "${KEBECHET_SLUG}"
       volumes:
         - name: ssh-config
           secret:


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/investigator/issues/496

I added KEBECHET_SLUG to the OpenShift template to keep the above error from occuring. It is not currently being used in `prod` or `stage` but I added it to the base as they have a more recent version of `thoth-common` which attempts to set the template parameter.
