### PR TITLE
Enable the transfer-issue prow plugin

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -271,6 +271,7 @@ plugins:
       - require-matching-label
       - shrug
       - size
+      - transfer-issue
       - trigger
       - verify-owners
       - wip
@@ -288,6 +289,7 @@ plugins:
       - override
       - shrug
       - size
+      - transfer-issue
       - trigger
       - verify-owners
       - wip
@@ -309,6 +311,7 @@ plugins:
       - require-matching-label
       - shrug
       - size
+      - transfer-issue
       - trigger
       - verify-owners
       - wip
@@ -325,6 +328,7 @@ plugins:
       - lifecycle
       - override
       - size
+      - transfer-issue
       - trigger
       - verify-owners
       - wip


### PR DESCRIPTION


## Related Issues and Dependencies

An example of a `/transfer` request (currently not working because the plugin is not enabled): https://github.com/thoth-station/kebechet/issues/942#issuecomment-998797918

## Description

This is to enable the [transfer-issue hook plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/transfer-issue) in prow so that org members can ask prow to move issues across repos within the org