### PR TITLE
Bump package-extract to v1.2.0 in stage environment

### DIFF
--- a/package-extract/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-extract/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/package-extract:v1.1.2"
+        name: "quay.io/thoth-station/package-extract:v1.2.0"
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/package-extract/pull/454
