### PR TITLE
setting up balrog alerting-rules

### DIFF
--- a/monitoring/overlays/aws-prod/alerting-rules.yaml
+++ b/monitoring/overlays/aws-prod/alerting-rules.yaml
@@ -1,0 +1,109 @@
+- op: replace
+  path: /spec
+  value:
+    groups:
+      - name: Thoth-rules
+        rules:
+          #### Alerts for services
+
+          # Alert for User API down
+        - alert: ThothUserAPIProd
+          expr: up{field="user-api-thoth-frontend-prod.apps.balrog.aws.operate-first.cloud:80"} < 1
+          for: 1m
+          annotations:
+            summary: "Thoth User API is down, all services are not available!"
+            severity: "HIGH"
+
+          # Alert for mismatch between number of requests and documents produced
+        - alert: ThothResultsMissingProd
+          expr: thoth_reporter_requests_gauge{env="aws-prod"} - thoth_reporter_reports_gauge{env="aws-prod"} > 0
+          for: 60m
+          annotations:
+            summary: "Thoth {{ $labels.component }} results do no match requests, some requests have been lost!"
+            severity: "HIGH"
+
+          # Alert for purge job once runtime is deleted
+        - alert: ThothPurgeJobMissedProd
+          expr: thoth_number_purge_issues_total{env="aws-prod"} - thoth_number_purge_issues_created{env="aws-prod"} > 0
+          for: 1m
+          annotations:
+            summary: "Not all purge job issues have been opened!"
+            severity: "HIGH"
+
+          # Alert for number of workflows in middletier
+        - alert: ThothMiddletierIngestionProd
+          expr: argo_workflows_count{field="workflow-controller-metrics-thoth-middletier-prod.apps.balrog.aws.operate-first.cloud:80", status="Running"} < 1
+          for: 60m
+          annotations:
+            summary: "Workflows running in Middletier Prod is 0! Please verify status of Data Ingestion in Thoth or add more workload!"
+            severity: "HIGH"
+
+          # Alert when solvers do not match Thoth s2i offered
+        - alert: ThothSolversThothS2iOfferedMismatchProd
+          expr: thoth_graphdb_solvers_number_match{field="metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"} == 1
+          for: 30m
+          annotations:
+            summary: "Number of solvers from ConfigMap and from database do not match!"
+            severity: "MEDIUM"
+
+          #### Alerts for Ceph
+
+          # Alert for issue in connection with Ceph
+        - alert: ThothCephConnectionProd
+          expr: thoth_ceph_connection_issues{field="metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"} == 1
+          for: 10m
+          annotations:
+            summary: "Ceph cannot be reached! Components are not able to store documents."
+            severity: "HIGH"
+
+          #### Alerts for Kafka
+
+          # Alert for issue in connection with Kafka
+        - alert: ThothKafkaConnectionProd
+          expr: thoth_kafka_connection_issues{field="metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"} == 1
+          for: 10m
+          annotations:
+            summary: "Kafka cannot be reached! Services cannot be scheduled."
+            severity: "HIGH"
+
+          # Alert when any of the message is halted
+        - alert: ThothKafkaMessageHaltedProd
+          expr: thoth_investigator_halted_topics{field="investigator-faust-web-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"} == 1
+          for: 5m
+          annotations:
+            summary: "Message {{ $labels.base_topic_name }} is halted! Please check errors."
+            severity: "HIGH"
+
+          #### Alerts for Database
+
+          # Alert for issue in connection to Database
+        - alert: ThothDatabaseConnectionProd
+          expr: thoth_graphdb_connection_issues{field="metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"} == 1
+          for: 10m
+          annotations:
+            summary: "Database cannot be reached! Services cannot be guaranteed."
+            severity: "HIGH"
+
+          # Alerts for alembic version mismatch between components and database.
+        - alert: ThothSchemaCheckProd
+          expr: thoth_graph_db_component_revision_check{env="aws-prod"} == 1
+          for: 5m
+          annotations:
+            summary: "Schema of {{ $labels.component }} is not in sync with database schema."
+            severity: "HIGH"
+
+          # Alert for amcheck database corruption check.
+        - alert: ThothDatabaseCorruptionCheckProd
+          expr: thoth_graphdb_is_corrupted{field="metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"} == 1
+          for: 5m
+          annotations:
+            summary: "Database schema is corrupted, all services need to be stopped."
+            severity: "HIGH"
+
+          # Alert for alembic version table corruption.
+        - alert: ThothMultipleAlembicRowsProd
+          expr: thoth_graphdb_alembic_table_check{field="metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"} == 1
+          for: 5m
+          annotations:
+            summary: "Database table for alembic version has more than one row, database is corrupted, all services need to be stopped."
+            severity: "HIGH"

