### PR TITLE
setup image patch to refer the absolute path for images

### DIFF
--- a/advise-reporter/base/cronjob.yaml
+++ b/advise-reporter/base/cronjob.yaml
@@ -12,9 +12,6 @@ spec:
   jobTemplate:
     spec:
       template:
-        metadata:
-          annotations:
-            alpha.image.policy.openshift.io/resolve-names: '*'
         spec:
           containers:
             - image: advise-reporter:latest

--- a/advise-reporter/overlays/aws-prod/cronjob.yaml
+++ b/advise-reporter/overlays/aws-prod/cronjob.yaml
@@ -12,9 +12,6 @@ spec:
   jobTemplate:
     spec:
       template:
-        metadata:
-          annotations:
-            alpha.image.policy.openshift.io/resolve-names: '*'
         spec:
           containers:
             - image: advise-reporter:latest

--- a/advise-reporter/overlays/aws-prod/kustomization.yaml
+++ b/advise-reporter/overlays/aws-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: advise-reporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/advise-reporter
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/advise-reporter/overlays/moc-prod/cronjob.yaml
+++ b/advise-reporter/overlays/moc-prod/cronjob.yaml
@@ -12,9 +12,6 @@ spec:
   jobTemplate:
     spec:
       template:
-        metadata:
-          annotations:
-            alpha.image.policy.openshift.io/resolve-names: '*'
         spec:
           containers:
             - image: advise-reporter:latest

--- a/advise-reporter/overlays/moc-prod/kustomization.yaml
+++ b/advise-reporter/overlays/moc-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: advise-reporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/advise-reporter
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/advise-reporter/overlays/moc-prod/thoth-notification.yaml
+++ b/advise-reporter/overlays/moc-prod/thoth-notification.yaml
@@ -22,7 +22,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'Successfully synchronized *advise-reporter* to *MOC-SMAUG*, see <https://argocd.operate-first.cloud/applications/prod-thoth-adviser-reporter-smaug|ArgoCD UI> 🚚'}"
+            - "{'text':'Successfully synchronized *advise-reporter* to *MOC-SMAUG*, see <https://argocd.operate-first.cloud/applications/prod-thoth-advise-reporter-smaug|ArgoCD UI> 🚚'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL
@@ -55,7 +55,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'🔥 *FAILED* to sync *advise-reporter* to *MOC-SMAUG*, see <https://argocd.operate-first.cloud/applications/prod-thoth-adviser-reporter-smaug|ArgoCD UI>'}"
+            - "{'text':'🔥 *FAILED* to sync *advise-reporter* to *MOC-SMAUG*, see <https://argocd.operate-first.cloud/applications/prod-thoth-advise-reporter-smaug|ArgoCD UI>'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL

--- a/advise-reporter/overlays/ocp4-stage/kustomization.yaml
+++ b/advise-reporter/overlays/ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: advise-reporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-stage/advise-reporter
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/advise-reporter/overlays/ocp4-stage/thoth-notification.yaml
+++ b/advise-reporter/overlays/ocp4-stage/thoth-notification.yaml
@@ -22,7 +22,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'Successfully synchronized *advise-reporter* to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/ocp4-stage-thoth-adviser-reporter|ArgoCD UI> 🚚'}"
+            - "{'text':'Successfully synchronized *advise-reporter* to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/ocp4-stage-thoth-advise-reporter|ArgoCD UI> 🚚'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL
@@ -55,7 +55,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'🔥 *FAILED* to sync *advise-reporter* to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/ocp4-stage-thoth-adviser-reporter|ArgoCD UI>'}"
+            - "{'text':'🔥 *FAILED* to sync *advise-reporter* to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/ocp4-stage-thoth-advise-reporter|ArgoCD UI>'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL

--- a/advise-reporter/overlays/test/cronjob.yaml
+++ b/advise-reporter/overlays/test/cronjob.yaml
@@ -12,9 +12,6 @@ spec:
   jobTemplate:
     spec:
       template:
-        metadata:
-          annotations:
-            alpha.image.policy.openshift.io/resolve-names: '*'
         spec:
           containers:
             - image: advise-reporter:latest

--- a/advise-reporter/overlays/test/kustomization.yaml
+++ b/advise-reporter/overlays/test/kustomization.yaml
@@ -5,6 +5,10 @@ commonLabels:
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: advise-reporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/advise-reporter
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/advise-reporter/overlays/test/thoth-notification.yaml
+++ b/advise-reporter/overlays/test/thoth-notification.yaml
@@ -22,7 +22,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'Successfully synchronized *advise-reporter* to *OCP4-TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/test-thoth-adviser-reporter|ArgoCD UI> 🚚'}"
+            - "{'text':'Successfully synchronized *advise-reporter* to *OCP4-TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/test-thoth-advise-reporter|ArgoCD UI> 🚚'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL
@@ -55,7 +55,7 @@ spec:
             - "-H"
             - "Content-Type: application/json; charset=UTF-8"
             - "-d"
-            - "{'text':'🔥 *FAILED* to sync *advise-reporter* to *OCP4-TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/test-thoth-adviser-reporter|ArgoCD UI>'}"
+            - "{'text':'🔥 *FAILED* to sync *advise-reporter* to *OCP4-TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/test-thoth-advise-reporter|ArgoCD UI>'}"
             - "$(THOTH_DEVOPS_WEBHOOK_URL)"
           env:
             - name: THOTH_DEVOPS_WEBHOOK_URL

