### PR TITLE
use GitHub app authentication present in secrets

### DIFF
--- a/adviser/base/argo-workflows/kebechet-run-results.yaml
+++ b/adviser/base/argo-workflows/kebechet-run-results.yaml
@@ -20,6 +20,9 @@ spec:
           - name: ssh-config
             mountPath: /home/user/.ssh
             readOnly: true
+          - name: github-app-privatekey
+            mountPath: /home/user/github
+            readOnly: true
         env:
           - name: PIPENV_NOSPIN
             value: "1"
@@ -35,6 +38,13 @@ spec:
             value: "{{inputs.parameters.git_service}}"
           - name: KEBECHET_ANALYSIS_ID
             value: "{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: GITHUB_APP_ID
+            valueFrom:
+              secretKeyRef:
+                key: GITHUB_APP_ID
+                name: kebechet
+          - name: GITHUB_PRIVATE_KEY_PATH
+            value: "/home/user/github/github-privatekey"
           - name: GITHUB_KEBECHET_TOKEN
             valueFrom:
               secretKeyRef:

--- a/adviser/base/openshift-templates/adviser.yaml
+++ b/adviser/base/openshift-templates/adviser.yaml
@@ -194,6 +194,12 @@ objects:
               - key: ssh-privatekey
                 path: id_rsa
                 mode: 0600
+        - name: github-app-privatekey
+          secret:
+            secretName: kebechet
+            items:
+            - key: KEBBHUT_GITHUB_PRIVATE_KEY
+              path: github-privatekey
 
       templates:
         - name: "adviser"


### PR DESCRIPTION
This config was missing from kebechet run results making Kebechet authenticate using OAuth rather than GitHub app authentication
