### PR TITLE
setup prow on the data-driven-development repo

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -229,14 +229,15 @@ tide:
         - AICoE/aicoe-cd
         - AICoE/aicoe-ci
         - AICoE/aicoe-sre
+        - AICoE/data-driven-development
         - AICoE/elyra-aidevsecops-tutorial
         - AICoE/idh-manifests
         - AICoE/internal-data-hub
         - AICoE/manage-dependencies-tutorial
         - AICoE/overlays-for-ai-pipeline-tutorial
-        - AICoE/recommend-base-image-tutorial
         - AICoE/prometheus-anomaly-detector
         - AICoE/prometheus-api-client-python
+        - AICoE/recommend-base-image-tutorial
         - AICoE/s2i-custom-notebook
         - AICoE/sefkhet-abwy
         - AICoE/Varangian


### PR DESCRIPTION
setup prow on the data-driven-development repo
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

ci not functioning on that repo