--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -3,12 +3,11 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: advise
+  annotations:
+    operation: adviser
 spec:
   templates:
     - name: advise
-      metadata:
-        annotations:
-          alpha.image.policy.openshift.io/resolve-names: '*'
       metrics:
         prometheus:
           - name: task_status_counter

--- a/adviser/base/argo-workflows/dependency-monkey.yaml
+++ b/adviser/base/argo-workflows/dependency-monkey.yaml
@@ -4,6 +4,7 @@ kind: WorkflowTemplate
 metadata:
   name: dm
   annotations:
+    operation: adviser
     thoth-station.ninja/template-version: 0.0.1
   labels:
     app: thoth
@@ -11,9 +12,6 @@ metadata:
 spec:
   templates:
     - name: dm
-      metadata:
-        annotations:
-          alpha.image.policy.openshift.io/resolve-names: '*'
       resubmitPendingPods: true
       inputs:
         parameters:

--- a/adviser/base/argo-workflows/kebechet-run-results.yaml
+++ b/adviser/base/argo-workflows/kebechet-run-results.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   templates:
     - name: schedule-kebechet
-      metadata:
-        annotations:
-          alpha.image.policy.openshift.io/resolve-names: '*'
       resubmitPendingPods: true
       inputs:
         parameters:

--- a/adviser/base/argo-workflows/parse-adviser-output.yaml
+++ b/adviser/base/argo-workflows/parse-adviser-output.yaml
@@ -3,12 +3,11 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: parse-adviser-output
+  annotations:
+    operation: workflow-helpers
 spec:
   templates:
     - name: parse-adviser-output
-      metadata:
-        annotations:
-          alpha.image.policy.openshift.io/resolve-names: '*'
       resubmitPendingPods: true
       inputs:
         parameters:

--- a/adviser/base/argo-workflows/parse-provenance-checker-output.yaml
+++ b/adviser/base/argo-workflows/parse-provenance-checker-output.yaml
@@ -3,12 +3,11 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: parse-provenance-checker-output
+  annotations:
+    operation: workflow-helpers
 spec:
   templates:
     - name: parse-provenance-checker-output
-      metadata:
-        annotations:
-          alpha.image.policy.openshift.io/resolve-names: '*'
       resubmitPendingPods: true
       inputs:
         parameters:

--- a/adviser/base/argo-workflows/provenance-check.yaml
+++ b/adviser/base/argo-workflows/provenance-check.yaml
@@ -6,12 +6,11 @@ metadata:
   labels:
     app: thoth
     component: provenance-check
+  annotations:
+    operation: adviser
 spec:
   templates:
     - name: provenance-check
-      metadata:
-        annotations:
-          alpha.image.policy.openshift.io/resolve-names: '*'
       resubmitPendingPods: true
       inputs:
         parameters:

--- a/adviser/base/argo-workflows/trigger-integration.yaml
+++ b/adviser/base/argo-workflows/trigger-integration.yaml
@@ -3,12 +3,11 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: trigger-integration
+  annotations:
+    operation: workflow-helpers
 spec:
   templates:
     - name: trigger-integration
-      metadata:
-        annotations:
-          alpha.image.policy.openshift.io/resolve-names: '*'
       resubmitPendingPods: true
       inputs:
         parameters:

--- a/adviser/overlays/aws-prod/kustomization.yaml
+++ b/adviser/overlays/aws-prod/kustomization.yaml
@@ -9,18 +9,49 @@ resources:
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:
+  # chat notification
   - path: put-into-infra-namespace.yaml
     target:
       group: batch
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=adviser"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: kebechet-run-results
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"
+  # resource patch
   - path: advise-resources-patch.yaml
     target:
       group: argoproj.io
       version: v1alpha1
       kind: WorkflowTemplate
       name: advise
+  # template patch namespace
   - path: put-into-infra-namespace.yaml
     target:
       group: template.openshift.io
@@ -39,6 +70,7 @@ patches:
       version: v1
       kind: Template
       name: provenance-checker
+  # wf template patch namespace
   - path: put-into-amun-inspection-namespace.yaml
     target:
       group: argoproj.io

--- a/adviser/overlays/moc-prod/kustomization.yaml
+++ b/adviser/overlays/moc-prod/kustomization.yaml
@@ -9,18 +9,49 @@ resources:
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:
-  - path: advise-resources-patch.yaml
-    target:
-      group: argoproj.io
-      version: v1alpha1
-      kind: WorkflowTemplate
-      name: advise
+  # chat notification
   - path: put-into-infra-namespace.yaml
     target:
       group: batch
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=adviser"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: kebechet-run-results
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"
+  # resource patch
+  - path: advise-resources-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: advise
+  # template patch namespace
   - path: put-into-infra-namespace.yaml
     target:
       group: template.openshift.io
@@ -39,6 +70,7 @@ patches:
       version: v1
       kind: Template
       name: provenance-checker
+  # wf template patch namespace
   - path: put-into-amun-inspection-namespace.yaml
     target:
       group: argoproj.io

--- a/adviser/overlays/ocp4-stage/kustomization.yaml
+++ b/adviser/overlays/ocp4-stage/kustomization.yaml
@@ -9,12 +9,42 @@ resources:
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:
+  # chat notification
   - path: put-into-infra-namespace.yaml
     target:
       group: batch
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=adviser"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: kebechet-run-results
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"
+  # template patch namespace
   - path: put-into-infra-namespace.yaml
     target:
       group: template.openshift.io
