### PR TITLE
Bump prescriptions-refresh to v0.5.0 in test environment

### DIFF
--- a/prescriptions-refresh-job/overlays/test/imagestreamtag.yaml
+++ b/prescriptions-refresh-job/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions-refresh-job:v0.4.0
+        name: quay.io/thoth-station/prescriptions-refresh-job:v0.5.0
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/prescriptions-refresh-job/issues/91
