### PR TITLE
Disable prescriptions before adding prescriptions with dir structure

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -84,22 +84,6 @@ spec:
               secretKeySecret:
                 name: argo-artifact-repository-secrets
                 key: secretKey
-          - name: prescription
-            path: "/mnt/workdir/prescription.yaml"
-            archive:
-              none: {}
-            s3:
-              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
-                {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/prescription.yaml"
-              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
-              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
-              accessKeySecret:
-                name: argo-artifact-repository-secrets
-                key: accessKey
-              secretKeySecret:
-                name: argo-artifact-repository-secrets
-                key: secretKey
       outputs:
         artifacts:
           - name: outputdocument
@@ -141,8 +125,6 @@ spec:
             value: "{{inputs.parameters.THOTH_ADVISER_LIMIT}}"
           - name: THOTH_ADVISER_BLOCKED_UNITS
             value: "SecurityIndicatorStep"
-          - name: THOTH_ADVISER_PRESCRIPTION
-            value: "/mnt/workdir/prescription.yaml"
           - name: THOTH_ADVISER_REQUIREMENTS
             value: "input/Pipfile"
           - name: THOTH_ADVISER_REQUIREMENTS_LOCKED


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/pull/1695/

As new prescriptions with directory structure are not backwards compatible with old, single file, prescriptions, let's disable old ones. Once the transition is made, we can enable prescriptions with directory structure https://github.com/thoth-station/thoth-application/pull/1695/.