### PR TITLE
Add graph-namespace to configmaps

### DIFF
--- a/core/overlays/cnv-prod/common/configmaps.yaml
+++ b/core/overlays/cnv-prod/common/configmaps.yaml
@@ -10,6 +10,7 @@ data:
   amun-inspection-namespace: thoth-amun-inspection-prod
   amun-namespace: thoth-amun-api-prod
   backend-namespace: thoth-backend-prod
+  graph-namespace: thoth-graph-prod
   middletier-namespace: thoth-middletier-prod
   frontend-namespace: thoth-frontend-prod
   infra-namespace: thoth-infra-prod

--- a/core/overlays/ocp4-stage/common/configmaps.yaml
+++ b/core/overlays/ocp4-stage/common/configmaps.yaml
@@ -11,6 +11,7 @@ data:
   amun-namespace: thoth-amun-api-stage
   backend-namespace: thoth-backend-stage
   middletier-namespace: thoth-middletier-stage
+  graph-namespace: thoth-graph-stage
   frontend-namespace: thoth-frontend-stage
   infra-namespace: thoth-infra-stage
   package-releases-only-if-package-seen: "1"

--- a/core/overlays/quicklab/configmaps.yaml
+++ b/core/overlays/quicklab/configmaps.yaml
@@ -9,6 +9,7 @@ data:
   postgresql-host: postgresql.thoth-test-core.svc
   backend-namespace: thoth-test-core
   middletier-namespace: thoth-test-core
+  graph-namespace: thoth-test-core
   frontend-namespace: thoth-test-core
   infra-namespace: thoth-test-core
   solvers: |

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -11,6 +11,7 @@ data:
   amun-namespace: thoth-test-core
   backend-namespace: thoth-test-core
   middletier-namespace: thoth-test-core
+  graph-namespace: thoth-test-core
   frontend-namespace: thoth-test-core
   infra-namespace: thoth-test-core
   package-releases-only-if-package-seen: "1"

--- a/core/overlays/zero-test/configmaps.yaml
+++ b/core/overlays/zero-test/configmaps.yaml
@@ -11,6 +11,7 @@ data:
   amun-namespace: thoth-test-core
   backend-namespace: thoth-test-core
   middletier-namespace: thoth-test-core
+  graph-namespace: thoth-test-core
   frontend-namespace: thoth-test-core
   infra-namespace: thoth-test-core
   package-releases-only-if-package-seen: "1"


### PR DESCRIPTION
## Description

Let's add graph namespace to configmaps to have it accessible in a deployment.
