### PR TITLE
Branch workflow with more resources if solver fails

### DIFF
--- a/solver/base/argo-workflows/solver-template.yaml
+++ b/solver/base/argo-workflows/solver-template.yaml
@@ -39,8 +39,6 @@ spec:
               value: "{{duration}}"
 
       resubmitPendingPods: true
-      retryStrategy:
-        limit: 2
       inputs:
         parameters:
           - name: "THOTH_SOLVER_NAME"
@@ -119,3 +117,119 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+
+    # This template is the same as the previous one, except
+    # for resources allocated. It is used in cases when packages
+    # are compiled and the default workflow fails.
+    - name: solve-res
+
+      metrics:
+        prometheus:
+          - name: task_status_counter
+            help: "Count of workflow task by status"
+            labels:
+              - key: name
+                value: solver
+              - key: status
+                value: "{{status}}"
+            counter:
+              value: "1"
+
+          - name: task_duration_seconds_histogram
+            help: "Duration of workflow task when succeded"
+            when: "{{status}} == Succeeded"
+            labels:
+              - key: name
+                value: solver
+            histogram:
+              buckets:
+                - 5
+                - 10
+                - 30
+                - 60
+                - 120
+                - 180
+                - 300
+                - 600
+                - 900
+              value: "{{duration}}"
+
+      resubmitPendingPods: true
+      inputs:
+        parameters:
+          - name: "THOTH_SOLVER_NAME"
+          - name: "THOTH_SOLVER_DOCUMENT_ID"
+          - name: "THOTH_LOG_SOLVER"
+          - name: "THOTH_SOLVER_NO_TRANSITIVE"
+          - name: "THOTH_SOLVER_PACKAGES"
+          - name: "THOTH_SOLVER_INDEXES"
+          - name: "THOTH_S3_ENDPOINT_URL"
+          - name: "THOTH_CEPH_BUCKET_NAME"
+          - name: "THOTH_CEPH_BUCKET_PREFIX"
+          - name: "THOTH_DEPLOYMENT_NAME"
+      outputs:
+        artifacts:
+          - name: outputdocument
+            path: "/mnt/workdir/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
+            archive:
+              none: {}
+            s3:
+              key: "{{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/\
+                {{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/\
+                solver/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
+              endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
+              bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
+              insecure: true
+              accessKeySecret:
+                name: argo-artifact-repository-secrets
+                key: accessKey
+              secretKeySecret:
+                name: argo-artifact-repository-secrets
+                key: secretKey
+      container:
+        name: solver
+        image: "{{inputs.parameters.THOTH_SOLVER_NAME}}"
+        env:
+          - name: THOTH_SOLVER
+            value: "{{inputs.parameters.THOTH_SOLVER_NAME}}"
+          - name: THOTH_SOLVER_RAISE_ON_SYSTEM_EXIT_CODES
+            value: "1"
+          - name: THOTH_SOLVER_VIRTUALENV
+            value: "/opt/app-root/src/solver-venv"
+          - name: THOTH_LOG_SOLVER
+            value: "{{inputs.parameters.THOTH_LOG_SOLVER}}"
+          - name: THOTH_SOLVER_NO_TRANSITIVE
+            value: "{{inputs.parameters.THOTH_SOLVER_NO_TRANSITIVE}}"
+          - name: THOTH_SOLVER_PACKAGES
+            value: "{{inputs.parameters.THOTH_SOLVER_PACKAGES}}"
+          - name: THOTH_SOLVER_OUTPUT
+            value: "/mnt/workdir/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
+          - name: THOTH_SOLVER_INDEXES
+            value: "{{inputs.parameters.THOTH_SOLVER_INDEXES}}"
+          - name: "THOTH_DOCUMENT_ID"
+            value: "{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
+          - name: THOTH_DEPLOYMENT_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: deployment-name
+                name: thoth
+          - name: THOTH_LOGGING_NO_JSON
+            valueFrom:
+              configMapKeyRef:
+                name: thoth
+                key: logging-no-json
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: thoth
+                key: sentry-dsn
+        volumeMounts:
+          - name: workdir
+            mountPath: /mnt/workdir
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 1
+            memory: 2Gi

--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -79,7 +79,7 @@ objects:
 
           - name: duration_seconds_histogram
             help: "Duration of workflow when succeded"
-            when: "{{workflow.status}} == Succeeded"
+            when: "({{workflow.status}}) == Succeeded"
             labels:
               - key: name
                 value: solver
@@ -143,6 +143,8 @@ objects:
                 templateRef:
                   name: "solver-any"
                   template: "solve"
+                continueOn:
+                  failed: true
                 arguments:
                   parameters:
                     - name: "THOTH_SOLVER_NAME"
@@ -169,6 +171,7 @@ objects:
               - name: "graph-sync-solverany"
                 dependencies:
                   - "solverany"
+                when: "({{tasks.solverany.status}}) == Succeeded"
                 templateRef:
                   name: "graph-sync"
                   template: "graph-sync"
@@ -185,6 +188,7 @@ objects:
               - name: "parse-solver-output"
                 dependencies:
                   - "graph-sync-solverany"
+                when: "({{tasks.solverany.status}}) == Succeeded"
                 templateRef:
                   name: "parse-solver-output"
                   template: "parse-solver-output"
