### PR TITLE
Bump up the sefkhet-abwy version v0.22.2

### DIFF
--- a/sefkhet-abwy-chatbot/overlays/moc/imagestreamtag.yaml
+++ b/sefkhet-abwy-chatbot/overlays/moc/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.20.3
+        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.22.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/sefkhet-abwy/overlays/moc/imagestreamtag.yaml
+++ b/sefkhet-abwy/overlays/moc/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.22.0-dev
+        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.22.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/sefkhet-abwy/overlays/ocp/imagestreamtag.yaml
+++ b/sefkhet-abwy/overlays/ocp/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.21.1
+      name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.22.2
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Bump up the sefkhet-abwy version v0.22.2
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

The image is already available: https://quay.io/repository/thoth-station/sefkhet-abwy-webhook-receiver?tab=tags
