### PR TITLE
Add latest tags to cronjobs

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -20,9 +20,7 @@ spec:
         spec:
           serviceAccount: mi-scheduler
           containers:
-            - image: mi-scheduler
-              tags:
-                - name: latest
+            - image: mi-scheduler:latest
               name: mi-scheduler
               resources:
                 limits:

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -157,9 +157,7 @@ spec:
           serviceAccount: mi-scheduler
           containers:
             - image: mi-scheduler
-              name: mi-scheduler
-              tags:
-                - name: latest
+              name: mi-scheduler:latest
               resources:
                 limits:
                   cpu: 256m

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -21,6 +21,8 @@ spec:
           serviceAccount: mi-scheduler
           containers:
             - image: mi-scheduler
+              tags:
+                - name: latest
               name: mi-scheduler
               resources:
                 limits:
@@ -78,6 +80,8 @@ spec:
           containers:
             - image: mi-scheduler
               name: mi-scheduler
+              tags:
+                - name: latest
               resources:
                 limits:
                   cpu: 256m
@@ -158,6 +162,8 @@ spec:
           containers:
             - image: mi-scheduler
               name: mi-scheduler
+              tags:
+                - name: latest
               resources:
                 limits:
                   cpu: 256m

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -77,9 +77,7 @@ spec:
           serviceAccount: mi-scheduler
           containers:
             - image: mi-scheduler
-              name: mi-scheduler
-              tags:
-                - name: latest
+              name: mi-scheduler:latest
               resources:
                 limits:
                   cpu: 256m


### PR DESCRIPTION
## Related Issues and Dependencies
None

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

Cronjobs does not use the latest deployments, therefore it is now explicitly specified
