### PR TITLE
adding graph service monitor

### DIFF
--- a/core/overlays/moc-prod/graph-prod/kustomization.yaml
+++ b/core/overlays/moc-prod/graph-prod/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - pgbouncer.yaml
   - postgresql.yaml
   - postgresql-metrics-exporter.yaml
+  - service-monitor.yaml
   - thoth-notification.yaml
 patches:
   - patch: |-

--- a/core/overlays/moc-prod/graph-prod/service-monitor.yaml
+++ b/core/overlays/moc-prod/graph-prod/service-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-graph-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - interval: 15s
+      port: metrics
+      scheme: http
+      relabelings:
+        - source_labels: [service]
+          regex: "postgres-metrics-exporter"
+          action: replace
+          target_label: field
+          replacement: postgres-metrics-exporter-thoth-graph-prod.apps.smaug.na.operate-first.cloud
+  namespaceSelector:
+    matchNames:
+      - thoth-graph-prod
+  selector: {}


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/2013

## Does this require new deployment ?

- no

## Description

Applying service monitors to Smaug for the Thoth-graph-prod namespace, to relabel subdomain style URL as the field label.
