### PR TITLE
Patch the smaug cluster postgresql pvc to default ceph based storage

### DIFF
--- a/core/overlays/moc-prod/graph-prod/postgresql.yaml
+++ b/core/overlays/moc-prod/graph-prod/postgresql.yaml
@@ -29,7 +29,7 @@ items:
       resources:
         requests:
           storage: 80Gi
-      storageClassName: moc-nfs-csi
+      storageClassName: ocs-external-storagecluster-ceph-rbd
       volumeMode: Filesystem
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig


### PR DESCRIPTION
Patch the smaug cluster postgresql pvc to default ceph based storage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

ceph based pvc storages are default in smaug cluster