### PR TITLE
Fix the route to prow's deck

### DIFF
--- a/prow/overlays/smaug/routes.yaml
+++ b/prow/overlays/smaug/routes.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Service
     name: deck
     weight: 100
+  port:
+    targetPort: main
 ---
 kind: Route
 apiVersion: route.openshift.io/v1
@@ -41,6 +43,22 @@ spec:
   to:
     kind: Service
     name: hook
+    weight: 100
+  port:
+    targetPort: metrics
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: deck-metrics
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/timeout: 45s
+spec:
+  path: /metrics
+  to:
+    kind: Service
+    name: deck
     weight: 100
   port:
     targetPort: metrics


### PR DESCRIPTION

## Related Issues and Dependencies

Found while investigating #2075, although this should not affect prow's tide

## Does this require new deployment ?

No

## Description

<!--- Describe your changes in detail -->

With the addition of a metrics port to the deck service (#2078), the deck route was splitting traffic between the two ports in the service (main and metrics), resulting in half of the requests returning a 404:

```
$ for i in {1..10}; do (curl -Is https://prow.operate-first.cloud/ | grep ^HTTP) done | sort | uniq -c
      6 HTTP/1.1 200 OK
      4 HTTP/1.1 404 Not Found
```

This change specifes the service target port for the deck Route and adds a separate Route for the metrics endpoint.
