### PR TITLE
chore: add aicoe/seraph to tide

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -251,6 +251,7 @@ tide:
         - AICoE/s2i-custom-notebook
         - AICoE/sefkhet-abwy
         - AICoE/Varangian
+        - AICoE/seraph
       labels:
         - approved
       missingLabels:


### PR DESCRIPTION
Enable Tide on AICoE/seraph