### PR TITLE
attach the routes for user-api in the balrog cluster

### DIFF
--- a/user-api/overlays/aws-prod/kustomization.yaml
+++ b/user-api/overlays/aws-prod/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
   - ../../base
   - role-binding.yaml
   - thoth-notification.yaml
+  - route53.yaml
+  - khemenu-route.yaml
 images:
   - name: user-api
     newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-prod/user-api


### PR DESCRIPTION
attach the routes for user-api in the balrog cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/1983

## Description

Explicit routes were missing, this PR adds them.