### PR TITLE
Increase memory requirements for package-extract

### DIFF
--- a/package-extract/base/argo-workflows/package-extract.yaml
+++ b/package-extract/base/argo-workflows/package-extract.yaml
@@ -114,10 +114,10 @@ spec:
         resources:
           limits:
             cpu: 1
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 1
-            memory: 1Gi
+            memory: 2Gi
         livenessProbe:
           # Give analyzer 60 minutes to compute results, kill it if it was not able result anything.
           tcpSocket:


### PR DESCRIPTION
## Description

Some container image analyses fail on OOM. Increase allocated memory for package-extract.
