### PR TITLE
Make repository parameter not required

### DIFF
--- a/mi-scheduler/base/openshift-templates/mi-run-template.yaml
+++ b/mi-scheduler/base/openshift-templates/mi-run-template.yaml
@@ -9,7 +9,6 @@ metadata:
 
 parameters:
   - name: REPOSITORY
-    required: true
     description: GitHub repository whose Health Indicator will be computed
     displayName: inspected GitHub repository
 


### PR DESCRIPTION
## Related Issues and Dependencies
Related to #1723 

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

Repository parameter is not optional, when using `mi` for data merge action