@@ -33,6 +63,7 @@ patches:
       version: v1
       kind: Template
       name: provenance-checker
+  # wf template patch namespace
   - path: put-into-amun-inspection-namespace.yaml
     target:
       group: argoproj.io

--- a/adviser/overlays/test/kustomization.yaml
+++ b/adviser/overlays/test/kustomization.yaml
@@ -7,3 +7,32 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+patches:
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=adviser"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: kebechet-run-results
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"

--- a/amun/overlays/aws-prod/amun-inspection/argo-deployments.yaml
+++ b/amun/overlays/aws-prod/amun-inspection/argo-deployments.yaml
@@ -11,8 +11,6 @@ spec:
     metadata:
       labels:
         app: argo-server
-      annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
         - args:
@@ -44,15 +42,13 @@ spec:
     metadata:
       labels:
         app: workflow-controller
-      annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
         - args:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/amun/overlays/aws-prod/amun-inspection/kustomization.yaml
+++ b/amun/overlays/aws-prod/amun-inspection/kustomization.yaml
@@ -20,3 +20,11 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/workflow-controller
+    newTag: latest

--- a/amun/overlays/moc-prod/amun-inspection/argo-deployments.yaml
+++ b/amun/overlays/moc-prod/amun-inspection/argo-deployments.yaml
@@ -48,7 +48,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/amun/overlays/moc-prod/amun-inspection/kustomization.yaml
+++ b/amun/overlays/moc-prod/amun-inspection/kustomization.yaml
@@ -20,3 +20,11 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/workflow-controller
+    newTag: latest

--- a/amun/overlays/ocp4-stage/amun-inspection/argo-deployments.yaml
+++ b/amun/overlays/ocp4-stage/amun-inspection/argo-deployments.yaml
@@ -48,7 +48,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/amun/overlays/ocp4-stage/amun-inspection/kustomization.yaml
+++ b/amun/overlays/ocp4-stage/amun-inspection/kustomization.yaml
@@ -19,3 +19,11 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-stage/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-stage/workflow-controller
+    newTag: latest

--- a/amun/overlays/power9/amun-inspection/argo-namespace-install.yaml
+++ b/amun/overlays/power9/amun-inspection/argo-namespace-install.yaml
@@ -104,7 +104,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/amun/overlays/test/argo-workflows/send-messages.yaml
+++ b/amun/overlays/test/argo-workflows/send-messages.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: send-messages
+  annotations:
+    operation: messaging
 spec:
   templates:
     - name: send-messages

--- a/amun/overlays/test/kustomization.yaml
+++ b/amun/overlays/test/kustomization.yaml
@@ -13,3 +13,13 @@ patchesStrategicMerge:
   - openshift-templates/inspection-workflow.yaml
   - openshift-templates/inspection-with-cpu-workflow.yaml
   - deploymentconfig.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/base/argo-workflows/send-message.yaml
+++ b/core/base/argo-workflows/send-message.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: send-message
+  annotations:
+    operation: messaging
 spec:
   templates:
     - name: send-message

--- a/core/base/argo-workflows/send-messages.yaml
+++ b/core/base/argo-workflows/send-messages.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: send-messages
+  annotations:
+    operation: messaging
 spec:
   templates:
     - name: send-messages

--- a/core/overlays/aws-prod/backend-prod/argo-deployments.yaml
+++ b/core/overlays/aws-prod/backend-prod/argo-deployments.yaml
@@ -11,8 +11,6 @@ spec:
     metadata:
       labels:
         app: argo-server
-      annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
         - args:
@@ -43,15 +41,13 @@ spec:
     metadata:
       labels:
         app: workflow-controller
-      annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
         - args:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/aws-prod/backend-prod/kustomization.yaml
+++ b/core/overlays/aws-prod/backend-prod/kustomization.yaml
@@ -10,6 +10,14 @@ resources:
   - argo-workflow-controller.yaml
   - thoth-notification.yaml
   - configmaps.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/workflow-controller
+    newTag: latest
 patches:
   - patch: |-
       - op: add
@@ -20,3 +28,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/overlays/aws-prod/middletier-prod/argo-deployments.yaml
+++ b/core/overlays/aws-prod/middletier-prod/argo-deployments.yaml
@@ -9,8 +9,6 @@ spec:
       app: argo-server
   template:
     metadata:
-      annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
       labels:
         app: argo-server
     spec:
@@ -41,8 +39,6 @@ spec:
       app: workflow-controller
   template:
     metadata:
-      annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
       labels:
         app: workflow-controller
     spec:
@@ -51,7 +47,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/aws-prod/middletier-prod/kustomization.yaml
+++ b/core/overlays/aws-prod/middletier-prod/kustomization.yaml
@@ -10,6 +10,14 @@ resources:
   - argo-workflow-controller.yaml
   - thoth-notification.yaml
   - configmaps.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/workflow-controller
+    newTag: latest
 patches:
   - patch: |-
       - op: add
@@ -20,3 +28,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/overlays/moc-prod/backend-prod/argo-deployments.yaml
+++ b/core/overlays/moc-prod/backend-prod/argo-deployments.yaml
@@ -47,7 +47,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/moc-prod/backend-prod/kustomization.yaml
+++ b/core/overlays/moc-prod/backend-prod/kustomization.yaml
@@ -10,6 +10,14 @@ resources:
   - argo-workflow-controller.yaml
   - thoth-notification.yaml
   - configmaps.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/workflow-controller
