### PR TITLE
use emptyDir for cloning git repo

### DIFF
--- a/kebechet/base/argo-workflows/kebechet-run-url.yaml
+++ b/kebechet/base/argo-workflows/kebechet-run-url.yaml
@@ -36,6 +36,8 @@ spec:
             value: "{{inputs.parameters.KEBECHET_SERVICE_NAME}}"
           - name: KEBECHET_METADATA
             value: "{{inputs.parameters.KEBECHET_METADATA}}"
+          - name: KEBECHET_GIT_CLONE_DIRECTORY
+            value: "/tmp/clone-dir"
           - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:
@@ -85,6 +87,8 @@ spec:
           - name: github-app-privatekey
             mountPath: /home/user/github
             readOnly: true
+          - name: clone-dir
+            mountPath: /tmp/clone-dir
         resources:
           limits:
             cpu: 1

--- a/kebechet/base/argo-workflows/kebechet.yaml
+++ b/kebechet/base/argo-workflows/kebechet.yaml
@@ -30,6 +30,8 @@ spec:
             value: "run-webhook"
           - name: KEBECHET_PAYLOAD
             value: "{{inputs.parameters.WEBHOOK_PAYLOAD}}"
+          - name: KEBECHET_GIT_CLONE_DIRECTORY
+            value: "/tmp/clone-dir"
           - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:
@@ -79,6 +81,8 @@ spec:
           - name: github-app-privatekey
             mountPath: /home/user/github
             readOnly: true
+          - name: clone-dir
+            mountPath: /tmp/clone-dir
         resources:
           limits:
             cpu: 1

--- a/kebechet/base/openshift-templates/kebechet-run-url.yaml
+++ b/kebechet/base/openshift-templates/kebechet-run-url.yaml
@@ -104,6 +104,8 @@ objects:
             items:
             - key: KEBBHUT_GITHUB_PRIVATE_KEY
               path: github-privatekey
+        - name: clone-dir
+          emptyDir: {}
 
       templates:
         - name: "kebechet-run-url"

--- a/kebechet/base/openshift-templates/kebechet.yaml
+++ b/kebechet/base/openshift-templates/kebechet.yaml
@@ -95,6 +95,8 @@ objects:
             items:
             - key: KEBBHUT_GITHUB_PRIVATE_KEY
               path: github-privatekey
+        - name: clone-dir
+          emptyDir: {}
 
       templates:
         - name: "kebechet"


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/kebechet/pull/880
https://github.com/thoth-station/support/issues/73

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

No space left on device when cloning large repositories such as prescriptions.

This change does not break anything, but needs a new version of Kebechet to take advantage of the empty directory