### PR TITLE
bump graph-metrics-exporter to v0.5.1

### DIFF
--- a/graph-metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.4.1
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.1
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.4.1
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.1
       importPolicy: {}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Metrics pushed to pushgateway have environment in labels 

