### PR TITLE
Update mi to v2.10.1

### DIFF
--- a/mi-scheduler/overlays/test/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/mi:v2.7.0
+        name: quay.io/thoth-station/mi:v2.10.1
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/mi/issues/496

## Does this require new deployment ?

- [X] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.
