### PR TITLE
Bump up the version of thoth station for v2021.09.27 release

### DIFF
--- a/adviser/overlays/moc-prod/imagestreamtag.yaml
+++ b/adviser/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.42.0
+        name: quay.io/thoth-station/adviser:v0.45.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.44.0
+        name: quay.io/thoth-station/adviser:v0.45.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/test/imagestreamtag.yaml
+++ b/adviser/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.42.0
+        name: quay.io/thoth-station/adviser:v0.45.0
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/core/overlays/moc-prod/common/imagestreamtags.yaml
+++ b/core/overlays/moc-prod/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.9.0
+      name: quay.io/thoth-station/workflow-helpers:v0.9.1
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.15.0
+      name: quay.io/thoth-station/investigator:v0.15.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.9.0
+      name: quay.io/thoth-station/workflow-helpers:v0.9.1
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.15.0
+      name: quay.io/thoth-station/investigator:v0.15.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/rick-test/imagestreamtags.yaml
+++ b/core/overlays/rick-test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.0
+        name: quay.io/thoth-station/workflow-helpers:v0.9.1
       importPolicy: {}
       referencePolicy:
         type: Source
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.15.0
+        name: quay.io/thoth-station/investigator:v0.15.1
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/core/overlays/test/imagestreamtags.yaml
+++ b/core/overlays/test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.0
+        name: quay.io/thoth-station/workflow-helpers:v0.9.1
       importPolicy: {}
       referencePolicy:
         type: Source
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.15.0
+        name: quay.io/thoth-station/investigator:v0.15.1
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/cve-update/overlays/moc-prod/imagestreamtag.yaml
+++ b/cve-update/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.4.0
+        name: quay.io/thoth-station/cve-update-job:v0.4.1
       importPolicy: {}

--- a/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.4.0
+        name: quay.io/thoth-station/cve-update-job:v0.4.1
       importPolicy: {}

--- a/cve-update/overlays/test/imagestreamtag.yaml
+++ b/cve-update/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.4.0
+        name: quay.io/thoth-station/cve-update-job:v0.4.1
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/graph-backup-job/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.9
+        name: quay.io/thoth-station/graph-backup-job:v0.8.10
       importPolicy: {}

--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.9
+        name: quay.io/thoth-station/graph-backup-job:v0.8.10
       importPolicy: {}

--- a/graph-backup-job/overlays/test/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.9
+        name: quay.io/thoth-station/graph-backup-job:v0.8.10
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.4
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.5
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.4
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.5
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/test/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.4
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.5
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/graph-refresh/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-refresh/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.14
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.15
       importPolicy: {}

--- a/graph-sync/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-sync/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.14
+        name: quay.io/thoth-station/graph-sync-job:v0.10.15
       importPolicy: {}

--- a/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-sync/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.14
+        name: quay.io/thoth-station/graph-sync-job:v0.10.15
       importPolicy: {}

--- a/graph-sync/overlays/test/imagestreamtag.yaml
+++ b/graph-sync/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.14
+        name: quay.io/thoth-station/graph-sync-job:v0.10.15
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/kebechet/overlays/moc-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.5.1
+        name: quay.io/thoth-station/kebechet-job:v1.5.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.5.1
+        name: quay.io/thoth-station/kebechet-job:v1.5.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/management-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/management-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.10
+      name: quay.io/thoth-station/management-api:v0.17.11
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.10
+      name: quay.io/thoth-station/management-api:v0.17.11
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/test/imagestreamtag.yaml
+++ b/management-api/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/management-api:v0.17.10
+        name: quay.io/thoth-station/management-api:v0.17.11
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.18.2
+        name: quay.io/thoth-station/metrics-exporter:v0.18.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.18.3
+        name: quay.io/thoth-station/metrics-exporter:v0.18.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/test/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.18.3
+        name: quay.io/thoth-station/metrics-exporter:v0.18.4
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/package-releases/overlays/moc-prod/imagestreamtag.yaml
+++ b/package-releases/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.1
+        name: quay.io/thoth-station/package-releases-job:v0.11.2
       importPolicy: {}

--- a/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.1
+        name: quay.io/thoth-station/package-releases-job:v0.11.2
       importPolicy: {}

--- a/package-releases/overlays/test/imagestreamtag.yaml
+++ b/package-releases/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.1
+        name: quay.io/thoth-station/package-releases-job:v0.11.2
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/package-update/overlays/moc-prod/imagestreamtag.yaml
+++ b/package-update/overlays/moc-prod/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.12
+        name: quay.io/thoth-station/package-update-job:v0.8.13
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.12
+        name: quay.io/thoth-station/package-update-job:v0.8.13
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-update/overlays/test/imagestreamtag.yaml
+++ b/package-update/overlays/test/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.12
+        name: quay.io/thoth-station/package-update-job:v0.8.13
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/revsolver/overlays/moc-prod/imagestreamtag.yaml
+++ b/revsolver/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/revsolver:v0.2.8"
+        name: "quay.io/thoth-station/revsolver:v0.2.9"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/revsolver/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/revsolver/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/revsolver:v0.2.8"
+        name: "quay.io/thoth-station/revsolver:v0.2.9"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/revsolver/overlays/test/imagestreamtag.yaml
+++ b/revsolver/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/revsolver:v0.2.8
+        name: quay.io/thoth-station/revsolver:v0.2.9
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/slo-reporter/overlays/moc-prod-ocp4-stage/imagestreamtag.yaml
+++ b/slo-reporter/overlays/moc-prod-ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.17.1
+        name: quay.io/thoth-station/slo-reporter:v0.17.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/slo-reporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/slo-reporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.17.1
+        name: quay.io/thoth-station/slo-reporter:v0.17.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/slo-reporter/overlays/test/imagestreamtag.yaml
+++ b/slo-reporter/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.17.1
+        name: quay.io/thoth-station/slo-reporter:v0.17.2
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.27.0
+        name: quay.io/thoth-station/user-api:v0.27.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.27.0
+        name: quay.io/thoth-station/user-api:v0.27.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/test/imagestreamtag.yaml
+++ b/user-api/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.27.0
+        name: quay.io/thoth-station/user-api:v0.27.1
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
Bump up the version of thoth station for v2021.09.27 release
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/1961

