### PR TITLE
Reduce the cpu limit for metrics-exporter

### DIFF
--- a/metrics-exporter/overlays/cnv-prod/resources_patch.yaml
+++ b/metrics-exporter/overlays/cnv-prod/resources_patch.yaml
@@ -3,7 +3,7 @@
   value:
     requests:
       memory: "384Mi"
-      cpu: "1"
+      cpu: "100m"
     limits:
       memory: "768Mi"
-      cpu: "1"
+      cpu: "250m"


### PR DESCRIPTION
Reduce the cpu limit for metrics-exporter
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

![metrics-exporter](https://user-images.githubusercontent.com/14028058/121074691-343d6400-c7a2-11eb-8539-0d2acc6df979.png)

