### PR TITLE
deploy triage-party #1649

### DIFF
--- a/triage-party/overlays/zero-prod/kustomization.yaml
+++ b/triage-party/overlays/zero-prod/kustomization.yaml
@@ -6,10 +6,8 @@ resources:
 patchesStrategicMerge:
   - imagestreamtags.yaml
 configMapGenerator:
-  - name: config
+  - name: triage-party-config
     files:
       - config.yaml
 generatorOptions:
   disableNameSuffixHash: true
-generators:
-  - secret-generator.yaml

--- a/triage-party/overlays/zero-prod/kustomization.yaml
+++ b/triage-party/overlays/zero-prod/kustomization.yaml
@@ -11,3 +11,5 @@ configMapGenerator:
       - config.yaml
 generatorOptions:
   disableNameSuffixHash: true
+generators:
+  - secret-generator.yaml

--- a/triage-party/overlays/zero-prod/pcache.yaml
+++ b/triage-party/overlays/zero-prod/pcache.yaml
@@ -11,4 +11,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: openshift-storage.noobaa.io
+  storageClassName: ocs-storagecluster-cephfs


### PR DESCRIPTION
## Related Issues and Dependencies

Deployment failed because of incorrect storage type

## Does this require new deployment ?

- [ x ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

When manually deployed it failed because the storage instance was Ceph instead of noobaa.
