### PR TITLE
Frontend service-monitor creates field label on balrog

### DIFF
--- a/core/overlays/aws-prod/frontend-prod/kustomization.yaml
+++ b/core/overlays/aws-prod/frontend-prod/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../common/
+  - service-monitor.yaml
   - thoth-notification.yaml
 patches:
   - patch: |-

--- a/core/overlays/aws-prod/frontend-prod/service-monitor.yaml
+++ b/core/overlays/aws-prod/frontend-prod/service-monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-frontend-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - interval: 15s
+      port: metrics
+      scheme: http
+      relabelings:
+        - sourceLabels: [service]
+          regex: "user-api"
+          action: replace
+          targetLabel: field
+          replacement: user-api-thoth-frontend-prod.apps.balrog.aws.operate-first.cloud
+        - sourceLabels: [service]
+          regex: "management-api"
+          action: replace
+          targetLabel: field
+          replacement: management-api-thoth-frontend-prod.apps.balrog.aws.operate-first.cloud
+  namespaceSelector:
+    matchNames:
+      - thoth-frontend-prod
+  selector: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses part of [issue 2029](https://github.com/thoth-station/thoth-application/issues/2029)
    - [_3/5_] create service monitor for each namespace corresponding components
Deploys this service monitor in the same way as [pr 2043](https://github.com/thoth-station/thoth-application/pull/2043/) but for balrog.

## Description

This PR adds enables our service label for metrics from thoth-frontend-prod to have a new field label with the path/route of the corresponding service as the value through a service monitor deployed to balrog.