### PR TITLE
Make monitored container images by prescriptions-refresh configurable

### DIFF
--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-quay.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-quay.yaml
@@ -30,6 +30,11 @@ spec:
             value: "1"
           - name: THOTH_PRESCRIPTIONS_REFRESH_SUBCOMMAND
             value: quay-security
+          - name: THOTH_PRESCRIPTIONS_REFRESH_CONFIGURED_IMAGES
+            valueFrom:
+              configMapKeyRef:
+                key: configured-images
+                name: prescriptions-refresh-job
           - name: GITHUB_PRIVATE_KEY_PATH
             value: /opt/app-root/src/.github/github-privatekey
           - name: THOTH_LOGGING_NO_JSON

--- a/prescriptions-refresh-job/base/configmap.yaml
+++ b/prescriptions-refresh-job/base/configmap.yaml
@@ -1,0 +1,7 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prescriptions-refresh-job
+data:
+  configured-images: ""

--- a/prescriptions-refresh-job/base/kustomization.yaml
+++ b/prescriptions-refresh-job/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - argo-workflows/prescriptions-refresh-scorecards.yaml
   - argo-workflows/prescriptions-refresh.yaml
   - imagestream.yaml
+  - configmap.yaml
 generatorOptions:
   disableNameSuffixHash: true
 generators:


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/prescriptions-refresh-job/pull/37

## Description

The new implementation provides a way to configure which container images should be monitored and checked for security by Quay security scanners.