### PR TITLE
Increase number of seconds allowed package-extract to run

### DIFF
--- a/package-extract/base/argo-workflows/package-extract.yaml
+++ b/package-extract/base/argo-workflows/package-extract.yaml
@@ -119,9 +119,9 @@ spec:
             cpu: 1
             memory: 1Gi
         livenessProbe:
-          # Give analyzer 30 minutes to compute results, kill it if it was not able result anything.
+          # Give analyzer 60 minutes to compute results, kill it if it was not able result anything.
           tcpSocket:
             port: 80
-          initialDelaySeconds: 1800
+          initialDelaySeconds: 3600
           failureThreshold: 1
           periodSeconds: 10


### PR DESCRIPTION
## Related Issues and Dependencies

Some container images take way too long to be analyzed and exceed limit configured.
