### PR TITLE
Bump package-releases-job to v0.11.0 in stage environment

### DIFF
--- a/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.10.1
+        name: quay.io/thoth-station/package-releases-job:v0.11.0
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/package-releases-job/issues/589