+    newTag: latest
 patches:
   - patch: |-
       - op: add
@@ -20,3 +28,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/overlays/moc-prod/middletier-prod/argo-deployments.yaml
+++ b/core/overlays/moc-prod/middletier-prod/argo-deployments.yaml
@@ -47,7 +47,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/moc-prod/middletier-prod/kustomization.yaml
+++ b/core/overlays/moc-prod/middletier-prod/kustomization.yaml
@@ -10,6 +10,14 @@ resources:
   - argo-workflow-controller.yaml
   - thoth-notification.yaml
   - configmaps.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/workflow-controller
+    newTag: latest
 patches:
   - patch: |-
       - op: add
@@ -20,3 +28,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/overlays/ocp4-stage/backend-stage/argo-deployments.yaml
+++ b/core/overlays/ocp4-stage/backend-stage/argo-deployments.yaml
@@ -47,7 +47,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/ocp4-stage/backend-stage/kustomization.yaml
+++ b/core/overlays/ocp4-stage/backend-stage/kustomization.yaml
@@ -9,6 +9,14 @@ resources:
   - argo-workflow-controller.yaml
   - thoth-notification.yaml
   - configmaps.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/workflow-controller
+    newTag: latest
 patches:
   - patch: |-
       - op: add
@@ -19,3 +27,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/overlays/ocp4-stage/middletier-stage/argo-deployments.yaml
+++ b/core/overlays/ocp4-stage/middletier-stage/argo-deployments.yaml
@@ -47,7 +47,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/ocp4-stage/middletier-stage/kustomization.yaml
+++ b/core/overlays/ocp4-stage/middletier-stage/kustomization.yaml
@@ -9,6 +9,14 @@ resources:
   - argo-workflow-controller.yaml
   - thoth-notification.yaml
   - configmaps.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/workflow-controller
+    newTag: latest
 patches:
   - patch: |-
       - op: add
@@ -19,3 +27,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/overlays/rick-test/argo-deployments.yaml
+++ b/core/overlays/rick-test/argo-deployments.yaml
@@ -47,7 +47,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/rick-test/kustomization.yaml
+++ b/core/overlays/rick-test/kustomization.yaml
@@ -22,3 +22,21 @@ generatorOptions:
   disableNameSuffixHash: true
 generators:
   - ./secret-generator.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/workflow-controller
+    newTag: latest
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/core/overlays/test/argo-deployments.yaml
+++ b/core/overlays/test/argo-deployments.yaml
@@ -47,7 +47,7 @@ spec:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - argoexec:latest
+            - quay.io/argoproj/argoexec:v2.12.5
             - --namespaced
           command:
             - workflow-controller

--- a/core/overlays/test/kustomization.yaml
+++ b/core/overlays/test/kustomization.yaml
@@ -20,3 +20,21 @@ generatorOptions:
   disableNameSuffixHash: true
 generators:
   - ./secret-generator.yaml
+# wf controller image patch
+images:
+  - name: argocli
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/argocli
+    newTag: latest
+  - name: workflow-controller
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/workflow-controller
+    newTag: latest
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/messaging:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=messaging"

--- a/cve-update/overlays/aws-prod/kustomization.yaml
+++ b/cve-update/overlays/aws-prod/kustomization.yaml
@@ -16,3 +16,7 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+images:
+  - name: cve-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/cve-update-job
+    newTag: latest

--- a/cve-update/overlays/moc-prod/kustomization.yaml
+++ b/cve-update/overlays/moc-prod/kustomization.yaml
@@ -16,3 +16,7 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+images:
+  - name: cve-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/cve-update-job
+    newTag: latest

--- a/cve-update/overlays/ocp4-stage/kustomization.yaml
+++ b/cve-update/overlays/ocp4-stage/kustomization.yaml
@@ -16,3 +16,7 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+images:
+  - name: cve-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/cve-update-job
+    newTag: latest

--- a/cve-update/overlays/test/kustomization.yaml
+++ b/cve-update/overlays/test/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml
+images:
+  - name: cve-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/cve-update-job
+    newTag: latest

--- a/graph-backup-job/overlays/aws-prod/kustomization.yaml
+++ b/graph-backup-job/overlays/aws-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-backup-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-graph-prod/graph-backup-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-backup-job/overlays/moc-prod/kustomization.yaml
+++ b/graph-backup-job/overlays/moc-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-backup-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-graph-prod/graph-backup-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-backup-job/overlays/ocp4-stage/kustomization.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-backup-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-graph-stage/graph-backup-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-backup-job/overlays/test/kustomization.yaml
+++ b/graph-backup-job/overlays/test/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-backup-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/graph-backup-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-metrics-exporter/overlays/aws-prod/kustomization.yaml
+++ b/graph-metrics-exporter/overlays/aws-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-graph-prod/graph-metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-metrics-exporter/overlays/moc-prod/kustomization.yaml
+++ b/graph-metrics-exporter/overlays/moc-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-graph-prod/graph-metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-metrics-exporter/overlays/ocp4-stage/kustomization.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-graph-stage/graph-metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-metrics-exporter/overlays/test/kustomization.yaml
+++ b/graph-metrics-exporter/overlays/test/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: graph-metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/graph-metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-refresh/overlays/aws-prod/kustomization.yaml
+++ b/graph-refresh/overlays/aws-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - rolebindings.yaml
   - thoth-notification.yaml
