### PR TITLE
Fix accessing pod log from amun namespace by management-api

### DIFF
--- a/management-api/base/role.yaml
+++ b/management-api/base/role.yaml
@@ -65,3 +65,18 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: management-api-amun-pods-info
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+      - pods/status
+    verbs:
+      - get
+      - list
+      - watch

--- a/management-api/overlays/cnv-prod/kustomization.yaml
+++ b/management-api/overlays/cnv-prod/kustomization.yaml
@@ -30,7 +30,7 @@ patchesJson6902:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role
-      name: management-api-pods-info
+      name: management-api-amun-pods-info
   - path: put-into-middletier-namespace.yaml
     target:
       group: rbac.authorization.k8s.io

--- a/management-api/overlays/cnv-prod/role-binding.yaml
+++ b/management-api/overlays/cnv-prod/role-binding.yaml
@@ -63,7 +63,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: management-api-pods-info
+  name: management-api-amun-pods-info
 subjects:
   - kind: ServiceAccount
     name: management-api


### PR DESCRIPTION
Fix accessing pod log from amun namespace by management-api
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/management-api/issues/745

## Description

Rechecked on the log issue, it seems that the role was getting overridden, this would fix it.