### PR TITLE
updating name of datasource in dashboards

### DIFF
--- a/grafana-dashboard/overlays/aws-prod/thoth-kafka-argo-metrics.json
+++ b/grafana-dashboard/overlays/aws-prod/thoth-kafka-argo-metrics.json
@@ -826,7 +826,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "description": "Percentage of workflows that has queue latency below a certain threshold",
       "fill": 1,
       "fillGradient": 0,

--- a/grafana-dashboard/overlays/aws-prod/thoth-knowledge-graph-content-metrics.json
+++ b/grafana-dashboard/overlays/aws-prod/thoth-knowledge-graph-content-metrics.json
@@ -27,7 +27,7 @@
   "panels": [
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -181,7 +181,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -330,7 +330,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -415,7 +415,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -500,7 +500,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -575,7 +575,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -649,7 +649,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -738,7 +738,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -812,7 +812,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -886,7 +886,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1041,7 +1041,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1192,7 +1192,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1266,7 +1266,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1340,7 +1340,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1414,7 +1414,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1488,7 +1488,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1562,7 +1562,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1636,7 +1636,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1710,7 +1710,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1799,7 +1799,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1873,7 +1873,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1947,7 +1947,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2021,7 +2021,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2095,7 +2095,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2188,7 +2188,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -2316,7 +2316,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -2413,7 +2413,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -2526,7 +2526,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -2626,7 +2626,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -2757,7 +2757,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -2855,7 +2855,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -2968,7 +2968,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -3064,7 +3064,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -3172,7 +3172,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3246,7 +3246,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3320,7 +3320,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3394,7 +3394,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3486,7 +3486,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -3614,7 +3614,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,
@@ -3717,7 +3717,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "decimals": 3,
       "fill": 1,
       "fillGradient": 0,

--- a/grafana-dashboard/overlays/aws-prod/thoth-sli-slo.json
+++ b/grafana-dashboard/overlays/aws-prod/thoth-sli-slo.json
@@ -509,7 +509,7 @@
       "type": "stat"
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -992,7 +992,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1067,7 +1067,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1140,7 +1140,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1215,7 +1215,7 @@
     },
     {
       "cacheTimeout": null,
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1504,7 +1504,7 @@
       }
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1737,7 +1737,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1978,7 +1978,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2249,7 +2249,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2489,7 +2489,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2785,7 +2785,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2988,7 +2988,7 @@
       "type": "state-timeline"
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4776,7 +4776,7 @@
       "yBucketSize": null
     },
     {
-      "datasource": "smaug-openshift-monitoring",
+      "datasource": "aws-balrog-monitoring",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
## Related Issues and Dependencies

[Origional issue](https://github.com/thoth-station/thoth-application/issues/2029)

modifying the [recent pr for the field update](https://github.com/thoth-station/thoth-application/pull/2097/)

updating datsource name in dashboard to match the smaug datasources definition updated in [operate-first/apps pull 1271](https://github.com/operate-first/apps/pull/1271/files#diff-6bf4d5d6548dd07ee15e2f0df300d5dde1ccbcdb437196b00ae2a66353286ca9R44)

## Does this require new deployment ?

no new deployment required

## Description

In the last PR, I named the datasource smaug-openshift-monitoring, however in the definition of the datasource itself, it was deployed as aws-balrog-monitoring, so I am opening a new PR to rectify this.
