### PR TITLE
fixing field label with double apps

### DIFF
--- a/core/overlays/moc-prod/frontend-prod/service-monitor.yaml
+++ b/core/overlays/moc-prod/frontend-prod/service-monitor.yaml
@@ -14,7 +14,7 @@ spec:
           regex: "user-api"
           action: replace
           targetLabel: field
-          replacement: user-api-thoth-frontend-prod.apps.apps.smaug.na.operate-first.cloud
+          replacement: user-api-thoth-frontend-prod.apps.smaug.na.operate-first.cloud
         - sourceLabels: [service]
           regex: "management-api"
           action: replace


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses [orrigional issue](https://github.com/thoth-station/thoth-application/issues/2160)
Allows fix in [thoth-application 2186](https://github.com/thoth-station/thoth-application/pull/2186)

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

Removing double apps from the service monitor, to change the route from which the metric is being scraped.
