### PR TITLE
Bump investigator to v0.14.2 to fix bugs

### DIFF
--- a/core/overlays/cnv-prod/common/imagestreamtags.yaml
+++ b/core/overlays/cnv-prod/common/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.14.0
+      name: quay.io/thoth-station/investigator:v0.14.2
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

This should allow scheduling adviser again. Current errors, solved in v0.14.1:

```
{"name": "__main__", "levelname": "WARNING", "module": "consumer", "lineno": 196, "funcname": "_worker", "created": 1629184645.1864533, "asctime": "2021-08-17 07:17:25,186", "msecs": 186.45334243774414, "relative_created": 1078239.2547130585, "process": 1, "message": "schedule_adviser() got an unexpected keyword argument 'github_event_type'"}
```