+images:
+  - name: graph-refresh-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/graph-refresh-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-refresh/overlays/moc-prod/kustomization.yaml
+++ b/graph-refresh/overlays/moc-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - rolebindings.yaml
   - thoth-notification.yaml
+images:
+  - name: graph-refresh-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/graph-refresh-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-refresh/overlays/ocp4-stage/kustomization.yaml
+++ b/graph-refresh/overlays/ocp4-stage/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - rolebindings.yaml
   - thoth-notification.yaml
+images:
+  - name: graph-refresh-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/graph-refresh-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-refresh/overlays/test/kustomization.yaml
+++ b/graph-refresh/overlays/test/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - rolebindings.yaml
   - thoth-notification.yaml
+images:
+  - name: graph-refresh-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/graph-refresh-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/graph-sync/overlays/test/kustomization.yaml
+++ b/graph-sync/overlays/test/kustomization.yaml
@@ -8,3 +8,13 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/graph-sync-job:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: graph-sync

--- a/integration-tests/overlays/cnv-prod-ocp4-stage/kustomization.yaml
+++ b/integration-tests/overlays/cnv-prod-ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: integration-tests
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/integration-tests
+    newTag: latest
 patchesStrategicMerge:
   - configmap.yaml
   - cronjob.yaml

--- a/integration-tests/overlays/ocp4-stage/kustomization.yaml
+++ b/integration-tests/overlays/ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: integration-tests
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-stage/integration-tests
+    newTag: latest
 patchesStrategicMerge:
   - configmap.yaml
   - cronjob.yaml

--- a/integration-tests/overlays/test/kustomization.yaml
+++ b/integration-tests/overlays/test/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: integration-tests
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/integration-tests
+    newTag: latest
 patchesStrategicMerge:
   - configmap.yaml
   - cronjob.yaml

--- a/investigator/overlays/aws-prod/kustomization.yaml
+++ b/investigator/overlays/aws-prod/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - route.yaml
   - service.yaml
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
 patches:

--- a/investigator/overlays/moc-prod/kustomization.yaml
+++ b/investigator/overlays/moc-prod/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - route.yaml
   - service.yaml
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
 patches:

--- a/investigator/overlays/ocp4-stage/kustomization.yaml
+++ b/investigator/overlays/ocp4-stage/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - route.yaml
   - service.yaml
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-stage/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
 patches:

--- a/investigator/overlays/rick-test/kustomization.yaml
+++ b/investigator/overlays/rick-test/kustomization.yaml
@@ -7,5 +7,9 @@ resources:
   - route.yaml
   - service.yaml
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml

--- a/investigator/overlays/test/kustomization.yaml
+++ b/investigator/overlays/test/kustomization.yaml
@@ -7,5 +7,9 @@ resources:
   - route.yaml
   - service.yaml
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml

--- a/investigator_message_metrics/overlays/aws-prod/kustomization.yaml
+++ b/investigator_message_metrics/overlays/aws-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
 patches:

--- a/investigator_message_metrics/overlays/moc-prod/kustomization.yaml
+++ b/investigator_message_metrics/overlays/moc-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
 patches:

--- a/investigator_message_metrics/overlays/ocp4-stage/kustomization.yaml
+++ b/investigator_message_metrics/overlays/ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-stage/investigator
+    newTag: latest
 patches:
   - patch: |-
       - op: add

--- a/investigator_message_metrics/overlays/test/kustomization.yaml
+++ b/investigator_message_metrics/overlays/test/kustomization.yaml
@@ -3,5 +3,9 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: investigator
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/investigator
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml

--- a/kebechet/base/argo-workflows/kebechet-administrator.yaml
+++ b/kebechet/base/argo-workflows/kebechet-administrator.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: kebechet-administrator
+  annotations:
+    operation: workflow-helpers
 spec:
   templates:
     - name: kebechet-administrator

--- a/kebechet/base/argo-workflows/kebechet-run-url.yaml
+++ b/kebechet/base/argo-workflows/kebechet-run-url.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: thoth
     component: kebechet
+  annotations:
+    operation: kebechet
 spec:
   templates:
     - name: kebechet-run-url

--- a/kebechet/base/argo-workflows/kebechet.yaml
+++ b/kebechet/base/argo-workflows/kebechet.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: thoth
     component: kebechet
+  annotations:
+    operation: kebechet
 spec:
   templates:
     - name: kebechet

--- a/kebechet/base/argo-workflows/update_keb_installation.yaml
+++ b/kebechet/base/argo-workflows/update_keb_installation.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: update-kebechet-installation
+  annotations:
+    operation: workflow-helpers
 spec:
   templates:
     - name: update-kebechet-installation

--- a/kebechet/overlays/aws-prod/kustomization.yaml
+++ b/kebechet/overlays/aws-prod/kustomization.yaml
@@ -33,6 +33,24 @@ patches:
       version: v1
       kind: Template
       name: kebechet-administrator
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/kebechet/overlays/moc-prod/kustomization.yaml
+++ b/kebechet/overlays/moc-prod/kustomization.yaml
@@ -33,6 +33,24 @@ patches:
       version: v1
       kind: Template
       name: kebechet-administrator
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/kebechet/overlays/ocp4-stage/kustomization.yaml
+++ b/kebechet/overlays/ocp4-stage/kustomization.yaml
@@ -33,6 +33,24 @@ patches:
       version: v1
       kind: Template
       name: kebechet-administrator
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/kebechet/overlays/test/kustomization.yaml
+++ b/kebechet/overlays/test/kustomization.yaml
@@ -13,3 +13,22 @@ generatorOptions:
   disableNameSuffixHash: true
 generators:
   - ./secret-generator.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"

