### PR TITLE
correct the role name for user-api pods log access

### DIFF
--- a/user-api/base/role.yaml
+++ b/user-api/base/role.yaml
@@ -32,7 +32,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: backend-pods-info
+  name: user-api-pods-info
 rules:
   - apiGroups:
       - ""

--- a/user-api/overlays/cnv-prod/kustomization.yaml
+++ b/user-api/overlays/cnv-prod/kustomization.yaml
@@ -37,7 +37,7 @@ patchesJson6902:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role
-      name: backend-pods-info
+      name: user-api-pods-info
   - path: put-into-middletier-namespace.yaml
     target:
       group: rbac.authorization.k8s.io

--- a/user-api/overlays/cnv-prod/role-binding.yaml
+++ b/user-api/overlays/cnv-prod/role-binding.yaml
@@ -21,7 +21,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: backend-pods-info
+  name: user-api-pods-info
 subjects:
   - kind: ServiceAccount
     name: user-api

--- a/user-api/overlays/ocp4-stage/kustomization.yaml
+++ b/user-api/overlays/ocp4-stage/kustomization.yaml
@@ -44,7 +44,7 @@ patchesJson6902:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role
-      name: user-api-pods-info
+      name: middletier-pods-info
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/user-api/overlays/ocp4-stage/role-binding.yaml
+++ b/user-api/overlays/ocp4-stage/role-binding.yaml
@@ -35,7 +35,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: user-api-pods-info
+  name: middletier-pods-info
 subjects:
   - kind: ServiceAccount
     name: user-api


### PR DESCRIPTION
correct the role name for user-api pods log access
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #1244 

## Description

sorry, I forgot to fix this in the #1244.