### PR TITLE
Enable prow/tide for the aicoe/donkeycar repo

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -261,6 +261,7 @@ tide:
         - AICoE/aicoe-sre
         - AICoE/content-pipeline
         - AICoE/data-driven-development
+        - AICoE/donkeycar
         - AICoE/elyra-aidevsecops-tutorial
         - AICoE/idh-manifests
         - AICoE/internal-data-hub


### PR DESCRIPTION
## Related Issues and Dependencies

For an example of a PR that is not merging see https://github.com/AICoE/donkeycar/pull/4

## Does this require new deployment ?

No

## Description

Enable prow (tide) to merge PRs in the [AICoE/donkeycar](https://github.com/AICoE/donkeycar) repository