--- a/management-api/overlays/aws-prod/kustomization.yaml
+++ b/management-api/overlays/aws-prod/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - role-binding.yaml
   - thoth-notification.yaml
   - route53.yaml
+images:
+  - name: management-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/management-api
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/management-api/overlays/moc-prod/kustomization.yaml
+++ b/management-api/overlays/moc-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: management-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/management-api
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/management-api/overlays/ocp4-stage/kustomization.yaml
+++ b/management-api/overlays/ocp4-stage/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: management-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/management-api
+    newTag: latest
 patchesStrategicMerge:
   - configmap.yaml
   - imagestreamtag.yaml

--- a/management-api/overlays/test/kustomization.yaml
+++ b/management-api/overlays/test/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: management-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/management-api
+    newTag: latest
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/metrics-exporter/overlays/aws-prod/kustomization.yaml
+++ b/metrics-exporter/overlays/aws-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role_bindings.yaml
   - thoth-notification.yaml
+images:
+  - name: metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
   - imagestreamtag.yaml

--- a/metrics-exporter/overlays/moc-prod/kustomization.yaml
+++ b/metrics-exporter/overlays/moc-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role_bindings.yaml
   - thoth-notification.yaml
+images:
+  - name: metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
   - imagestreamtag.yaml

--- a/metrics-exporter/overlays/ocp4-stage/kustomization.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role_bindings.yaml
   - thoth-notification.yaml
+images:
+  - name: metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-stage/metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/metrics-exporter/overlays/test/kustomization.yaml
+++ b/metrics-exporter/overlays/test/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: metrics-exporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/metrics-exporter
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/mi-scheduler/base/argo-workflows/mi-merge-workflow.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-merge-workflow.yaml
@@ -6,7 +6,8 @@ metadata:
     app: thoth
     component: mi
     template: mi-merge
-
+  annotations:
+    operation: mi
 spec:
   serviceAccountName: argo
   entrypoint: mi-merge-workflow

--- a/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
+++ b/mi-scheduler/base/argo-workflows/mi-workflow-template.yaml
@@ -6,7 +6,8 @@ metadata:
     app: thoth
     component: mi
     template: mi
-
+  annotations:
+    operation: mi
 spec:
   serviceAccountName: argo
   entrypoint: mi-workflow

--- a/mi-scheduler/base/kustomization.yaml
+++ b/mi-scheduler/base/kustomization.yaml
@@ -6,6 +6,8 @@ commonLabels:
   app.kubernetes.io/managed-by: aicoe-thoth-devops
 resources:
   - argo-workflows/mi-workflow-template.yaml
+  - argo-workflows/mi-merge-workflow.yaml
+  - openshift-templates/mi-merge-template.yaml
   - openshift-templates/mi-run-template.yaml
   - configmaps.yaml
   - cronjob.yaml

--- a/mi-scheduler/overlays/moc-prod/kustomization.yaml
+++ b/mi-scheduler/overlays/moc-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: mi-scheduler
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-prod/mi-scheduler
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml
@@ -17,6 +21,15 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/1/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/mi:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=mi"
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/mi-scheduler/overlays/ocp4-stage/kustomization.yaml
+++ b/mi-scheduler/overlays/ocp4-stage/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
   app.kubernetes.io/version: "0.6"
+images:
+  - name: mi-scheduler
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-stage/mi-scheduler
+    newTag: latest
 resources:
   - ../../base
   - role-binding.yaml
@@ -19,6 +23,15 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/1/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/mi:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=mi"
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/mi-scheduler/overlays/rick-test/kustomization.yaml
+++ b/mi-scheduler/overlays/rick-test/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: mi-scheduler
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/mi-scheduler
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml
@@ -11,3 +15,13 @@ generatorOptions:
   disableNameSuffixHash: true
 generators:
   - ./secret-generator.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/1/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/mi:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=mi"

--- a/mi-scheduler/overlays/test/kustomization.yaml
+++ b/mi-scheduler/overlays/test/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
   app.kubernetes.io/version: "0.6"
+images:
+  - name: mi-scheduler
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/mi-scheduler
+    newTag: latest
 resources:
   - ../../base
   - role-binding.yaml
@@ -13,3 +17,13 @@ generatorOptions:
   disableNameSuffixHash: true
 generators:
   - ./secret-generator.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/1/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/mi:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=mi"

--- a/nepthys/overlays/ocp/kustomization.yaml
+++ b/nepthys/overlays/ocp/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: nepthys
+    newName: image-registry.openshift-image-registry.svc:5000/aicoe-prod-bots/nepthys
+    newTag: latest
 generatorOptions:
   disableNameSuffixHash: true
 generators:

--- a/package-extract/overlays/aws-prod/kustomization.yaml
+++ b/package-extract/overlays/aws-prod/kustomization.yaml
@@ -27,3 +27,12 @@ patches:
       version: v1
       kind: Template
       name: build-analysis
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/package-extract:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: revsolve

--- a/package-extract/overlays/moc-prod/kustomization.yaml
+++ b/package-extract/overlays/moc-prod/kustomization.yaml
@@ -27,3 +27,12 @@ patches:
       version: v1
       kind: Template
       name: build-analysis
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/package-extract:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: revsolve

