### PR TITLE
Randomize walks in prescriptions in deployment

### DIFF
--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-gh.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-gh.yaml
@@ -28,6 +28,8 @@ spec:
             value: app.sh
           - name: THOTH_PRESCRIPTIONS_REFRESH_SUBCOMMAND
             value: gh-link
+          - name: THOTH_PRESCRIPTIONS_REFRESH_RANDOMIZE
+            value: "1"
           - name: GITHUB_PRIVATE_KEY_PATH
             value: /opt/app-root/src/.github/github-privatekey
           - name: THOTH_LOGGING_NO_JSON
@@ -122,6 +124,8 @@ spec:
             value: app.sh
           - name: THOTH_PRESCRIPTIONS_REFRESH_SUBCOMMAND
             value: gh-archived
+          - name: THOTH_PRESCRIPTIONS_REFRESH_RANDOMIZE
+            value: "1"
           - name: GITHUB_PRIVATE_KEY_PATH
             value: /opt/app-root/src/.github/github-privatekey
           - name: THOTH_LOGGING_NO_JSON
@@ -197,6 +201,8 @@ spec:
             value: app.sh
           - name: THOTH_PRESCRIPTIONS_REFRESH_SUBCOMMAND
             value: gh-release-notes
+          - name: THOTH_PRESCRIPTIONS_REFRESH_RANDOMIZE
+            value: "1"
           - name: GITHUB_PRIVATE_KEY_PATH
             value: /opt/app-root/src/.github/github-privatekey
           - name: THOTH_LOGGING_NO_JSON


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/prescriptions-refresh-job/pull/19/

## Description

Let's randomize walks when checking prescriptions available. If a job in deployment fails for some reason, it will will not start from the beginning but will take another random path (ex. caused by GitHub API limits).
