### PR TITLE
Bump up the images based on the version update v2021.08.30

### DIFF
--- a/adviser/overlays/cnv-prod/imagestreamtag.yaml
+++ b/adviser/overlays/cnv-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.38.1
+        name: quay.io/thoth-station/adviser:v0.41.0
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions:v0.5.1
+        name: quay.io/thoth-station/prescriptions:v0.7.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/zero-test/imagestreamtags.yaml
+++ b/core/overlays/zero-test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.8.7
+        name: quay.io/thoth-station/workflow-helpers:v0.8.9
       importPolicy: {}
       referencePolicy:
         type: Source
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.14.2
+        name: quay.io/thoth-station/investigator:v0.14.4
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/graph-refresh/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-refresh/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.12
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.13
       importPolicy: {}

--- a/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-sync/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.12
+        name: quay.io/thoth-station/graph-sync-job:v0.10.13
       importPolicy: {}

--- a/package-releases/overlays/cnv-prod/imagestreamtag.yaml
+++ b/package-releases/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.10.1
+        name: quay.io/thoth-station/package-releases-job:v0.11.0
       importPolicy: {}


### PR DESCRIPTION
Bump up the images based on the version update v2021.08.30
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/1882

