### PR TITLE
Bump advise-reporter-v0.7.4

### DIFF
--- a/advise-reporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/advise-reporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.7.3
+      name: quay.io/thoth-station/advise-reporter:v0.7.4
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/advise-reporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/advise-reporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.7.3
+      name: quay.io/thoth-station/advise-reporter:v0.7.4
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Bump adviser reporter to v0.7.4, using new logic to identify errors when report is missing from adviser document:

![Adviser quality analysis (3)](https://user-images.githubusercontent.com/27498679/115589323-fc508f00-a2cf-11eb-94bc-38f8320ba173.jpg)
