### PR TITLE
Enable ingesting Fedora:34+Python 3.9 data in stage environment

### DIFF
--- a/core/overlays/ocp4-stage/common/configmaps.yaml
+++ b/core/overlays/ocp4-stage/common/configmaps.yaml
@@ -38,6 +38,7 @@ metadata:
 data:
   solvers: |
     solver-rhel-8-py38
+    solver-fedora-34-py39
 ---
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/issues/1764

## Description

It looks like UBI 8 + Python 3.8 finished ingesting. Let's enable ingesting Fedora:34 + Python 3.9 data.
