### PR TITLE
Add missing template for Kebechet administrator

### DIFF
--- a/kebechet/overlays/cnv-prod/kustomization.yaml
+++ b/kebechet/overlays/cnv-prod/kustomization.yaml
@@ -33,6 +33,12 @@ patchesJson6902:
       version: v1
       kind: Template
       name: kebechet-run-url
+  - path: put-into-infra-namespace.yaml
+    target:
+      group: template.openshift.io
+      version: v1
+      kind: Template
+      name: kebechet-administrator
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/kebechet/overlays/ocp4-stage/kustomization.yaml
+++ b/kebechet/overlays/ocp4-stage/kustomization.yaml
@@ -33,6 +33,12 @@ patchesJson6902:
       version: v1
       kind: Template
       name: kebechet-run-url
+  - path: put-into-infra-namespace.yaml
+    target:
+      group: template.openshift.io
+      version: v1
+      kind: Template
+      name: kebechet-administrator
 generatorOptions:
   disableNameSuffixHash: true
 generators:


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
{"name": "__main__", "levelname": "WARNING", "module": "consumer", "lineno": 197, "funcname": "_worker", "created": 1624273232.1878748, "asctime": "2021-06-21 11:00:32,187", "msecs": 187.87479400634766, "relative_created": 114727.7638912201, "process": 1, "message": "Application misconfiguration - number of templates available in namespace 'thoth-infra-prod' is 0, should be 1: label selector: 'template=kebechet-administrator', name: None"}
```

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

Missing template in thoth-infra namespaces
