### PR TITLE
Increase package-releases deadline to 4 hours

### DIFF
--- a/package-releases/base/cronjob.yaml
+++ b/package-releases/base/cronjob.yaml
@@ -113,8 +113,8 @@ spec:
                   cpu: "500m"
               livenessProbe:
                 failureThreshold: 1
-                # Give this job 2 hours to finish
-                initialDelaySeconds: 7200
+                # Give this job 4 hours to finish
+                initialDelaySeconds: 14400
                 periodSeconds: 10
                 tcpSocket:
                   port: 80


### PR DESCRIPTION
## Related Issues and Dependencies

It looks like we require more time to check all the packages that we monitor.
