### PR TITLE
Middletier service-monitor creates field label on balrog

### DIFF
--- a/core/overlays/aws-prod/middletier-prod/kustomization.yaml
+++ b/core/overlays/aws-prod/middletier-prod/kustomization.yaml
@@ -8,8 +8,9 @@ resources:
   - argo-role.yaml
   - argo-ui-controller.yaml
   - argo-workflow-controller.yaml
-  - thoth-notification.yaml
   - configmaps.yaml
+  - service-monitor.yaml
+  - thoth-notification.yaml
 # wf controller image patch
 images:
   - name: argocli

--- a/core/overlays/aws-prod/middletier-prod/service-monitor.yaml
+++ b/core/overlays/aws-prod/middletier-prod/service-monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-middletier-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - interval: 15s
+      port: metrics
+      scheme: http
+      relabelings:
+        - sourceLabels: [service]
+          regex: "argo-server"
+          action: replace
+          targetLabel: field
+          replacement: argo-ui-thoth-middletier-prod.apps.balrog.aws.operate-first.cloud
+        - sourceLabels: [service]
+          regex: "workflow-controller-metrics"
+          action: replace
+          targetLabel: field
+          replacement: workflow-controller-metrics-thoth-middletier-prod.apps.balrog.aws.operate-first.cloud
+  namespaceSelector:
+    matchNames:
+      - thoth-middletier-prod
+  selector: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses [issue 2029](https://github.com/thoth-station/thoth-application/issues/2029)
    - [_5/5_] create service monitor for each namespace corresponding components
Deploys this service monitor in the same way as [pr 2044](https://github.com/thoth-station/thoth-application/pull/2044/) but for balrog.

Dependencies / related PRs:
 - [Frontend service Monitor](https://github.com/thoth-station/thoth-application/pull/2105)
 - [Backend service Monitor](https://github.com/thoth-station/thoth-application/pull/2104)
 - [Graph service Monitor](https://github.com/thoth-station/thoth-application/pull/2103)
 - [Infra service Monitor](https://github.com/thoth-station/thoth-application/pull/2108)

Also alphabetized resources.

## Description

This PR adds enables our service label for metrics from thoth-middletier-prod to have a new field label with the path/route of the corresponding service as the value through a service monitor deployed to balrog.