### PR TITLE
 set the required env vars for triage-party

### DIFF
--- a/triage-party/base/deployment.yaml
+++ b/triage-party/base/deployment.yaml
@@ -14,13 +14,17 @@ spec:
     spec:
       containers:
         - name: triage-party
-          image: triage-party
+          image: triage-party:latest
           env:
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: triage-party-github-token
                   key: token
+            - name: PERSIST_PATH
+              value: "/app/pcache"
+            - name: PERSIST_BACKEND
+              value: "disk"
           volumeMounts:
             - name: config
               mountPath: /app/config


### PR DESCRIPTION
 set the required env vars for triage-party
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/1649
