### PR TITLE
set the workflow template in the inspection namespace

### DIFF
--- a/amun/overlays/ocp4-stage/amun-api/kustomization.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/kustomization.yaml
@@ -95,6 +95,12 @@ patchesJson6902:
       name: send-messages
   - path: put-into-inspection-namespace.yaml
     target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: create-inspection-complete-message
+  - path: put-into-inspection-namespace.yaml
+    target:
       group: ""
       version: v1
       kind: ServiceAccount


### PR DESCRIPTION
set the workflow template in the inspection namespace
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

```
invalid spec: templates.main.tasks.create-inspection-complete-message template reference create-inspection-complete-message.create-inspection-complete-message not found
```
