### PR TITLE
Increase CPU for package-releases-job

### DIFF
--- a/package-releases/base/cronjob.yaml
+++ b/package-releases/base/cronjob.yaml
@@ -102,10 +102,10 @@ spec:
               resources:
                 requests:
                   memory: "256Mi"
-                  cpu: "500m"
+                  cpu: "1"
                 limits:
                   memory: "512Mi"
-                  cpu: "500m"
+                  cpu: "1"
               livenessProbe:
                 failureThreshold: 1
                 # Give this job 4 hours to finish


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/package-releases-job/pull/586

## Description

As package-releases were rewritten to asyncio, they can utilize more CPU as they are no longer idled on response awaiting from the monitored package index.
