### PR TITLE
Bump integration-tests to v0.8.5 in all the environments

### DIFF
--- a/integration-tests/overlays/cnv-prod-ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.8.4
+        name: quay.io/thoth-station/integration-tests:v0.8.5
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.8.3
+        name: quay.io/thoth-station/integration-tests:v0.8.5
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/integration-tests/overlays/test/imagestreamtag.yaml
+++ b/integration-tests/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.8.4
+        name: quay.io/thoth-station/integration-tests:v0.8.5
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/integration-tests/pull/214

## Description

See https://quay.io/repository/thoth-station/integration-tests?tab=tags
