### PR TITLE
patch back the stable version 1.2.4

### DIFF
--- a/kebechet/overlays/cnv-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.4.0
+        name: quay.io/thoth-station/kebechet-job:v1.2.4
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
patch back the stable version 1.2.4
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/kebechet/issues/774


## Description

revert the stable version 