### PR TITLE
Suspend prescription-sync-job in all deployments

### DIFF
--- a/prescription-sync-job/overlays/cnv-prod/cronjob.yaml
+++ b/prescription-sync-job/overlays/cnv-prod/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: prescription-sync
 spec:
-  suspend: false
+  suspend: true

--- a/prescription-sync-job/overlays/ocp4-stage/cronjob.yaml
+++ b/prescription-sync-job/overlays/ocp4-stage/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: prescription-sync
 spec:
-  suspend: false
+  suspend: true

--- a/prescription-sync-job/overlays/test/cronjob.yaml
+++ b/prescription-sync-job/overlays/test/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: prescription-sync
 spec:
-  suspend: false
+  suspend: true


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/prescription-sync-job/pull/7
Related: https://github.com/thoth-station/adviser/issues/1908
