### PR TITLE
Enable CVE update job in stage

### DIFF
--- a/cve-update/overlays/ocp4-stage/cronjob.yaml
+++ b/cve-update/overlays/ocp4-stage/cronjob.yaml
@@ -7,4 +7,4 @@ metadata:
     app: thoth
     component: cve-update
 spec:
-  suspend: true
+  suspend: false


### PR DESCRIPTION
Let's enable CVE update job so we sync CVEs and solve stacks affected by CVEs.