### PR TITLE
Bump up the kebechet version to v1.6.4

### DIFF
--- a/kebechet/overlays/aws-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.6.3
+        name: quay.io/thoth-station/kebechet-job:v1.6.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/kebechet/overlays/moc-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.6.3
+        name: quay.io/thoth-station/kebechet-job:v1.6.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.6.3
+        name: quay.io/thoth-station/kebechet-job:v1.6.4
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up the kebechet version to v1.6.4
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/solver-error-classfier/issues/10
