### PR TITLE
Bump adviser to v0.49.0 in stage environment

### DIFF
--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.48.0
+        name: quay.io/thoth-station/adviser:v0.49.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Related: https://github.com/thoth-station/adviser/issues/2218