### PR TITLE
Freeze the data ingestion on balrog prod cluster

### DIFF
--- a/cve-update/overlays/aws-prod/cronjob.yaml
+++ b/cve-update/overlays/aws-prod/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: cve-update
 spec:
   schedule: "@daily"
-  suspend: false
+  suspend: true
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4
   concurrencyPolicy: Forbid

--- a/graph-backup-job/overlays/aws-prod/cronjob.yaml
+++ b/graph-backup-job/overlays/aws-prod/cronjob.yaml
@@ -3,5 +3,9 @@ kind: CronJob
 apiVersion: batch/v1beta1
 metadata:
   name: graph-backup
+  labels:
+    app: thoth
+    component: graph-backup
 spec:
+  schedule: "@weekly"
   suspend: false

--- a/graph-refresh/overlays/aws-prod/cronjob.yaml
+++ b/graph-refresh/overlays/aws-prod/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: graph-refresh
 spec:
   schedule: "0 */1 * * *"
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4

--- a/package-update/overlays/aws-prod/cronjob.yaml
+++ b/package-update/overlays/aws-prod/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: package-update
 spec:
   schedule: "0 */12 * * *"
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4


### PR DESCRIPTION
Freeze the data ingestion on balrog prod cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/thoth-station/thoth-application/issues/2172

## Description

As discussed in the Tech Talk the data ingestion would be carried out on stage.
So freezing the ingestion in prod
along with making the db dump of prod weekly.