### PR TITLE
Bump up the version of thoth station for v2021.08.02 release

### DIFF
--- a/advise-reporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/advise-reporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.10.2
+      name: quay.io/thoth-station/advise-reporter:v0.10.3
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/advise-reporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/advise-reporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.10.2
+      name: quay.io/thoth-station/advise-reporter:v0.10.3
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.36.0
+        name: quay.io/thoth-station/adviser:v0.38.1
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions:v0.2.0
+        name: quay.io/thoth-station/prescriptions:v0.5.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/test/imagestreamtag.yaml
+++ b/adviser/overlays/test/imagestreamtag.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions:v0.4.0
+        name: quay.io/thoth-station/prescriptions:v0.5.1
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/core/overlays/cnv-prod/common/imagestreamtags.yaml
+++ b/core/overlays/cnv-prod/common/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.14.0
+      name: quay.io/thoth-station/investigator:v0.15.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.13.1
+      name: quay.io/thoth-station/investigator:v0.15.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/test/imagestreamtags.yaml
+++ b/core/overlays/test/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.14.1
+        name: quay.io/thoth-station/investigator:v0.15.0
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/core/overlays/zero-test/imagestreamtags.yaml
+++ b/core/overlays/zero-test/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.13.1
+        name: quay.io/thoth-station/investigator:v0.15.0
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/cve-update/overlays/cnv-prod/imagestreamtag.yaml
+++ b/cve-update/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.3.0
+        name: quay.io/thoth-station/cve-update-job:v0.3.1
       importPolicy: {}

--- a/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.3.0
+        name: quay.io/thoth-station/cve-update-job:v0.3.1
       importPolicy: {}

--- a/graph-backup-job/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.5
+        name: quay.io/thoth-station/graph-backup-job:v0.8.6
       importPolicy: {}

--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.5
+        name: quay.io/thoth-station/graph-backup-job:v0.8.6
       importPolicy: {}

--- a/graph-backup-job/overlays/test/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.5
+        name: quay.io/thoth-station/graph-backup-job:v0.8.6
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/graph-metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.2
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.3
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.2
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.3
       importPolicy: {}

--- a/graph-refresh/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-refresh/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.11
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.12
       importPolicy: {}

--- a/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.11
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.12
       importPolicy: {}

--- a/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.11
+        name: quay.io/thoth-station/graph-sync-job:v0.10.12
       importPolicy: {}

--- a/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.11
+        name: quay.io/thoth-station/graph-sync-job:v0.10.12
       importPolicy: {}

--- a/kebechet/overlays/cnv-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.2.4
+        name: quay.io/thoth-station/kebechet-job:v1.4.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.3.2
+        name: quay.io/thoth-station/kebechet-job:v1.4.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.18.0
+        name: quay.io/thoth-station/metrics-exporter:v0.18.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.18.0
+        name: quay.io/thoth-station/metrics-exporter:v0.18.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/test/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.18.0
+        name: quay.io/thoth-station/metrics-exporter:v0.18.1
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/package-releases/overlays/cnv-prod/imagestreamtag.yaml
+++ b/package-releases/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.9.2
+        name: quay.io/thoth-station/package-releases-job:v0.10.1
       importPolicy: {}

--- a/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.9.2
+        name: quay.io/thoth-station/package-releases-job:v0.10.1
       importPolicy: {}

--- a/package-update/overlays/cnv-prod/imagestreamtag.yaml
+++ b/package-update/overlays/cnv-prod/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.10
+        name: quay.io/thoth-station/package-update-job:v0.8.11
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.9
+        name: quay.io/thoth-station/package-update-job:v0.8.11
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/revsolver/overlays/cnv-prod/imagestreamtag.yaml
+++ b/revsolver/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/revsolver:v0.2.6"
+        name: "quay.io/thoth-station/revsolver:v0.2.7"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/revsolver/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/revsolver/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/revsolver:v0.2.6"
+        name: "quay.io/thoth-station/revsolver:v0.2.7"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/slo-reporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/slo-reporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.16.0
+        name: quay.io/thoth-station/slo-reporter:v0.16.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/slo-reporter/overlays/zero-prod-ocp4-stage/imagestreamtag.yaml
+++ b/slo-reporter/overlays/zero-prod-ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.16.0
+        name: quay.io/thoth-station/slo-reporter:v0.16.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/solver/overlays/cnv-prod/imagestreamtag.yaml
+++ b/solver/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.10.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.10.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -36,7 +36,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-32-py38:v1.10.1"
+        name: "quay.io/thoth-station/solver-fedora-32-py38:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -50,7 +50,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.10.1"
+        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/solver/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/solver/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.10.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.10.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -36,7 +36,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-32-py38:v1.10.1"
+        name: "quay.io/thoth-station/solver-fedora-32-py38:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -50,7 +50,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.10.1"
+        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.10.2"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/cnv-prod/imagestreamtag.yaml
+++ b/user-api/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.26.5
+        name: quay.io/thoth-station/user-api:v0.26.7
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.26.5
+        name: quay.io/thoth-station/user-api:v0.26.7
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up the version of thoth station for v2021.08.02 release
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to:  https://github.com/thoth-station/thoth-application/issues/1849
Fixes: https://github.com/thoth-station/thoth-application/issues/1792 

## Description

This is the release update of the thoth-station