### PR TITLE
Update the correct ceph host url for argo workflow controller

### DIFF
--- a/core/overlays/moc-prod/backend-prod/configmaps.yaml
+++ b/core/overlays/moc-prod/backend-prod/configmaps.yaml
@@ -39,7 +39,7 @@ data:
       s3:
         bucket: "thoth"
         keyPrefix: "data/smaug-prod/argo/artifacts/"
-        endpoint: "rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local"
+        endpoint: "s3-openshift-storage.apps.smaug.na.operate-first.cloud"
         insecure: true
         accessKeySecret:
           name: argo-artifact-repository-secrets

--- a/core/overlays/moc-prod/middletier-prod/configmaps.yaml
+++ b/core/overlays/moc-prod/middletier-prod/configmaps.yaml
@@ -39,7 +39,7 @@ data:
       s3:
         bucket: "thoth"
         keyPrefix: "data/smaug-prod/argo/artifacts/"
-        endpoint: "rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local"
+        endpoint: "s3-openshift-storage.apps.smaug.na.operate-first.cloud"
         insecure: true
         accessKeySecret:
           name: argo-artifact-repository-secrets


### PR DESCRIPTION
Update the correct ceph host url for argo workflow controller
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2149
## Description

As the URL was wrong, the argo event used to fail and didn't log the metrics correctly 
