### PR TITLE
Freeze the db dump of smaug cluster

### DIFF
--- a/graph-backup-job/overlays/moc-prod/cronjob.yaml
+++ b/graph-backup-job/overlays/moc-prod/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: graph-backup
 spec:
-  suspend: false
+  suspend: true


### PR DESCRIPTION
Freeze the db dump of smaug cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

Smaug cluster deployment is a copy of the prod.
Taking db dump seems to be redundant.
Freezing it.