### PR TITLE
Bump prescriptions-refresh-job to v0.5.0 in moc

### DIFF
--- a/prescriptions-refresh-job/overlays/moc/imagestreamtag.yaml
+++ b/prescriptions-refresh-job/overlays/moc/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions-refresh-job:kebechet-v0.4.0
+        name: quay.io/thoth-station/prescriptions-refresh-job:kebechet-v0.5.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/prescriptions-refresh-job/issues/91
