### PR TITLE
Bump metrics-exporter to v0.15.0

### DIFF
--- a/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.14.6
+        name: quay.io/thoth-station/metrics-exporter:v0.15.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.14.6
+        name: quay.io/thoth-station/metrics-exporter:v0.15.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>


## Does this require new deployment ?

- [x] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

New metrics exporter with metric on number of CVE.
