### PR TITLE
Pass configured solvers in a deployment to adviser

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -167,6 +167,11 @@ spec:
             value: "advise"
           - name: THOTH_ADVISER_LIBRARY_USAGE
             value: "input/library_usage.json"
+          - name: THOTH_ADVISER_DEPLOYMENT_CONFIGURED_SOLVERS
+            valueFrom:
+              configMapKeyRef:
+                name: solvers
+                key: solvers
           - name: PROMETHEUS_PUSHGATEWAY_HOST
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/issues/1516

## Description

As discussed on the call, we can pass solvers to the adviser and let the adviser decide whether the given runtime environment has solvers enabled in the configmap. If they will not be present there, adviser can warn about the fact in a separate pipeline unit. This might be better to maintain than having two configuration entries for solvers enabled & solvers deprecated.
