### PR TITLE
Bump graph-sync to v0.10.13 in stage environment

### DIFF
--- a/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.12
+        name: quay.io/thoth-station/graph-sync-job:v0.10.13
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/storages/pull/2420
Related: https://github.com/thoth-station/graph-sync-job/issues/610