### PR TITLE
turn the utility images into imagestreamtags

### DIFF
--- a/prow/add-ist
+++ b/prow/add-ist
@@ -35,9 +35,7 @@ def reset_latest_tag(imagestream: dict, new_tag: str) -> None:
     """Reset the latest tag of the imagestream to the tag provided."""
     for tag in imagestream["spec"]["tags"]:
         if tag["name"] == "latest":
-            logging.info(
-                f"resetting latest tag from {tag['from']['name']} to {new_tag}"
-            )
+            logging.info(f"resetting latest tag from {tag['from']['name']} to {new_tag}")
             tag["from"]["name"] = new_tag
     return
 
@@ -50,7 +48,7 @@ def add_tag(imagestream: dict, tag_name: str) -> None:
             "annotations": None,
             "name": tag_name,
             "from": {
-                "kind": "ImageStreamTag",
+                "kind": "DockerImage",
                 "name": f"gcr.io/k8s-prow/{image_name}:{tag_name}",
             },
         }

--- a/prow/base/imagestreams.yaml
+++ b/prow/base/imagestreams.yaml
@@ -94,3 +94,35 @@ metadata:
 spec:
   lookupPolicy:
     local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: clonerfs
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: entrypoint
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: initupload
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: sidecar
+spec:
+  lookupPolicy:
+    local: true

--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -12,10 +12,10 @@ plank:
       ssh_key_secrets:
         - ssh-secret
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20210319-be35a198b9
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20210319-be35a198b9
-        initupload: gcr.io/k8s-prow/initupload:v20210319-be35a198b9
-        sidecar: gcr.io/k8s-prow/sidecar:v20210319-be35a198b9
+        clonerefs: clonerefs
+        entrypoint: entrypoint
+        initupload: initupload
+        sidecar: sidecar
 sinker:
   # MaxPodAge is how old a Pod can be before it is garbage-collected.
   # Defaults to one day.

--- a/prow/overlays/cnv-prod/imagestreamtags.yaml
+++ b/prow/overlays/cnv-prod/imagestreamtags.yaml
@@ -2,7 +2,7 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: clonerefs
+  name: clonerfs
 spec:
   lookupPolicy:
     local: true
@@ -15,7 +15,7 @@ spec:
     - annotations: null
       from:
         kind: DockerImage
-        name: gcr.io/k8s-prow/clonerefs:v20210319-be35a198b9
+        name: gcr.io/k8s-prow/clonerfs:v20210319-be35a198b9
       importPolicy: {}
       name: v20210319-be35a198b9
       referencePolicy:

--- a/prow/overlays/cnv-prod/imagestreamtags.yaml
+++ b/prow/overlays/cnv-prod/imagestreamtags.yaml
@@ -2,6 +2,28 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
+  name: clonerefs
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations: null
+      from:
+        kind: ImageStreamTag
+        name: v20210319-be35a198b9
+      name: latest
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: gcr.io/k8s-prow/clonerefs:v20210319-be35a198b9
+      importPolicy: {}
+      name: v20210319-be35a198b9
+      referencePolicy:
+        type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
   name: commenter
 spec:
   lookupPolicy:
@@ -104,6 +126,28 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
+  name: entrypoint
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations: null
+      from:
+        kind: ImageStreamTag
+        name: v20210319-be35a198b9
+      name: latest
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: gcr.io/k8s-prow/entrypoint:v20210319-be35a198b9
+      importPolicy: {}
+      name: v20210319-be35a198b9
+      referencePolicy:
+        type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
   name: hook
 spec:
   lookupPolicy:
@@ -180,6 +224,28 @@ spec:
         kind: DockerImage
         name: gcr.io/k8s-prow/horologium:v20210412-f0c722e283
       name: v20210412-f0c722e283
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: initupload
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations: null
+      from:
+        kind: ImageStreamTag
+        name: v20210319-be35a198b9
+      name: latest
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: gcr.io/k8s-prow/initupload:v20210319-be35a198b9
+      importPolicy: {}
+      name: v20210319-be35a198b9
+      referencePolicy:
+        type: Local
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -317,6 +383,28 @@ spec:
         kind: DockerImage
         name: gcr.io/k8s-prow/pipeline:v20210412-f0c722e283
       name: v20210412-f0c722e283
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: sidecar
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations: null
+      from:
+        kind: ImageStreamTag
+        name: v20210319-be35a198b9
+      name: latest
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: gcr.io/k8s-prow/sidecar:v20210319-be35a198b9
+      importPolicy: {}
+      name: v20210319-be35a198b9
+      referencePolicy:
+        type: Local
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>

## Description

I turned the decorator utility images into imagestreamtags, so that we can save some pull-time on each job execution

/sig devops
/kind feature