### PR TITLE
Update mi-scheduler to v1.7.2

### DIFF
--- a/mi-scheduler/overlays/test/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/test/imagestreamtag.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/mi-scheduler:v1.7.1
+        name: quay.io/thoth-station/mi-scheduler:v1.7.2
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/thoth-station/mi-scheduler/issues/200

## Does this require new deployment ?

- [X] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.
