### PR TITLE
Bump cve-update to v0.5.0 in stage environment

### DIFF
--- a/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.4.1
+        name: quay.io/thoth-station/cve-update-job:v0.5.0
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/issues/2091
Related: https://github.com/thoth-station/cve-update-job/issues/441
Related: https://github.com/thoth-station/cve-update-job/pull/442