### PR TITLE
Enable fedora34 python 3.9 data ingestion in prod

### DIFF
--- a/core/overlays/cnv-prod/common/configmaps.yaml
+++ b/core/overlays/cnv-prod/common/configmaps.yaml
@@ -39,6 +39,7 @@ metadata:
 data:
   solvers: |
     solver-rhel-8-py38
+    solver-fedora-34-py39
 ---
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
Enable fedora34 python 3.9 data ingestion in prod
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
