### PR TITLE
Run kebechet-run-results only if authentication was done

### DIFF
--- a/adviser/base/openshift-templates/adviser.yaml
+++ b/adviser/base/openshift-templates/adviser.yaml
@@ -319,4 +319,6 @@ objects:
                       value: "{{tasks.trigger-integration.outputs.parameters.metadata_origin}}"
                     - name: git_service
                       value: "{{tasks.trigger-integration.outputs.parameters.git_service}}"
-                when: "{{tasks.trigger-integration.outputs.parameters.source_type}} == KEBECHET"
+                when: >-
+                  {{workflow.parameters.THOTH_AUTHENTICATED_ADVISE}} == 1
+                  && {{tasks.trigger-integration.outputs.parameters.source_type}} == KEBECHET


### PR DESCRIPTION
## Related Issues and Dependencies

When running an advise workflow without authentication being set, the kebechet-run-results task should not be executed. Even though the task has a dependency on trigger-integration, argo evaluates `when` conditional for this task which results to an error. The workflow should not be marked as failed if the advise task succeeds but the kebechet-run-results conditional is evaluated as false.

The screenshot shows failed advise task, but if the advise succeeds, the kebechet-run-results fails with the same error marking the whole workflow as failed:

![Screenshot_2021-04-26_13-03-15](https://user-images.githubusercontent.com/880687/116072944-0be52480-a690-11eb-9985-33373292dac4.png)
