### PR TITLE
Reduce the time to live 15 mins instead

### DIFF
--- a/core/overlays/cnv-prod/backend-prod/configmaps.yaml
+++ b/core/overlays/cnv-prod/backend-prod/configmaps.yaml
@@ -12,9 +12,9 @@ data:
     workflowDefaults:
       spec:
         ttlStrategy:
-          secondsAfterCompletion: 7200
-          secondsAfterSuccess: 7200
-          secondsAfterFailure: 7200
+          secondsAfterCompletion: 900
+          secondsAfterSuccess: 900
+          secondsAfterFailure: 900
       parallelism: 2
 
     # metricsConfig controls the path and port for prometheus metrics
@@ -34,7 +34,7 @@ data:
           memory: 256Mi
 
     artifactRepository:
-      archiveLogs: false
+      archiveLogs: true
 
       s3:
         bucket: "thoth"


### PR DESCRIPTION
Reduce the time to live 15 mins instead
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/1202

## Description

set archiving log true, for longer log retention without the issue of pod logs.
Reduce the time to live 15 mins instead