### PR TITLE
Fix accessing pod log from different namespace by user-api

### DIFF
--- a/user-api/base/role.yaml
+++ b/user-api/base/role.yaml
@@ -32,7 +32,22 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: user-api-pods-info
+  name: backend-pods-info
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+      - pods/status
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: middletier-pods-info
 rules:
   - apiGroups:
       - ""

--- a/user-api/overlays/cnv-prod/kustomization.yaml
+++ b/user-api/overlays/cnv-prod/kustomization.yaml
@@ -37,13 +37,13 @@ patchesJson6902:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role
-      name: user-api-pods-info
+      name: backend-pods-info
   - path: put-into-middletier-namespace.yaml
     target:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role
-      name: user-api-pods-info
+      name: middletier-pods-info
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/user-api/overlays/cnv-prod/role-binding.yaml
+++ b/user-api/overlays/cnv-prod/role-binding.yaml
@@ -21,7 +21,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: user-api-pods-info
+  name: backend-pods-info
 subjects:
   - kind: ServiceAccount
     name: user-api
@@ -35,7 +35,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: user-api-pods-info
+  name: middletier-pods-info
 subjects:
   - kind: ServiceAccount
     name: user-api


### PR DESCRIPTION
Fix accessing pod log from different namespace by user-api
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/user-api/issues/1413

## Description

Rechecked on the user-api pod logs accessibility issue. 
It was getting overwritten while applying on deployment time.
This separation would fix this issue.