### PR TITLE
fix of the volume usage in the workflow

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -4,9 +4,11 @@ kind: WorkflowTemplate
 metadata:
   name: advise
 spec:
+  volumes:
+    - name: prescriptions
+      emptyDir: {}
   templates:
     - name: advise
-
       metrics:
         prometheus:
           - name: task_status_counter
@@ -105,7 +107,7 @@ spec:
                 key: secretKey
       initContainers:
         - name: prescriptions
-          image: prescriptions
+          image: prescriptions:latest
           command:
             - /bin/sh
             - -c
@@ -113,7 +115,7 @@ spec:
           mirrorVolumeMounts: true
       container:
         name: advise
-        image: adviser
+        image: adviser:latest
         env:
           - name: THOTH_DOCUMENT_ID
             value: "{{inputs.parameters.THOTH_DOCUMENT_ID}}"
@@ -224,9 +226,6 @@ spec:
             mountPath: /mnt/workdir
           - name: prescriptions
             mountPath: /mnt/prescriptions
-        volumes:
-          - name: prescriptions
-            emptyDir: {}
         resources:
           limits:
             cpu: 1.1


### PR DESCRIPTION
fix of the volume usage in the workflow
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies
```
time="2021-06-22T14:47:59.753Z" level=info msg="
DAG adviser-210622144758-3c1f7e02554603e-3173750276 deemed errored due to task 
adviser-210622144758-3c1f7e02554603e.advise error: volume 'prescriptions' not found in workflow spec" 
namespace=thoth-backend-prod workflow=adviser-210622144758-3c1f7e02554603e
```

## Description

volume description lives on the same indentation level as template in workflow
Reference: https://github.com/argoproj/argo-workflows/blob/master/examples/volumes-emptydir.yaml
