### PR TITLE
removing jobs from smaug dashboards

### DIFF
--- a/grafana-dashboard/overlays/moc-prod/argocd.json
+++ b/grafana-dashboard/overlays/moc-prod/argocd.json
@@ -167,7 +167,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "time() - max(process_start_time_seconds{namespace=~\"$namespace\", job=\"Thoth ArgoCD Server Metrics\"})",
+              "expr": "time() - max(process_start_time_seconds{namespace=~\"$namespace\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A",

--- a/grafana-dashboard/overlays/moc-prod/thoth-knowledge-graph-content-metrics.json
+++ b/grafana-dashboard/overlays/moc-prod/thoth-knowledge-graph-content-metrics.json
@@ -92,7 +92,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "thoth_graphdb_adviser_count_per_source_type{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_adviser_count_per_source_type{field=\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -167,7 +167,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "thoth_graphdb_adviser_count_per_source_type{field=\"$instance\", job=\"Thoth Metrics\", prometheus=\"moc/smaug\"}",
+          "expr": "thoth_graphdb_adviser_count_per_source_type{field=\"$instance\", prometheus=\"moc/smaug\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -243,7 +243,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_kebechet_total_active_repo_count{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_kebechet_total_active_repo_count{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -316,7 +316,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "thoth_kebechet_total_active_repo_count{field=\"$instance\", job=\"Thoth Metrics\", prometheus=\"moc/smaug\"}",
+          "expr": "thoth_kebechet_total_active_repo_count{field=\"$instance\", prometheus=\"moc/smaug\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -393,7 +393,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "thoth_pypi_stats{stats_type=\"packages\", field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_pypi_stats{stats_type=\"packages\", field=\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -403,7 +403,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(thoth_graphdb_total_python_packages_per_indexes{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "sum(thoth_graphdb_total_python_packages_per_indexes{field=\"$instance\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "Thoth",
@@ -478,7 +478,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "thoth_pypi_stats{stats_type=\"releases\", field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_pypi_stats{stats_type=\"releases\", field=\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -488,7 +488,7 @@
         },
         {
           "exemplar": true,
-          "expr": "thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_number_python_package_versions{field=\"$instance\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Thoth",
@@ -562,7 +562,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_python_packages_per_indexes{field=\"$instance\", job=\"Thoth Metrics\", index_url=\"https://pypi.org/simple\"} / ignoring(index_url, stats_type) group_right thoth_pypi_stats{stats_type=\"packages\", field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_python_packages_per_indexes{field=\"$instance\", index_url=\"https://pypi.org/simple\"} / ignoring(index_url, stats_type) group_right thoth_pypi_stats{stats_type=\"packages\", field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -637,7 +637,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\"} / ignoring(stats_type) group_right thoth_pypi_stats{stats_type=\"releases\", field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_number_python_package_versions{field=\"$instance\"} / ignoring(stats_type) group_right thoth_pypi_stats{stats_type=\"releases\", field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -711,7 +711,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_python_indexes{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_python_indexes{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -800,7 +800,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_solvers{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_solvers{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -874,7 +874,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_solvers_database{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_solvers_database{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -949,7 +949,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-rhel-8-py38\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", solver_name=\"solver-rhel-8-py38\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1027,7 +1027,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-rhel-8-py38\", prometheus=\"moc/smaug\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\", prometheus=\"moc/smaug\"}",
+          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", solver_name=\"solver-rhel-8-py38\", prometheus=\"moc/smaug\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\", prometheus=\"moc/smaug\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1104,7 +1104,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-fedora-34-py39\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", solver_name=\"solver-fedora-34-py39\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1178,7 +1178,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-fedora-34-py39\", prometheus=\"moc/smaug\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\", prometheus=\"moc/smaug\"}",
+          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", solver_name=\"solver-fedora-34-py39\", prometheus=\"moc/smaug\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{field=\"$instance\", prometheus=\"moc/smaug\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1254,7 +1254,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_unsolved_python_packages{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_unsolved_python_packages{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1328,7 +1328,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1402,7 +1402,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(thoth_graphdb_total_python_packages_with_no_error{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "sum(thoth_graphdb_total_python_packages_with_no_error{field=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1476,7 +1476,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error{field=\"$instance\", job=\"Thoth Metrics\"}) - sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error{field=\"$instance\"}) - sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1550,7 +1550,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1624,7 +1624,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(thoth_graphdb_total_python_packages_with_no_error{field=\"$instance\", job=\"Thoth Metrics\"}) / sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "sum(thoth_graphdb_total_python_packages_with_no_error{field=\"$instance\"}) / sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1698,7 +1698,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "(sum(thoth_graphdb_total_python_packages_with_solver_error{field=\"$instance\", job=\"Thoth Metrics\"}) - sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\", job=\"Thoth Metrics\"})) / sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "(sum(thoth_graphdb_total_python_packages_with_solver_error{field=\"$instance\"}) - sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\"})) / sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1772,7 +1772,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\", job=\"Thoth Metrics\"}) / sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\"})",
+          "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\"}) / sum(thoth_graphdb_total_number_solved_python_packages{field=\"$instance\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1861,7 +1861,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_cve{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_cve{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1935,7 +1935,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_si_unanalyzed_python_packages{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_si_unanalyzed_python_packages{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -2009,7 +2009,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -2083,7 +2083,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_si_not_analyzable_python_packages{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_si_not_analyzable_python_packages{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -2158,7 +2158,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{field=\"$instance\", job=\"Thoth Metrics\"} / thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{field=\"$instance\"} / thoth_graphdb_number_python_package_versions{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -2231,7 +2231,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_python_packages_per_indexes{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_python_packages_per_indexes{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "PythonPackages: {{index_url}}",
@@ -2239,7 +2239,7 @@
           "step": 600
         },
         {
-          "expr": "thoth_graphdb_sum_python_packages_per_indexes{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_sum_python_packages_per_indexes{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Tot Python Packages per Index",
@@ -2247,7 +2247,7 @@
           "step": 600
         },
         {
-          "expr": "thoth_graphdb_number_python_package_versions{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_number_python_package_versions{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Tot Python Packages Releases",
@@ -2358,7 +2358,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -2456,7 +2456,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_solved_python_packages{field=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -2570,7 +2570,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_python_packages_with_no_error{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_python_packages_with_no_error{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Solved Python Packages with no error: {{solver_name}}",
@@ -2670,7 +2670,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_python_packages_with_solver_error{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_python_packages_with_solver_error{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Solved Python Packages with solver error (unsolvable=False, unparseable=False)): {{solver_name}}",
@@ -2678,7 +2678,7 @@
           "step": 1200
         },
         {
-          "expr": "thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_python_packages_with_solver_error_unsolvable{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Solved Python Packages with solver error (unsolvable=TRUE): {{solver_name}}",
@@ -2686,7 +2686,7 @@
           "step": 1200
         },
         {
-          "expr": "thoth_graphdb_total_python_packages_with_solver_error_unparseable{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_python_packages_with_solver_error_unparseable{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Solved Python Packages with solver error (unparseable=TRUE): {{solver_name}}",
@@ -2800,7 +2800,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_si_unanalyzed_python_packages{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_si_unanalyzed_python_packages{field=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -2898,7 +2898,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{field=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -3010,7 +3010,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_number_of_pi_per_framework{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_number_of_pi_per_framework{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "FRAMEWORK: {{framework}} | PI: {{pi}}",
@@ -3106,7 +3106,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{performance_table}}",
@@ -3234,7 +3234,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_matmul\"}",
+          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", performance_table=\"pi_matmul\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -3308,7 +3308,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_conv2d\"}",
+          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", performance_table=\"pi_conv2d\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -3382,7 +3382,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_conv1d\"}",
+          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", performance_table=\"pi_conv1d\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -3456,7 +3456,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_pybench\"}",
+          "expr": "thoth_graphdb_total_performance_records{field=\"$instance\", performance_table=\"pi_pybench\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -3529,7 +3529,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_user_software_stacks_records{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_user_software_stacks_records{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "External (User) Software Stacks",
@@ -3537,7 +3537,7 @@
           "step": 600
         },
         {
-          "expr": "thoth_graphdb_total_user_run_software_environment{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_user_run_software_environment{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of External Software Environment for Run",
@@ -3545,7 +3545,7 @@
           "step": 600
         },
         {
-          "expr": "thoth_graphdb_total_main_records{field=\"$instance\", job=\"Thoth Metrics\", main_table=~\"external_.*\"}",
+          "expr": "thoth_graphdb_total_main_records{field=\"$instance\", main_table=~\"external_.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of {{main_table}}",
@@ -3655,7 +3655,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "thoth_graphdb_total_run_software_environment{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_run_software_environment{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of Software Environment for Run",
@@ -3663,7 +3663,7 @@
           "step": 1200
         },
         {
-          "expr": "thoth_graphdb_total_build_software_environment{field=\"$instance\", job=\"Thoth Metrics\"}",
+          "expr": "thoth_graphdb_total_build_software_environment{field=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of Software Environment for Build",

--- a/grafana-dashboard/overlays/moc-prod/thoth-sli-slo.json
+++ b/grafana-dashboard/overlays/moc-prod/thoth-sli-slo.json
@@ -644,7 +644,7 @@
           "step": 600
         },
         {
-          "expr": "(thoth_graphdb_number_python_package_versions{field=\"$instance_metrics\", job=\"Thoth Metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
+          "expr": "(thoth_graphdb_number_python_package_versions{field=\"$instance_metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Estimated days to solve all packages adding a new solver (1h interval)",
@@ -841,7 +841,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\", job=\"Thoth Metrics\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
+          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Estimated days to solve (1h inverval): {{solver_name}}",
@@ -939,7 +939,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\", job=\"Thoth Metrics\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))",
+          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Estimated hours to solve (1h inverval): {{solver_name}}",
@@ -1054,7 +1054,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "(thoth_graphdb_number_python_package_versions{field=\"$instance_metrics\", job=\"Thoth Metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
+          "expr": "(thoth_graphdb_number_python_package_versions{field=\"$instance_metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Estimated days (1h interval)",
@@ -1201,7 +1201,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\", job=\"Thoth Metrics\", solver_name=\"solver-rhel-8-py38\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
+          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\", solver_name=\"solver-rhel-8-py38\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1276,7 +1276,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\", job=\"Thoth Metrics\", solver_name=\"solver-fedora-34-py39\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
+          "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{field=\"$instance_metrics\", solver_name=\"solver-fedora-34-py39\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{field=\"$instance_metrics\"}[1h]))/24",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses [Thoth grafana dashboards do not show any data](https://github.com/thoth-station/thoth-application/issues/2140)

Similar to [thoth-station/thoth-application pull 2118](https://github.com/thoth-station/thoth-application/pull/2118) but for smaug dashboards.

## Does this require new deployment ?

no

## Description

Removing the non-existent jobs from smaug dashboards so that metrics can reach grafana.
