### PR TITLE
Bump graph-sync-job to v0.10.9 in prod environment

### DIFF
--- a/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.8
+        name: quay.io/thoth-station/graph-sync-job:v0.10.9
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/storages/issues/2355