--- a/package-extract/overlays/ocp4-stage/kustomization.yaml
+++ b/package-extract/overlays/ocp4-stage/kustomization.yaml
@@ -27,3 +27,12 @@ patches:
       version: v1
       kind: Template
       name: build-analysis
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/package-extract:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: revsolve

--- a/package-extract/overlays/test/kustomization.yaml
+++ b/package-extract/overlays/test/kustomization.yaml
@@ -5,3 +5,13 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/package-extract:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: revsolve

--- a/package-releases/overlays/aws-prod/kustomization.yaml
+++ b/package-releases/overlays/aws-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-releases-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/package-releases-job
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/package-releases/overlays/moc-prod/kustomization.yaml
+++ b/package-releases/overlays/moc-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-releases-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/package-releases-job
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/package-releases/overlays/ocp4-stage/kustomization.yaml
+++ b/package-releases/overlays/ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-releases-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/package-releases-job
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/package-releases/overlays/test/kustomization.yaml
+++ b/package-releases/overlays/test/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-releases-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/package-releases-job
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/package-update/overlays/aws-prod/kustomization.yaml
+++ b/package-update/overlays/aws-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/package-update-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/package-update/overlays/moc-prod/kustomization.yaml
+++ b/package-update/overlays/moc-prod/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/package-update-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/package-update/overlays/ocp4-stage/kustomization.yaml
+++ b/package-update/overlays/ocp4-stage/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/package-update-job
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/package-update/overlays/test/kustomization.yaml
+++ b/package-update/overlays/test/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: package-update-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/package-update-job
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - cronjob.yaml

--- a/purge-job/overlays/moc-prod/kustomization.yaml
+++ b/purge-job/overlays/moc-prod/kustomization.yaml
@@ -21,3 +21,21 @@ patches:
       version: v1
       kind: Template
       name: purge
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: create-purge-issues
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/purge-job:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: purge

--- a/purge-job/overlays/ocp4-stage/kustomization.yaml
+++ b/purge-job/overlays/ocp4-stage/kustomization.yaml
@@ -21,3 +21,21 @@ patches:
       version: v1
       kind: Template
       name: purge-job
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: create-purge-issues
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/purge-job:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: purge

--- a/purge-job/overlays/test/kustomization.yaml
+++ b/purge-job/overlays/test/kustomization.yaml
@@ -8,3 +8,22 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: create-purge-issues
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/purge-job:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: purge

--- a/revsolver/overlays/aws-prod/kustomization.yaml
+++ b/revsolver/overlays/aws-prod/kustomization.yaml
@@ -25,3 +25,12 @@ patches:
       version: v1
       kind: Role
       name: revsolver
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/revsolver:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: extract-packages

--- a/revsolver/overlays/moc-prod/kustomization.yaml
+++ b/revsolver/overlays/moc-prod/kustomization.yaml
@@ -25,3 +25,12 @@ patches:
       version: v1
       kind: Role
       name: revsolver
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/revsolver:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: revsolve

--- a/revsolver/overlays/ocp4-stage/kustomization.yaml
+++ b/revsolver/overlays/ocp4-stage/kustomization.yaml
@@ -25,3 +25,12 @@ patches:
       version: v1
       kind: Role
       name: revsolver
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/revsolver:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: revsolve

--- a/revsolver/overlays/test/kustomization.yaml
+++ b/revsolver/overlays/test/kustomization.yaml
@@ -6,3 +6,13 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/revsolver:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: revsolve

--- a/security-indicators/overlays/aws-prod/kustomization.yaml
+++ b/security-indicators/overlays/aws-prod/kustomization.yaml
@@ -18,3 +18,39 @@ patches:
       version: v1
       kind: Template
       name: security-indicators
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/si-aggregator:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: aggregator
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/si-bandit:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: bandit
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/si-cloc:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: cloc
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: download-package

--- a/security-indicators/overlays/moc-prod/kustomization.yaml
+++ b/security-indicators/overlays/moc-prod/kustomization.yaml
@@ -18,3 +18,39 @@ patches:
       version: v1
       kind: Template
       name: security-indicators
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/si-aggregator:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: aggregator
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/si-bandit:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: bandit
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/si-cloc:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: cloc
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: download-package

--- a/security-indicators/overlays/ocp4-stage/kustomization.yaml
+++ b/security-indicators/overlays/ocp4-stage/kustomization.yaml
@@ -20,3 +20,39 @@ patches:
       version: v1
       kind: Template
       name: security-indicators
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/si-aggregator:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: aggregator
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/si-bandit:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: bandit
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/si-cloc:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: cloc
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: download-package

--- a/security-indicators/overlays/test/kustomization.yaml
+++ b/security-indicators/overlays/test/kustomization.yaml
@@ -7,3 +7,40 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/si-aggregator:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: aggregator
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/si-bandit:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: bandit
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/si-cloc:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: cloc
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      name: download-package

--- a/sefkhet-abwy-chatbot/overlays/moc/kustomization.yaml
+++ b/sefkhet-abwy-chatbot/overlays/moc/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+images:
+  - name: sefkhet-abwy-chatbot
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-bots-prod/sefkhet-abwy-chatbot
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 generatorOptions:

--- a/sefkhet-abwy/overlays/moc/kustomization.yaml
+++ b/sefkhet-abwy/overlays/moc/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - configmap.yaml
   - thoth-notification.yaml
+images:
+  - name: sefkhet-abwy
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-bots-prod/sefkhet-abwy
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 generatorOptions:

