### PR TITLE
Set timeoute under the step specification

### DIFF
--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -8,7 +8,6 @@ metadata:
     template: mi
 
 spec:
-  activeDeadlineSeconds: 3600
   serviceAccountName: argo
   entrypoint: mi-workflow
   templates:
@@ -38,6 +37,7 @@ spec:
                   value: "{{inputs.parameters.MI_THOTH}}"
 
     - name: analyse
+      activeDeadlineSeconds: 3600
       synchronization:
         semaphore:
           configMapKeyRef:

--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -46,7 +46,7 @@ objects:
     spec:
       serviceAccountName: argo
       entrypoint: mi
-      activeDeadlineSeconds: 3000
+      activeDeadlineSeconds: 3600
       ttlStrategy:
         secondsAfterCompletion: 10
         secondsAfterSuccess: 10

--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -46,7 +46,6 @@ objects:
     spec:
       serviceAccountName: argo
       entrypoint: mi
-      activeDeadlineSeconds: 3600
       ttlStrategy:
         secondsAfterCompletion: 10
         secondsAfterSuccess: 10


### PR DESCRIPTION
## Related Issues and Dependencies
Related to #1641 

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description
Specify `activeDeadlineSeconds` under the `analyse` step, instead in general namespace
