### PR TITLE
service monitor to expose prow metrics to smaug grafana

### DIFF
--- a/prow/overlays/smaug/kustomization.yaml
+++ b/prow/overlays/smaug/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - route-ghproxy-metrics.yaml
   - routes.yaml
   - s3-storage.yaml
+  - service-monitor.yaml
 patchesStrategicMerge:
   - imagestreamtags.yaml
   - unsuspend_branchprotector.yaml

--- a/prow/overlays/smaug/service-monitor.yaml
+++ b/prow/overlays/smaug/service-monitor.yaml
@@ -1,9 +1,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: thoth-station-prow-monitor
+  name: opf-prow-monitor
   labels:
-    monitor-component: thoth-station
+    monitor-component: operate-first
 spec:
   endpoints:
     - interval: 30s

--- a/prow/overlays/smaug/service-monitor.yaml
+++ b/prow/overlays/smaug/service-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-prow-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scheme: https
+  namespaceSelector:
+    matchNames:
+      - opf-ci-prow
+  selector: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses [issue 374](https://github.com/operate-first/support/issues/374). The service monitor should enable Grafana to access the metrics on its own.

## Does this require new deployment ?

no

## Description

Add a service monitor which scrapes the opf-ci-prow namespace and exposes those metics.