### PR TITLE
feat: Enable tide on meteor and require approved on common

### DIFF
--- a/prow/overlays/cnv-prod/config.yaml
+++ b/prow/overlays/cnv-prod/config.yaml
@@ -218,7 +218,6 @@ tide:
         - AICoE/aicoe-cd
         - AICoE/aicoe-ci
         - AICoE/aicoe-sre
-        - AICoE/common
         - AICoE/elyra-aidevsecops-tutorial
         - AICoE/idh-manifests
         - AICoE/internal-data-hub
@@ -229,6 +228,18 @@ tide:
         - AICoE/Varangian
       labels:
         - approved
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - AICoE/common
+        - AICoE/meteor
+      labels:
+        - approved
+        - lgtm
       missingLabels:
         - do-not-merge
         - do-not-merge/hold


### PR DESCRIPTION
Seems like Tide was not enabled in AICoE/meteor repo https://github.com/AICoE/meteor/pull/39

This is fixing it. Also switches for meteor and common repo to requiring both `lgtm` and `approved` labels.