### PR TITLE
Update mi-scheduler imagestream to tag v2.5.2

### DIFF
--- a/mi-scheduler/overlays/cnv-prod/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/mi:v2.0.1
+      name: quay.io/thoth-station/mi:v2.5.2
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/mi-scheduler/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/mi:v2.4.0
+      name: quay.io/thoth-station/mi:v2.5.2
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/mi-scheduler/overlays/test/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/mi:v2.5.1
+        name: quay.io/thoth-station/mi:v2.5.2
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/thoth-station/mi/issues/399

## Does this require new deployment ?

- [x] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

