### PR TITLE
Decrease TTL to 300 for pods

### DIFF
--- a/adviser/base/openshift-templates/adviser.yaml
+++ b/adviser/base/openshift-templates/adviser.yaml
@@ -93,9 +93,9 @@ objects:
       serviceAccountName: argo
       activeDeadlineSeconds: 3000
       ttlStrategy:
-        secondsAfterCompletion: 1800
-        secondsAfterSuccess: 1800
-        secondsAfterFailure: 1800
+        secondsAfterCompletion: 300
+        secondsAfterSuccess: 300
+        secondsAfterFailure: 300
       entrypoint: adviser
 
       metrics:

--- a/package-extract/base/openshift-templates/package-extract.yaml
+++ b/package-extract/base/openshift-templates/package-extract.yaml
@@ -60,9 +60,9 @@ objects:
       serviceAccountName: argo
       activeDeadlineSeconds: 3000
       ttlStrategy:
-        secondsAfterCompletion: 7200
-        secondsAfterSuccess: 7200
-        secondsAfterFailure: 7200
+        secondsAfterCompletion: 300
+        secondsAfterSuccess: 300
+        secondsAfterFailure: 300
       entrypoint: package-extract
       arguments:
         parameters:


### PR DESCRIPTION
## Related Issues and Dependencies

As we keep logs on Ceph, we can decrease TTL and cleanup pods sooner.

Related: https://github.com/thoth-station/thoth-application/issues/325
