### PR TITLE
Bump metric-exporter to v0.17.0

### DIFF
--- a/grafana-dashboard/overlays/cnv-prod/thoth-knowledge-graph-content-metrics.json
+++ b/grafana-dashboard/overlays/cnv-prod/thoth-knowledge-graph-content-metrics.json
@@ -4484,7 +4484,7 @@
             "value": "metrics-exporter-thoth-infra-prod.apps.zero.massopen.cloud:80"
           }
         ],
-        "query": "metrics-exporter-thoth-infra-prod.apps.zero.massopen.cloud:80,open.cloud:80",
+        "query": "metrics-exporter-thoth-infra-prod.apps.zero.massopen.cloud:80",
         "type": "custom"
       }
     ]

--- a/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.16.3
+        name: quay.io/thoth-station/metrics-exporter:v0.17.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.16.3
+        name: quay.io/thoth-station/metrics-exporter:v0.17.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Description

- new metrics for kebechet users per manager
- logic to not collect metrics if schema is not update
