### PR TITLE
Infra-prod service-monitor creates field label on balrog

### DIFF
--- a/core/overlays/aws-prod/infra-prod/kustomization.yaml
+++ b/core/overlays/aws-prod/infra-prod/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../common/
   - pushgateway.yaml
+  - service-monitor.yaml
   - thoth-notification.yaml
 generators:
   - secret-generator.yaml

--- a/core/overlays/aws-prod/infra-prod/service-monitor.yaml
+++ b/core/overlays/aws-prod/infra-prod/service-monitor.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-infra-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scheme: http
+      relabelings:
+        - sourceLabels: [service]
+          regex: "metrics-exporter"
+          action: replace
+          targetLabel: field
+          replacement: metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud
+        - sourceLabels: [service]
+          regex: "investigator-faust-web"
+          action: replace
+          targetLabel: field
+          replacement: investigator-faust-web-thoth-infra-prod.apps.balrog.aws.operate-first.cloud
+        - sourceLabels: [service]
+          regex: "investigator-message-metrics"
+          action: replace
+          targetLabel: field
+          replacement: investigator-message-metrics-thoth-infra-prod.apps.balrog.aws.operate-first.cloud
+  namespaceSelector:
+    matchNames:
+      - thoth-infra-prod
+  selector: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses part of [issue 2029](https://github.com/thoth-station/thoth-application/issues/2029)
    - [_4/5_] create service monitor for each namespace corresponding components
Deploys this service monitor in the same way as [pr 2038](https://github.com/thoth-station/thoth-application/pull/2038/) but for balrog.

## Description

This PR adds enables our service label for metrics from thoth-infra-prod to have a new field label with the path/route of the corresponding service as the value through a service monitor deployed to balrog.