### PR TITLE
Bump package-release in stage to v0.11.3

### DIFF
--- a/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.2
+        name: quay.io/thoth-station/package-releases-job:v0.11.3
       importPolicy: {}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

This patch will allow package release to identify correct versions from Pytorch indexes