### PR TITLE
Bump init-job to v0.8.1 in stage

### DIFF
--- a/init-job/overlays/test/imagestreamtag.yaml
+++ b/init-job/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/init-job:v0.8.0
+        name: quay.io/thoth-station/init-job:v0.8.1
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/init-job/issues/433
