### PR TITLE
Disable khemenu route from the moc prod as being used on balrog

### DIFF
--- a/user-api/overlays/moc-prod/kustomization.yaml
+++ b/user-api/overlays/moc-prod/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - khemenu-route.yaml
   - role-binding.yaml
   - route53.yaml
   - thoth-notification.yaml


### PR DESCRIPTION
Disable khemenu route from the moc prod as being used on balrog
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

As the khemenu is being used in the balrog cluster, it causes unnecessary pods on the moc smaug cluster. 