@@ -201,6 +205,7 @@ objects:
               - name: "send-messages"
                 dependencies:
                   - "parse-solver-output"
+                when: "({{tasks.solverany.status}}) == Succeeded"
                 templateRef:
                   name: "send-messages"
                   template: "send-messages"
@@ -208,6 +213,94 @@ objects:
                   artifacts:
                     - name: messagesdocument
                       from: "{{tasks.parse-solver-output.outputs.artifacts.messagestobesentdocument}}"
+                  parameters:
+                    - name: THOTH_MESSAGING_FROM_FILE
+                      value: "/mnt/workdir/messages_to_be_sent.json"
+                    - name: THOTH_DEPLOYMENT_NAME
+                      value: "{{workflow.parameters.deployment_name}}"
+                    - name: THOTH_MESSAGING_CREATE_IF_NOT_EXIST
+                      value: "1"
+                    - name: MESSAGES_DOCUMENT_NAME
+                      value: "messages_to_be_sent.json"
+
+              # Workflow path if the solver fails to solve packages with less resources allocated.
+              - name: "solverany-res"
+                dependencies:
+                  - "solverany"
+                when: "({{tasks.solverany.status}}) == Failed"
+                templateRef:
+                  name: "solver-any"
+                  template: "solve-res"
+                continueOn:
+                  failed: false
+                arguments:
+                  parameters:
+                    - name: "THOTH_SOLVER_NAME"
+                      value: "{{workflow.parameters.THOTH_SOLVER_NAME}}"
+                    - name: "THOTH_SOLVER_DOCUMENT_ID"
+                      value: "{{workflow.parameters.THOTH_SOLVER_WORKFLOW_ID}}"
+                    - name: "THOTH_LOG_SOLVER"
+                      value: "{{workflow.parameters.THOTH_LOG_SOLVER}}"
+                    - name: "THOTH_SOLVER_NO_TRANSITIVE"
+                      value: "{{workflow.parameters.THOTH_SOLVER_NO_TRANSITIVE}}"
+                    - name: "THOTH_SOLVER_PACKAGES"
+                      value: "{{workflow.parameters.THOTH_SOLVER_PACKAGES}}"
+                    - name: "THOTH_SOLVER_INDEXES"
+                      value: "{{workflow.parameters.THOTH_SOLVER_INDEXES}}"
+                    - name: "THOTH_S3_ENDPOINT_URL"
+                      value: "{{workflow.parameters.ceph_host}}"
+                    - name: "THOTH_CEPH_BUCKET_NAME"
+                      value: "{{workflow.parameters.ceph_bucket_name}}"
+                    - name: "THOTH_CEPH_BUCKET_PREFIX"
+                      value: "{{workflow.parameters.ceph_bucket_prefix}}"
+                    - name: "THOTH_DEPLOYMENT_NAME"
+                      value: "{{workflow.parameters.deployment_name}}"
+
+              - name: "graph-sync-solverany-res"
+                dependencies:
+                  - "solverany-res"
+                when: "({{tasks.solverany.status}}) == Failed"
+                templateRef:
+                  name: "graph-sync"
+                  template: "graph-sync"
+                arguments:
+                  artifacts:
+                    - name: outputdocument
+                      from: "{{tasks.solverany-res.outputs.artifacts.outputdocument}}"
+                  parameters:
+                    - name: "THOTH_DOCUMENT_ID"
+                      value: "{{workflow.parameters.THOTH_SOLVER_WORKFLOW_ID}}"
+                    - name: "THOTH_FORCE_SYNC"
+                      value: "{{workflow.parameters.THOTH_FORCE_SYNC}}"
+
+              - name: "parse-solver-output-res"
+                dependencies:
+                  - "graph-sync-solverany-res"
+                when: "({{tasks.solverany.status}}) == Failed"
+                templateRef:
+                  name: "parse-solver-output"
+                  template: "parse-solver-output"
+                arguments:
+                  artifacts:
+                    - name: outputdocument
+                      from: "{{tasks.solverany-res.outputs.artifacts.outputdocument}}"
+                  parameters:
+                    - name: "THOTH_DOCUMENT_ID"
+                      value: "{{workflow.parameters.THOTH_SOLVER_WORKFLOW_ID}}"
+                    - name: "THOTH_SOLVER_NAME"
+                      value: "{{workflow.parameters.THOTH_SOLVER_NAME}}"
+
+              - name: "send-messages-res"
+                dependencies:
+                  - "parse-solver-output-res"
+                when: "({{tasks.solverany.status}}) == Failed"
+                templateRef:
+                  name: "send-messages"
+                  template: "send-messages"
+                arguments:
+                  artifacts:
+                    - name: messagesdocument
+                      from: "{{tasks.parse-solver-output-res.outputs.artifacts.messagestobesentdocument}}"
                   parameters:
                     - name: THOTH_MESSAGING_FROM_FILE
                       value: "/mnt/workdir/messages_to_be_sent.json"


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/1892

## Description

Implement a new branch of the solver workflow that will retry solver with more resources when solver fails. The solver might fail due to not enough resources needed when compiling packages from the source.

Sadly Argo does not support parametrizing resources. Also, using anchors and YAML aliases just complicated things. If anyone has a better solution not to copy-paste parts of the workflow, suggestions are welcome.
