### PR TITLE
patch up the image resolution for solver images

### DIFF
--- a/solver/overlays/aws-prod/kustomization.yaml
+++ b/solver/overlays/aws-prod/kustomization.yaml
@@ -37,6 +37,9 @@ patches:
       - op: replace
         path: /spec/templates/0/container/image
         value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/{{inputs.parameters.THOTH_SOLVER_NAME}}:latest
+      - op: replace
+        path: /spec/templates/1/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/{{inputs.parameters.THOTH_SOLVER_NAME}}:latest
     target:
       group: argoproj.io
       version: v1alpha1

--- a/solver/overlays/moc-prod/kustomization.yaml
+++ b/solver/overlays/moc-prod/kustomization.yaml
@@ -37,6 +37,9 @@ patches:
       - op: replace
         path: /spec/templates/0/container/image
         value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/{{inputs.parameters.THOTH_SOLVER_NAME}}:latest
+      - op: replace
+        path: /spec/templates/1/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/{{inputs.parameters.THOTH_SOLVER_NAME}}:latest
     target:
       group: argoproj.io
       version: v1alpha1

--- a/solver/overlays/ocp4-stage/kustomization.yaml
+++ b/solver/overlays/ocp4-stage/kustomization.yaml
@@ -37,6 +37,9 @@ patches:
       - op: replace
         path: /spec/templates/0/container/image
         value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/{{inputs.parameters.THOTH_SOLVER_NAME}}:latest
+      - op: replace
+        path: /spec/templates/1/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/{{inputs.parameters.THOTH_SOLVER_NAME}}:latest
     target:
       group: argoproj.io
       version: v1alpha1


### PR DESCRIPTION
patch up the image resolution for solver images
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/2053

## Description

It seems there was missing the patch of the image in the solver worktemplate