### PR TITLE
Fix accessing pod log from amun namespace by management-api in stage

### DIFF
--- a/management-api/overlays/ocp4-stage/kustomization.yaml
+++ b/management-api/overlays/ocp4-stage/kustomization.yaml
@@ -31,7 +31,7 @@ patchesJson6902:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role
-      name: management-api-pods-info
+      name: management-api-amun-pods-info
   - path: put-into-middletier-namespace.yaml
     target:
       group: rbac.authorization.k8s.io

--- a/management-api/overlays/ocp4-stage/role-binding.yaml
+++ b/management-api/overlays/ocp4-stage/role-binding.yaml
@@ -63,7 +63,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: management-api-pods-info
+  name: management-api-amun-pods-info
 subjects:
   - kind: ServiceAccount
     name: management-api


### PR DESCRIPTION
Fix accessing pod log from amun namespace by management-api in stage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #1243 

## Description

sorry, missed this in the #1243 