### PR TITLE
Bump workflow helpers to v0.8.0 to fix provenance workflow

### DIFF
--- a/core/overlays/cnv-prod/common/imagestreamtags.yaml
+++ b/core/overlays/cnv-prod/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.7.1
+      name: quay.io/thoth-station/workflow-helpers:v0.8.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.7.1
+      name: quay.io/thoth-station/workflow-helpers:v0.8.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/test/imagestreamtags.yaml
+++ b/core/overlays/test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.7.1
+        name: quay.io/thoth-station/workflow-helpers:v0.8.0
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/core/overlays/zero-test/imagestreamtags.yaml
+++ b/core/overlays/zero-test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.7.1
+        name: quay.io/thoth-station/workflow-helpers:v0.8.0
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/1231
