### PR TITLE
Bump metrics-expoter to v0.16.0

### DIFF
--- a/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.15.0
+        name: quay.io/thoth-station/metrics-exporter:v0.16.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.15.0
+        name: quay.io/thoth-station/metrics-exporter:v0.16.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/metrics-exporter/issues/704

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

The new release is without long running queries, moved to graph-metrics-exporter component, this will avoid issues previously encountered.
