### PR TITLE
Don't declare namespace value explicitly in kustomize file

### DIFF
--- a/adviser/overlays/ocp4-stage/kustomization.yaml
+++ b/adviser/overlays/ocp4-stage/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-backend-stage
 commonLabels:
   app: thoth
   component: adviser

--- a/chat-notification/overlays/ocp4-stage/kustomization.yaml
+++ b/chat-notification/overlays/ocp4-stage/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-infra-stage
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/chat-notification/overlays/test/kustomization.yaml
+++ b/chat-notification/overlays/test/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-test-core
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/cve-update/overlays/aws-prod/kustomization.yaml
+++ b/cve-update/overlays/aws-prod/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-frontend-prod
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/cve-update/overlays/moc-prod/kustomization.yaml
+++ b/cve-update/overlays/moc-prod/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-frontend-prod
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/cve-update/overlays/ocp4-stage/kustomization.yaml
+++ b/cve-update/overlays/ocp4-stage/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-frontend-stage
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/cve-update/overlays/test/kustomization.yaml
+++ b/cve-update/overlays/test/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-test-core
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/graph-refresh/overlays/test/kustomization.yaml
+++ b/graph-refresh/overlays/test/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-test-core
 resources:
   - ../../base
   - rolebindings.yaml

--- a/package-releases/overlays/ocp4-stage/kustomization.yaml
+++ b/package-releases/overlays/ocp4-stage/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-frontend-stage
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/package-releases/overlays/test/kustomization.yaml
+++ b/package-releases/overlays/test/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-test-core
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/pulp-pypi-sync-job/overlays/test/kustomization.yaml
+++ b/pulp-pypi-sync-job/overlays/test/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-test-core
 resources:
   - ../../base
   - thoth-notification.yaml

--- a/solver-project-url-job/overlays/test/kustomization.yaml
+++ b/solver-project-url-job/overlays/test/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-test-core
 resources:
   - ../../base
   - thoth-notification.yaml


### PR DESCRIPTION
Don't declare namespace value explicitly in kustomize file
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #2008 

