### PR TITLE
Bump mng-api v0.17.6

### DIFF
--- a/management-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/management-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.5
+      name: quay.io/thoth-station/management-api:v0.17.6
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.5
+      name: quay.io/thoth-station/management-api:v0.17.6
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

See: https://github.com/thoth-station/thoth-application/issues/1792

