### PR TITLE
pause the data ingestion for the storage issue

### DIFF
--- a/graph-refresh/overlays/cnv-prod/cronjob.yaml
+++ b/graph-refresh/overlays/cnv-prod/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: graph-refresh
 spec:
   schedule: "0 */1 * * *"
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4

--- a/package-releases/overlays/cnv-prod/cronjob.yaml
+++ b/package-releases/overlays/cnv-prod/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: package-releases
 spec:
   schedule: "0 */12 * * *"
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   startingDeadlineSeconds: null

--- a/package-update/overlays/cnv-prod/cronjob.yaml
+++ b/package-update/overlays/cnv-prod/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: package-update
 spec:
   schedule: "0 */12 * * *"
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/1766

## Description

pause the data ingestion for the storage issue
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Due to the old storage module, the older sync job don't have the capability to update the dependsOn table in database.
This is to fix that in the storage and update other modules.
Till then we should pause the ingestion.