### PR TITLE
Bump adviser to v0.33.2 in prod and stage environments

### DIFF
--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.31.0
+        name: quay.io/thoth-station/adviser:v0.33.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.33.1
+        name: quay.io/thoth-station/adviser:v0.33.2
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related hotfixes:

Related: https://github.com/thoth-station/adviser/pull/1913
Related: https://github.com/thoth-station/adviser/pull/1905
