### PR TITLE
Graph service-monitor creates field label on balrog

### DIFF
--- a/core/overlays/aws-prod/graph-prod/kustomization.yaml
+++ b/core/overlays/aws-prod/graph-prod/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - pgbouncer.yaml
   - postgresql.yaml
   - postgresql-metrics-exporter.yaml
+  - service-monitor.yaml
   - thoth-notification.yaml
 patches:
   - patch: |-

--- a/core/overlays/aws-prod/graph-prod/service-monitor.yaml
+++ b/core/overlays/aws-prod/graph-prod/service-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-graph-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - interval: 15s
+      port: metrics
+      scheme: http
+      relabelings:
+        - sourceLabels: [service]
+          regex: "postgres-metrics-exporter"
+          action: replace
+          targetLabel: field
+          replacement: postgres-metrics-exporter-thoth-graph-prod.apps.balrog.aws.operate-first.cloud/
+  namespaceSelector:
+    matchNames:
+      - thoth-graph-prod
+  selector: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses part of [issue 2029](https://github.com/thoth-station/thoth-application/issues/2029)
    - [_1/5_] create service monitor for each namespace corresponding components
Deploys this service monitor in the same way as [pr 2046](https://github.com/thoth-station/thoth-application/pull/2046/) but for balrog.

## Description

This PR adds enables our service label for metrics from thoth-graph-prod to have a new field label with the path/route of the corresponding service as the value through a service monitor deployed to balrog.
