### PR TITLE
Bump graph-backup-job to v0.8.11 in stage

### DIFF
--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.10
+        name: quay.io/thoth-station/graph-backup-job:v0.8.11
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/graph-backup-job/issues
