### PR TITLE
Add thoth deployment name envvar from thoth configmap

### DIFF
--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -43,6 +43,11 @@ spec:
                     configMapKeyRef:
                       name: thoth
                       key: infra-namespace
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: deployment-name
                 - name: GITHUB_ACCESS_TOKEN
                   valueFrom:
                     secretKeyRef:
@@ -98,6 +103,11 @@ spec:
                     configMapKeyRef:
                       name: thoth
                       key: infra-namespace
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: deployment-name
                 - name: KNOWLEDGE_GRAPH_HOST
                   valueFrom:
                     configMapKeyRef:
@@ -178,6 +188,11 @@ spec:
                     configMapKeyRef:
                       name: thoth
                       key: infra-namespace
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: deployment-name
                 - name: KNOWLEDGE_GRAPH_HOST
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/mi-scheduler/pull/156

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.
