### PR TITLE
quotes added to the when expression for correct value substitution

### DIFF
--- a/adviser/base/openshift-templates/adviser.yaml
+++ b/adviser/base/openshift-templates/adviser.yaml
@@ -320,5 +320,5 @@ objects:
                     - name: git_service
                       value: "{{tasks.trigger-integration.outputs.parameters.git_service}}"
                 when: >-
-                  {{workflow.parameters.THOTH_AUTHENTICATED_ADVISE}} == 1
-                  && {{tasks.trigger-integration.outputs.parameters.source_type}} == KEBECHET
+                  "{{workflow.parameters.THOTH_AUTHENTICATED_ADVISE}} == 1
+                  && {{tasks.trigger-integration.outputs.parameters.source_type}} == KEBECHET"


### PR DESCRIPTION
quotes added to the when expression for correct value substitution
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #1232 
Related-to: https://github.com/thoth-station/integration-tests/issues/79

## Description

following the hint provided by the workflow validator :detective: 