### PR TITLE
Update triage-party configuration

### DIFF
--- a/triage-party/base/deployment.yaml
+++ b/triage-party/base/deployment.yaml
@@ -28,12 +28,12 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /app/config
-            - name: pcahce
+            - name: pcache
               mountPath: /app/pcache
       volumes:
         - name: config
           configMap:
             name: triage-party-config
-        - name: pcahce
+        - name: pcache
           persistentVolumeClaim:
             claimName: triage-party-pcache

--- a/triage-party/overlays/moc/config.yaml
+++ b/triage-party/overlays/moc/config.yaml
@@ -3,6 +3,10 @@ settings:
   name: thoth-station
   min_similarity: 0.8
   repos:
+    - https://github.com/AICoE/elyra-aidevsecops-tutorial
+    - https://github.com/AICoE/manage-dependencies-tutorial
+    - https://github.com/AICoE/overlays-for-ai-pipeline-tutorial
+    - https://github.com/AICoE/recommend-base-image-tutorial
     - https://github.com/thoth-station/adviser
     - https://github.com/thoth-station/amun-api
     - https://github.com/thoth-station/amun-client

--- a/triage-party/overlays/moc/pcache.yaml
+++ b/triage-party/overlays/moc/pcache.yaml
@@ -11,4 +11,3 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: moc-nfs-csi


### PR DESCRIPTION
## Related Issues and Dependencies

#1969

## Does this require new deployment ?

No

## Description

A small update to the triage-party configuration, to:

 - Add the tutorial repos
 - Remove explicit storage class from PVC (suggested by operate first sre), should use the default
 - Fix typo in volume name

