### PR TITLE
Bump management-api to v0.17.9 in stage

### DIFF
--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.8
+      name: quay.io/thoth-station/management-api:v0.17.9
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/issues/1872
