### PR TITLE
patch the tide service to type ClusterIP

### DIFF
--- a/prow/base/tide.yaml
+++ b/prow/base/tide.yaml
@@ -111,4 +111,4 @@ spec:
     - name: metrics
       port: 9090
       protocol: TCP
-  type: NodePort
+  type: ClusterIP


### PR DESCRIPTION
patch the tide service to type ClusterIP
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2075

## Description

The tide service should be available for pods in the clusters.
Reference: 
- https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
- https://cloud.google.com/kubernetes-engine/docs/concepts/service