### PR TITLE
Bump adviser to v0.33.1 in prod environment

### DIFF
--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.31.0
+        name: quay.io/thoth-station/adviser:v0.33.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Let's bump adviser in prod environment. This is a hotfix for issues caused when `recommendation_type` is set to security https://github.com/thoth-station/adviser/pull/1905.
