### PR TITLE
Exclude branches created for prescription updates

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -63,6 +63,7 @@ branch-protection:
             - "^revert-"
             - "^kebechet-"
             - "^dependabot/"
+            - "^pres-"
         meteor:
           protect: true
           allow_force_pushes: false


### PR DESCRIPTION
## Related Issues and Dependencies

When updating prescriptions, some branches are turned into protected. This is not excepted behavior as these branches should be deleted.