### PR TITLE
Update cronjob apiversion to batch/v1

### DIFF
--- a/advise-reporter/base/cronjob.yaml
+++ b/advise-reporter/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: advise-reporter
 spec:

--- a/advise-reporter/overlays/aws-prod/cronjob.yaml
+++ b/advise-reporter/overlays/aws-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: advise-reporter
 spec:

--- a/advise-reporter/overlays/moc-prod/cronjob.yaml
+++ b/advise-reporter/overlays/moc-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: advise-reporter
 spec:

--- a/advise-reporter/overlays/ocp4-stage/cronjob.yaml
+++ b/advise-reporter/overlays/ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: advise-reporter
   labels:

--- a/advise-reporter/overlays/test/cronjob.yaml
+++ b/advise-reporter/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: advise-reporter
 spec:

--- a/cve-update/base/cronjob.yaml
+++ b/cve-update/base/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cve-update

--- a/cve-update/overlays/aws-prod/cronjob.yaml
+++ b/cve-update/overlays/aws-prod/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cve-update

--- a/cve-update/overlays/moc-prod/cronjob.yaml
+++ b/cve-update/overlays/moc-prod/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cve-update

--- a/cve-update/overlays/ocp4-stage/cronjob.yaml
+++ b/cve-update/overlays/ocp4-stage/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cve-update

--- a/cve-update/overlays/test/cronjob.yaml
+++ b/cve-update/overlays/test/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cve-update

--- a/graph-backup-job/base/cronjob.yaml
+++ b/graph-backup-job/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-backup
   labels:

--- a/graph-backup-job/overlays/aws-prod/cronjob.yaml
+++ b/graph-backup-job/overlays/aws-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-backup
   labels:

--- a/graph-backup-job/overlays/moc-prod/cronjob.yaml
+++ b/graph-backup-job/overlays/moc-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-backup
 spec:

--- a/graph-backup-job/overlays/ocp4-stage/cronjob.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-backup
 spec:

--- a/graph-backup-job/overlays/test/cronjob.yaml
+++ b/graph-backup-job/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-backup
 spec:

--- a/graph-metrics-exporter/base/cronjob.yaml
+++ b/graph-metrics-exporter/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-metrics-exporter
   labels:

--- a/graph-metrics-exporter/overlays/aws-prod/cronjob.yaml
+++ b/graph-metrics-exporter/overlays/aws-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-metrics-exporter
 spec:

--- a/graph-metrics-exporter/overlays/moc-prod/cronjob.yaml
+++ b/graph-metrics-exporter/overlays/moc-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-metrics-exporter
 spec:

--- a/graph-metrics-exporter/overlays/ocp4-stage/cronjob.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-metrics-exporter
 spec:

--- a/graph-metrics-exporter/overlays/test/cronjob.yaml
+++ b/graph-metrics-exporter/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-metrics-exporter
 spec:

--- a/graph-refresh/base/cronjob.yaml
+++ b/graph-refresh/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-refresh
   labels:

--- a/graph-refresh/overlays/aws-prod/cronjob.yaml
+++ b/graph-refresh/overlays/aws-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-refresh
   labels:

--- a/graph-refresh/overlays/moc-prod/cronjob.yaml
+++ b/graph-refresh/overlays/moc-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-refresh
   labels:

--- a/graph-refresh/overlays/ocp4-stage/cronjob.yaml
+++ b/graph-refresh/overlays/ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-refresh
 spec:

--- a/graph-refresh/overlays/test/cronjob.yaml
+++ b/graph-refresh/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: graph-refresh
 spec:

--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: integration-tests

--- a/integration-tests/overlays/moc-prod-ocp4-stage/cronjob.yaml
+++ b/integration-tests/overlays/moc-prod-ocp4-stage/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: integration-tests

--- a/integration-tests/overlays/ocp4-stage/cronjob.yaml
+++ b/integration-tests/overlays/ocp4-stage/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: integration-tests

--- a/integration-tests/overlays/test/cronjob.yaml
+++ b/integration-tests/overlays/test/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: integration-tests

--- a/kebechet/overlays/bot/kebechet-aicoe-cronjob.yaml
+++ b/kebechet/overlays/bot/kebechet-aicoe-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: kebechet-aicoe

--- a/kebechet/overlays/bot/kebechet-thoth-cronjob.yaml
+++ b/kebechet/overlays/bot/kebechet-thoth-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: kebechet-thoth-station

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-gh
   labels:
@@ -65,7 +65,7 @@ spec:
           restartPolicy: OnFailure
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-analyse
   labels:
@@ -149,7 +149,7 @@ spec:
           restartPolicy: OnFailure
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-merge
   labels:

--- a/mi-scheduler/overlays/moc-prod/cronjob.yaml
+++ b/mi-scheduler/overlays/moc-prod/cronjob.yaml
@@ -1,20 +1,20 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-gh
 spec:
   suspend: true
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-analyse
 spec:
   suspend: true
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-merge
 spec:

