### PR TITLE
Add increased timeout seconds

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -8,6 +8,7 @@ metadata:
     template: mi
 
 spec:
+  activeDeadlineSeconds: 3600
   serviceAccountName: argo
   entrypoint: mi-workflow
   templates:
@@ -94,5 +95,3 @@ spec:
             value: "."
           - name: THOTH_ADJUST_LOGGING
             value: "{{inputs.parameters.THOTH_ADJUST_LOGGING}}"
-        livenessProbe:
-          timeoutSeconds: 3600

--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -94,3 +94,5 @@ spec:
             value: "."
           - name: THOTH_ADJUST_LOGGING
             value: "{{inputs.parameters.THOTH_ADJUST_LOGGING}}"
+        livenessProbe:
+          timeoutSeconds: 3600


### PR DESCRIPTION
## Related Issues and Dependencies
None

## Does this require new deployment ?

- [X] Deployment for Test

## Description
`mi` workflows were suspended because the one that was running waited too long for GH API limit to be reset (which is once per hour).

This PR should extend the timeout time up to one hour