--- a/sefkhet-abwy/overlays/ocp/kustomization.yaml
+++ b/sefkhet-abwy/overlays/ocp/kustomization.yaml
@@ -5,6 +5,10 @@ resources:
   - configmap.yaml
   - ultrahook.yaml
   - thoth-notification.yaml
+images:
+  - name: sefkhet-abwy
+    newName: image-registry.openshift-image-registry.svc:5000/aicoe-prod-bots/sefkhet-abwy
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 generatorOptions:

--- a/slo-reporter/overlays/moc-prod-ocp4-stage/kustomization.yaml
+++ b/slo-reporter/overlays/moc-prod-ocp4-stage/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - configmap.yaml
   - thoth-notification.yaml
+images:
+  - name: slo-reporter
+    newName: image-registry.openshift-image-registry.svc:5000/aicoe-prod-bots/slo-reporter
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/slo-reporter/overlays/ocp4-stage/kustomization.yaml
+++ b/slo-reporter/overlays/ocp4-stage/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - ../../base
   - configmap.yaml
   - thoth-notification.yaml
+images:
+  - name: slo-reporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-infra-stage/slo-reporter
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/slo-reporter/overlays/test/kustomization.yaml
+++ b/slo-reporter/overlays/test/kustomization.yaml
@@ -7,6 +7,10 @@ resources:
   - ../../base
   - configmap.yaml
   - thoth-notification.yaml
+images:
+  - name: slo-reporter
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/slo-reporter
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/solver-project-url-job/overlays/test/kustomization.yaml
+++ b/solver-project-url-job/overlays/test/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - thoth-notification.yaml
+images:
+  - name: solver-project-url-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/solver-project-url-job
+    newTag: latest
 patchesStrategicMerge:
   - cronjob.yaml
   - imagestreamtag.yaml

--- a/solver/base/argo-workflows/parse-solver-output.yaml
+++ b/solver/base/argo-workflows/parse-solver-output.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: parse-solver-output
+  annotations:
+    operation: workflow-helpers
 spec:
   templates:
     - name: parse-solver-output

--- a/solver/overlays/aws-prod/kustomization.yaml
+++ b/solver/overlays/aws-prod/kustomization.yaml
@@ -24,3 +24,12 @@ patches:
       version: v1
       kind: Template
       name: solver
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"

--- a/solver/overlays/moc-prod/kustomization.yaml
+++ b/solver/overlays/moc-prod/kustomization.yaml
@@ -24,3 +24,12 @@ patches:
       version: v1
       kind: Template
       name: solver
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"

--- a/solver/overlays/ocp4-stage/kustomization.yaml
+++ b/solver/overlays/ocp4-stage/kustomization.yaml
@@ -24,3 +24,12 @@ patches:
       version: v1
       kind: Template
       name: solver
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"

--- a/solver/overlays/test/kustomization.yaml
+++ b/solver/overlays/test/kustomization.yaml
@@ -13,3 +13,12 @@ patches:
       version: v1alpha1
       kind: WorkflowTemplate
       name: solver-any
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/workflow-helpers:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=workflow-helpers"

--- a/triage-party/overlays/moc/kustomization.yaml
+++ b/triage-party/overlays/moc/kustomization.yaml
@@ -3,6 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - pcache.yaml
+images:
+  - name: triage-party
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-bots-prod/triage-party
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtags.yaml
   - route.yaml

--- a/user-api/base/deploymentconfig.yaml
+++ b/user-api/base/deploymentconfig.yaml
@@ -19,7 +19,6 @@ spec:
         discovery.3scale.net: "true"
         service: user-api
       annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
         discovery.3scale.net/description-path: "/api/v1/openapi.json"
         discovery.3scale.net/path: "/api/v1"
         discovery.3scale.net/port: "443"

--- a/user-api/overlays/aws-prod/deploymentconfig.yaml
+++ b/user-api/overlays/aws-prod/deploymentconfig.yaml
@@ -19,7 +19,6 @@ spec:
         discovery.3scale.net: "true"
         service: user-api
       annotations:
-        alpha.image.policy.openshift.io/resolve-names: '*'
         discovery.3scale.net/description-path: "/api/v1/openapi.json"
         discovery.3scale.net/path: "/api/v1"
         discovery.3scale.net/port: "443"

--- a/user-api/overlays/aws-prod/kustomization.yaml
+++ b/user-api/overlays/aws-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: user-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/user-api
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
   - imagestreamtag.yaml

--- a/user-api/overlays/moc-prod/kustomization.yaml
+++ b/user-api/overlays/moc-prod/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: user-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/user-api
+    newTag: latest
 patchesStrategicMerge:
   - deploymentconfig.yaml
   - imagestreamtag.yaml

--- a/user-api/overlays/ocp4-stage/kustomization.yaml
+++ b/user-api/overlays/ocp4-stage/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: user-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/user-api
+    newTag: latest
 patchesStrategicMerge:
   - configmap.yaml
   - imagestreamtag.yaml

--- a/user-api/overlays/test/kustomization.yaml
+++ b/user-api/overlays/test/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+images:
+  - name: user-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/user-api
+    newTag: latest
 generatorOptions:
   disableNameSuffixHash: true
 generators:


### PR DESCRIPTION
setup image patch to refer to the absolute path for images
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-To: #1996 

## Description

The pull request adds the patch workaround to use the absolute path instead of imagestream shorthand.