### PR TITLE
Fix env variable breaking cronjob SLO reporter

### DIFF
--- a/slo-reporter/overlays/zero-prod-ocp4-stage/cronjob.yaml
+++ b/slo-reporter/overlays/zero-prod-ocp4-stage/cronjob.yaml
@@ -126,11 +126,6 @@ spec:
                     configMapKeyRef:
                       key: deployment-name
                       name: slo-reporter-stage-prod
-                - name: THOTH_LOGGING_NO_JSON
-                  valueFrom:
-                    configMapKeyRef:
-                      name: thoth
-                      key: logging-no-json
               livenessProbe:
                 failureThreshold: 1
                 initialDelaySeconds: 7200


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
Error: configmap "thoth" not found
```

## Description

Env variable was accidentally introduced by ??  and broke the SLO reporter that did not collect data from prod in the last week. I will retrigger it 7 days retrieval from Thanos, if available, to get data back.
