### PR TITLE
Bump user-api to v0.29.1 in stage

### DIFF
--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.28.2
+        name: quay.io/thoth-station/user-api:v0.29.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/user-api/pull/1535