--- a/monitoring/overlays/aws-prod/kustomization.yaml
+++ b/monitoring/overlays/aws-prod/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+generators:
+  - secret-generator.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+patches:
+  - path: alerting-rules.yaml
+    target:
+      group: monitoring.coreos.com
+      version: v1
+      kind: PrometheusRule
+      name: thoth-alerting-rules
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/args/0
+        value: --label=environment/aws/balrog
+    target:
+      group: apps
+      kind: Deployment
+      name: github-receiver
+      version: v1

--- a/monitoring/overlays/aws-prod/secret-generator.yaml
+++ b/monitoring/overlays/aws-prod/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: thoth-secret-generator
+files:
+  - ./secrets.enc.yaml

--- a/monitoring/overlays/aws-prod/secrets.enc.yaml
+++ b/monitoring/overlays/aws-prod/secrets.enc.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+items:
+-   apiVersion: v1
+    data:
+        auth-token: ENC[AES256_GCM,data:JMZxOxf7hhHSRRiOSiZ25D8OHkPIX8owi8IiZ9+jw4H1RW03NxBodq8tCqnEZd3dGX0RSvZvdno=,iv:aAjESuflNC9rwAGCqPMpU8P9yOgKnmpV90kL9P/dU1A=,tag:EqvcKsFH2jMYPp3HbIAu9A==,type:str]
+    kind: Secret
+    metadata:
+        name: github-secrets
+    type: Opaque
+kind: List
+metadata:
+    resourceVersion: ""
+    selfLink: ""
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2021-10-29T16:46:16Z'
+    mac: ENC[AES256_GCM,data:w5og442enILFsu6QnaKlBnn6o1nnz9dkRPBOH9PT2TWMr2TzKKhK763khT4QVdv8d6TkkXmBXZj+o9yMysQ5pMJxEo18I+CuYsNvZLz1i69R4q8A+xnrihFTUa/Ugar/Bvup4KZ9m9WTLy8Tkn1tdYQpaiRexL4gGht9oarNBkk=,iv:p9uN1zB9PdRCbdoNAvRUkG5IrlNY+ohf2FNGAVglNXE=,tag:PaPjVICiWKszQCa5Rpm1Iw==,type:str]
+    pgp:
+    -   created_at: '2021-10-29T16:46:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA1gbAjViyxWYARAAqcrbZS0bnmX4rTXbUgTphgbqj6uiQqrR6JTidHqIy16G
+            dCoAaJ41OV4bYoMhQdNqqkyZh1r+lUK9BNlId6nuzF4FelFweGuEMZh3+sXrEBJM
+            CVW1bETt9zzfb2yZtnIbYNN22z80PptX/YmdKTPV0MmyxIf0aEm4WXUxAUq0XrET
+            nmHnqCIUi3z6PhCpIufryCVWewzNHCLilZ8s1F185fAu491vxaEAcPhylWlMurlC
+            17ItfHGBYsjCnshPkUZVUfYU6AonOV6MHZYim0mgW0QGEfwIq22r0uSfnGmcwmlD
+            JWX2KOlirNTcQuhzZzZ5YnYmKNs/0vXDJDLpoQQq46rUhagMDxIg0Pq/JqS6Gjp7
+            lliwFqgsX7CHI87d5INSEZYdimxcW1nE7US85KXWJjDBpI07u9Tx5NV35DDklpxD
+            aQro8EDJKMg+28fS4Xs9YsW2dIZw89ACruzKLtLYlW1B5aFjdJd7yy4LCa53e6i2
+            hc/CQUhVMatc6+y9+u+9u2J+3eajlZR3+ePjjFeBteN+4IZx8PWBabTTlhPnnuxP
+            GLruYVKXWIcNMagY2OPQlj3fTMdTn5vUvLNLlnvYZVbpMxglKZh12hqEbCDUGT6m
+            ScS6ak/2uiMXfja7YGOyt4RilGoU9MnW9fyGbpBkUlk9o6uA8VbTHDJIYJdW0IDS
+            XgFaJnizAxtkJNP8R0smjmidHNzQloLRhTWXUSCNm7i8fVs81+C1p4P8RmPliHyT
+            QF8cv5vQuWUZbS+rJXmiYgQocgtpHe0+diWap/i7z2URYX6A0N7zCvKfh1PlQH8=
+            =8FXP
+            -----END PGP MESSAGE-----
+        fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
+    -   created_at: '2021-10-29T16:46:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA+/WpawS9RPbAQf7BgFKPSH8Sl2s0J7cJZiOhbT9aXYiXWLwXSC9U80bH7PX
+            EIWyZe8lHLl0UUF8Sabg74xlPAVVg6iJEd2uBMW9DYilHFxRHOU49N/Qs18Zi8O9
+            UmE5geZD45HQITHkUSgfzW89Ko0RuUkSDn0aFpXrCqRJMDbILaFPlS7HOe1NkuHT
+            saJkPpLE/XtFHt0lAo0wRAmFXqKRV6OAwPOFS+e/JCHDftJbrl55oG5PLusZQTjG
+            3a10AscThzQ7xuLwUUsLWr+z1jh9t4t6NkaMKHw9+mlLHqPjfkaaw2C0OrlOwrHZ
+            xPXR/iAJGlCVV4HkBPTnbqWaXYCtmdcyTyNpzBz+i9JeAfly7QVwLDebV6YWkXRy
+            h/O+eSta9flP6vbPIY3Psi73tEN8YPh5BMOtkNUwPBgoMXDwcmnUcAZijMN4S50O
+            LZp+qKv7lf2M+P79L3TEdGEjekybZnthvQg3+Qx62g==
+            =VTyH
+            -----END PGP MESSAGE-----
+        fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
+    -   created_at: '2021-10-29T16:46:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQgAj+aKuHYq6pytVC/8gHdvJtlFkhVE2zciza/zqmjdXqXF
+            O2Hbv9H0l9B8UwRvG0xM449KxRlUu9wBgZV00BAe/q4WAS222jqR6cY4nRfmixJb
+            tVRS5WJf9ahjarCBscFDXrp3G/a9sFdbOQd04jQduM8x6o3q6yVNK19sgSQULxs7
+            SY1/SgcorCLXr/iLi1QAqreVfonvyHHuil0r71saWgzioAvR5LrKDfWQsrmpkp7P
+            cbxK7GifVmRVQqE0GPVG/Yh+cehi0t9gZq4hdZGUINNajg6LOJFJMCqeOhHwZBxV
+            //+pxQ8k9Dy4SzCy7UXIU1hCA0OEt5MtqHK9k9lgxtJeARoutw0Yfxj8UilpkmYu
+            iHoTHBA8GjTZ9idwWC0Xpl8Mx1GPfFmyAKyHMDK4H1KzsqAFgwiT+ECXFTgk57PE
+            EExmsbE5hce835msZLWezqFZCkQnKX0w6uGW+PMleg==
+            =I4pO
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    -   created_at: '2021-10-29T16:46:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAAnAA6hEy4rL49LS3Je+8Nbp/r0scIt7PpLsYMry9frmH0
+            YzjMb6OfwnkaGwlsEoBbj2aQYFI+4jRUqWdbnjrCZvEXScFlBvuIQNDD/bhHPlty
+            Uktxv4+UVbF6jhCDur7m/XUiISRbS+NVgpEOinX7Kr9OgKnLxUpyQWW1f0GvU5Qf
+            nv7l1UbXh+UMreH6bSEBeG7ZfpDektl+G2NiOrmCp0epaJM1BiXS+HXOiabYjLf3
+            2Y5+d37dKNwzMtX+JAOYGkMNt0M1KIc5Rg/9lwc8ZlTj9aRQiXFMUyWtN79i3kKY
+            1fVrGaO7U62tAdMq/fbWqBTvuLQuSI+kubLzlE6+XYxKOu18MyolJgSqzmrSUsxR
+            XiCI7avXeuRx2sPvZANxMFbEBQwpONU0tXoVL1gAAFGAvP+R4U34y/BBvKpxJSxe
+            7NngzFmdalzBzF1YrkNEmUwLxMcitBgC5HqYsw2ZsjH1wjgrCqP+mAVZn1gRMdpZ
+            pkghJ8ucW3OE0xWI4PNBTbFOHKGffD5Z8ioPSw00HJBdVp647k5kWyHLP4TPpYvX
+            t4U0uV0vTkezS0j5WaM9jHfJpsdjvEHDCFuYhKX6qms+XFCePzqI18Zl4wM831KU
+            X9XcJFI0M5OfINvCK9Tams1XGAQ9NI4uZwe9YuMgkql0+ol6KjtHARvMJaUJQ0vS
+            XgG19amD/e4fK0u2bLGHDTy76FoBMo8wlxo8rmMtBvM5kmFYScJSku/F+YX/2v0m
+            BJy5ro76j9WIrtOPnC45sUhmr+oCwHq18d+T8eAgfgce6KKo2nQbUxfwL9jI//U=
+            =Gnv5
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    -   created_at: '2021-10-29T16:46:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIOA9LRbhPydJmLEAf/UxE6hFUr/2NrTyE9aWqEVl9blBN8cNkOipVIo/8k1PkJ
+            8M0EFZ4YWsJrW062vPlWkq0U0YR+KyPx+rGrZi1+BKdT6zbPUU6AzmTF+P2xu92o
+            CxzX6pD/a8B5tFKUzLpY/JqS5pFrPitBfod7OusPhavNTyl9Br4Fz1335wca7FD3
+            U+APgF3wRP0Uj0y/iwhJOIsfoco58de81CJ6N1lUH7MOXBgA38dkFrZBvbmwm5lk
+            9xvNKvww6oqmItnSbveB7d1IHo2gbr1MimX9UMXt/QktIqYSPWOKykZ4iVKGIFW/
+            qmYbC0GHGzHHb+pZmjzG5zK3kkTGw3ds8NIJ2Clciwf/UhirsRjLbPgbtD0cf6yz
+            PQx3MkzTAcJgsni0qJIFERaeCql6Kjg8gvqs9TdBPjF1K7yo0c/HwQDZe4TYnTCL
+            Emf4aCSwRh0AXPwQ8YuE4MJbvVheiXETH3cbUao4K14l7oO8lDxTOvp8fMk9uNcs
+            AR4HZPJ44ICaZboFviTOiuRiuNioZUwcmAN9aNfTFOI1mnLtUmKEZYMfoZz858GA
+            UCIEedSXozfICKIJQDvszqbrIbDM0Pg/AMSTUEYybhVOH8wyWt3gB5uG5Gv8//z9
+            I1t3bHUJFPpCgfWG4ZFoCHQJYn/WLTqErYrSamkYg9FdB5j7Qw84Rh2g4iWhainq
+            +9JeAZujSUCQbJ0aWQ2KNyCg7BiMMTfW4TwoF05PfXjBSef/tzxqGjoOmXBbDAfk
+            drHJyknssVjZ7V+zK3vEt71LJKYJxraAATSCnea+nKn7EKnrJBLzMh1voQUp4/4e
+            Eg==
+            =U2We
+            -----END PGP MESSAGE-----
+        fp: 8D191B7544E9CCC3547B25A877E5A5B31D13A647
+    -   created_at: '2021-10-29T16:46:15Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9NBwWNwg7uAAQ//b8k1zDxuzaYAwxlqkT7z7JjYxjcbZJzHPYaZBkj7n6Ux
+            d15CpISavpA4Ukn49fKKKN0RxvXFapocflPjAwAb6N8gcoZjOZemkYrS2LmSAfYb
+            PPstNHgFh8BtzCab6oT/Eo7we3AIog7fM6vh4ZP3gcGc3YGUA5AIJeeH6dLLTXOl
+            T7+oSL9rWHRUH7ey9DmUTEbbs95z4ua3NqMCgfef55gogIo8K2rIP2K4XEv1mIli
+            En7h7alu6X/ValOIwsKE9Ea634iOU+hpWL61+nu+47VfdewHw8wb0R3hi0VF0jsM
+            hwKQeyKWy1CnBY+LDR+0i2G5A01DkU6SnW33MV3XRl8jm1YZKbXqk/Zou9jzAVZg
+            83YZzQXXxxoPLeweZHExs/zlW5a/LywTte/fD+1h/DakqBapiO2uQjaGsgH9a3bW
+            bJQNJfwK1ry2VSlZ+myu/Lr0AMBwOczfwBleGp/vX3yB9t2CPwVi4eJXLa1MkQqL
+            VQla9chqkWa9/8DjZuHpL5t2Srw7YtLayoq4oKtaMiVrTfKQVPYxoscolZ7Q38EQ
+            sQogHucWDteFFkYvQBrIRZ4T+Wnb918iBPG15f42vI6wOepf0PRHRfMI2sz95NOf
+            j+Im5zN8f3hl5mPWuQd+7oD0tEgLxnJbjeN6d4GGTEQ+raUpUXZDtPmK7dyXGBnS
+            XgHBaTEVqPiy0ISZGR933RX3VK0pWiGoVeGluEtEgHseJVtr4cApUbJqBtJqOia7
+            xed+Qt55iGmXc5DBQgvNO0e8PwEF9uSGuPam1+7C8PSLNjfMK6320oG83qZMzmc=
+            =6ILj
+            -----END PGP MESSAGE-----
+        fp: A01778ACB7CC4D41B00FDD78CCBE624D8FF6D016
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.5.0


### PR DESCRIPTION
## Related Issues and Dependencies

Partially addresses [Setup Prometheus and Grafana service for collecting the Services Metrics](https://github.com/thoth-station/thoth-application/issues/2029)
    - specifically balrog --> alerts --> [x] setup the alerts rules for the openshift-monitoring alertmanager to pick up.

## Does this require new deployment ?

- no new deployment required

## Description

- Created alerting rules to use balrog routes and metrics
- Updated patch in kustomization to apply the aws/balrog for env
- moved over secret / secret generator
