### PR TITLE
bump graph-backup to v0.8.7 to fix issue

### DIFF
--- a/graph-backup-job/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.6
+        name: quay.io/thoth-station/graph-backup-job:v0.8.7
       importPolicy: {}

--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.6
+        name: quay.io/thoth-station/graph-backup-job:v0.8.7
       importPolicy: {}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Related-To: https://github.com/thoth-station/graph-backup-job/issues/180