--- a/mi-scheduler/overlays/ocp4-stage/cronjob.yaml
+++ b/mi-scheduler/overlays/ocp4-stage/cronjob.yaml
@@ -1,20 +1,20 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-gh
 spec:
   suspend: true
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-analyse
 spec:
   suspend: true
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-merge
 spec:

--- a/mi-scheduler/overlays/rick-test/cronjob.yaml
+++ b/mi-scheduler/overlays/rick-test/cronjob.yaml
@@ -1,20 +1,20 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-gh
 spec:
   suspend: true
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-analyse
 spec:
   suspend: true
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-merge
 spec:

--- a/mi-scheduler/overlays/test/cronjob.yaml
+++ b/mi-scheduler/overlays/test/cronjob.yaml
@@ -1,20 +1,20 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-gh
 spec:
   suspend: false
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-analyse
 spec:
   suspend: false
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: mi-scheduler-kebechet-merge
 spec:

--- a/nepthys/base/cronjob.yaml
+++ b/nepthys/base/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:

--- a/package-releases/base/cronjob.yaml
+++ b/package-releases/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-releases
   labels:

--- a/package-releases/overlays/aws-prod/cronjob.yaml
+++ b/package-releases/overlays/aws-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-releases
   labels:

--- a/package-releases/overlays/moc-prod/cronjob.yaml
+++ b/package-releases/overlays/moc-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-releases
   labels:

--- a/package-releases/overlays/ocp4-stage/cronjob.yaml
+++ b/package-releases/overlays/ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-releases
 spec:

--- a/package-releases/overlays/test/cronjob.yaml
+++ b/package-releases/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-releases
 spec:

--- a/package-update/base/cronjob.yaml
+++ b/package-update/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-update
 spec:

--- a/package-update/overlays/aws-prod/cronjob.yaml
+++ b/package-update/overlays/aws-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-update
 spec:

--- a/package-update/overlays/moc-prod/cronjob.yaml
+++ b/package-update/overlays/moc-prod/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-update
 spec:

--- a/package-update/overlays/ocp4-stage/cronjob.yaml
+++ b/package-update/overlays/ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-update
 spec:

--- a/package-update/overlays/test/cronjob.yaml
+++ b/package-update/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: package-update
 spec:

--- a/prow/base/branchprotector.yaml
+++ b/prow/base/branchprotector.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: branchprotector

--- a/prow/overlays/smaug/unsuspend_branchprotector.yaml
+++ b/prow/overlays/smaug/unsuspend_branchprotector.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: branchprotector

--- a/pulp-pypi-sync-job/base/cronjob.yaml
+++ b/pulp-pypi-sync-job/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: pulp-pypi-sync-job
   labels:

--- a/pulp-pypi-sync-job/overlays/moc/cronjob.yaml
+++ b/pulp-pypi-sync-job/overlays/moc/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: pulp-pypi-sync-job
 spec:

--- a/pulp-pypi-sync-job/overlays/test/cronjob.yaml
+++ b/pulp-pypi-sync-job/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: pulp-pypi-sync-job
 spec:

--- a/sefkhet-abwy/overlays/bot/thoth-friday-scrum-cronjob.yaml
+++ b/sefkhet-abwy/overlays/bot/thoth-friday-scrum-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:

--- a/sefkhet-abwy/overlays/bot/thoth-scrum-cronjob.yaml
+++ b/sefkhet-abwy/overlays/bot/thoth-scrum-cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:

--- a/sefkhet-abwy/overlays/moc/new-label-normalizer.yaml
+++ b/sefkhet-abwy/overlays/moc/new-label-normalizer.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:
@@ -43,7 +43,7 @@ spec:
   successfulJobsHistoryLimit: 1
   suspend: true
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:

--- a/slo-reporter/base/cronjob.yaml
+++ b/slo-reporter/base/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: slo-reporter
 spec:

--- a/slo-reporter/overlays/moc-prod-ocp4-stage/cronjob.yaml
+++ b/slo-reporter/overlays/moc-prod-ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: slo-reporter
 spec:

--- a/slo-reporter/overlays/ocp4-stage/cronjob.yaml
+++ b/slo-reporter/overlays/ocp4-stage/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: slo-reporter
 spec:

--- a/slo-reporter/overlays/test/cronjob.yaml
+++ b/slo-reporter/overlays/test/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: slo-reporter
 spec:


### PR DESCRIPTION
Update cronjob apiversion to batch/v1
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

All our clusters are running 4.8 or above the openshift version.

https://docs.openshift.com/container-platform/4.8/rest_api/workloads_apis/cronjob-batch-v1.html
https://docs.openshift.com/container-platform/4.8/nodes/jobs/nodes-nodes-jobs.html#nodes-nodes-jobs-creating-cron_nodes-nodes-jobs