### PR TITLE
Supply Prometheus URL to CVE update job

### DIFF
--- a/cve-update/base/cronjob.yaml
+++ b/cve-update/base/cronjob.yaml
@@ -45,6 +45,11 @@ spec:
                     secretKeyRef:
                       name: thoth
                       key: sentry-dsn
+                - name: PROMETHEUS_PUSHGATEWAY_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: prometheus
+                      key: pushgateway-url
                 - name: THOTH_DEPLOYMENT_NAME
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/cve-update-job/pull/410
