### PR TITLE
update mi-scheduler to the newest v1.6.1 version

### DIFF
--- a/mi-scheduler/overlays/zero-test/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/zero-test/imagestreamtag.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/mi-scheduler:v1.5.0
+        name: quay.io/thoth-station/mi-scheduler:v1.6.1
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
SSIA

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.


