### PR TITLE
Make prescriptions v0.0.1 available in stage and prod environments

### DIFF
--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions:v0.0.0
+        name: quay.io/thoth-station/prescriptions:v0.0.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions:v0.0.0
+        name: quay.io/thoth-station/prescriptions:v0.0.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/prescriptions/pull/31

## Description

v0.0.0 does not exist, let's start using v0.0.1 in deployments.
