### PR TITLE
Bump graph-sync-job to v0.10.18 in stage environment

### DIFF
--- a/graph-sync/overlays/ocp4-stage/common/imagestreamtag.yaml
+++ b/graph-sync/overlays/ocp4-stage/common/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.16
+        name: quay.io/thoth-station/graph-sync-job:v0.10.18
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/graph-sync-job/issues/634
