### PR TITLE
Temporarily revert the version update for the chatbot

### DIFF
--- a/sefkhet-abwy-chatbot/overlays/moc/imagestreamtag.yaml
+++ b/sefkhet-abwy-chatbot/overlays/moc/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.22.2
+        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.20.3
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION

## Related Issues and Dependencies

This is a temporary workaround while AICoE/sefkhet-abwy#178 is fixed

## Description

This reverts the version bump for the chatbot from #2064 because the bot is currently down.

