### PR TITLE
Add operate-first as an organization

### DIFF
--- a/mi-scheduler/base/configmaps.yaml
+++ b/mi-scheduler/base/configmaps.yaml
@@ -6,5 +6,5 @@ metadata:
 data:
   entities: "PullRequest,Issue"
   repositories: "openshift/origin"
-  organizations: "thoth-station,AICoE,aicoe-aiops"
+  organizations: "thoth-station,AICoE,aicoe-aiops,operate-first"
   parallel-workflows-limit: "1"


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/mi-scheduler/issues/155

## Does this require new deployment ?

- [X] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

