### PR TITLE
Bump management-api to v0.17.3 in stage environment

### DIFF
--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.2
+      name: quay.io/thoth-station/management-api:v0.17.3
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Related: https://github.com/thoth-station/management-api/issues/777