### PR TITLE
feat: Enable override to bypass failing CI if necessary

### DIFF
--- a/prow/overlays/cnv-prod/plugins.yaml
+++ b/prow/overlays/cnv-prod/plugins.yaml
@@ -146,6 +146,7 @@ plugins:
       - label
       - lgtm
       - lifecycle
+      - override
       - shrug
       - size
       - trigger
@@ -182,6 +183,7 @@ plugins:
       - label
       - lgtm
       - lifecycle
+      - override
       - size
       - trigger
       - verify-owners
@@ -197,6 +199,7 @@ plugins:
       - label
       - lgtm
       - lifecycle
+      - override
       - size
       - trigger
       - verify-owners


### PR DESCRIPTION
As seen on https://github.com/operate-first/common/pull/7 sometimes it's necessary to override CI tests. This plugins helps maintainers with that.

https://prow.operate-first.cloud/command-help#override