### PR TITLE
Bump metrics-exporter to v0.18.3 in stage environment

### DIFF
--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.18.2
+        name: quay.io/thoth-station/metrics-exporter:v0.18.3
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/metrics-exporter/issues/773
