### PR TITLE
Backend service-monitor creates field label on balrog

### DIFF
--- a/core/overlays/aws-prod/backend-prod/kustomization.yaml
+++ b/core/overlays/aws-prod/backend-prod/kustomization.yaml
@@ -8,8 +8,9 @@ resources:
   - argo-role.yaml
   - argo-ui-controller.yaml
   - argo-workflow-controller.yaml
-  - thoth-notification.yaml
   - configmaps.yaml
+  - service-monitor.yaml
+  - thoth-notification.yaml
 # wf controller image patch
 images:
   - name: argocli

--- a/core/overlays/aws-prod/backend-prod/service-monitor.yaml
+++ b/core/overlays/aws-prod/backend-prod/service-monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-backend-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - interval: 15s
+      port: metrics
+      scheme: http
+      relabelings:
+        - sourceLabels: [service]
+          regex: "argo-server"
+          action: replace
+          targetLabel: field
+          replacement: argo-ui-thoth-backend-prod.apps.balrog.aws.operate-first.cloud
+        - sourceLabels: [service]
+          regex: "workflow-controller-metrics"
+          action: replace
+          targetLabel: field
+          replacement: workflow-controller-metrics-thoth-backend-prod.apps.balrog.aws.operate-first.cloud
+  namespaceSelector:
+    matchNames:
+      - thoth-backend-prod
+  selector: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses part of [issue 2029](https://github.com/thoth-station/thoth-application/issues/2029)
    - [_2/5_] create service monitor for each namespace corresponding components
Deploys this service monitor in the same way as [pr 2045](https://github.com/thoth-station/thoth-application/pull/2045/) but for balrog.

Also alphabetized the resources in the overlay.

## Description

This PR adds enables our service label for metrics from thoth-backend-prod to have a new field label with the path/route of the corresponding service as the value through a service monitor deployed to balrog.