### PR TITLE
Bump package release to v0.11.4 in test and stage

### DIFF
--- a/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.3
+        name: quay.io/thoth-station/package-releases-job:v0.11.4
       importPolicy: {}

--- a/package-releases/overlays/test/imagestreamtag.yaml
+++ b/package-releases/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.2
+        name: quay.io/thoth-station/package-releases-job:v0.11.4
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

we should be able to analyze package versions correctly from torch indexes.