### PR TITLE
Update cve-update job to v0.4.0 in stage environment

### DIFF
--- a/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.3.1
+        name: quay.io/thoth-station/cve-update-job:v0.4.0
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/cve-update-job/pull/424

