### PR TITLE
Bump up the graph-backup-job to version v0.8.9

### DIFF
--- a/graph-backup-job/overlays/cnv-prod/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/cnv-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.8
+        name: quay.io/thoth-station/graph-backup-job:v0.8.9
       importPolicy: {}

--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.8
+        name: quay.io/thoth-station/graph-backup-job:v0.8.9
       importPolicy: {}

--- a/graph-backup-job/overlays/test/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.8
+        name: quay.io/thoth-station/graph-backup-job:v0.8.9
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
Bump up the graph-backup-job to version v0.8.9
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

This would resolve the failing backup.