### PR TITLE
Include investigator required env vars for the doc builds

### DIFF
--- a/nepthys/base/cronjob.yaml
+++ b/nepthys/base/cronjob.yaml
@@ -46,6 +46,12 @@ spec:
                   value: "1"
                 - name: PIPENV_HIDE_EMOJIS
                   value: "1"
+                - name: THOTH_BACKEND_NAMESPACE
+                  value: "thoth-backend-stage"
+                - name: THOTH_MIDDLETIER_NAMESPACE
+                  value: "thoth-middletier-stage"
+                - name: THOTH_DEPLOYMENT_NAME
+                  value: "ocp4-stage"
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Include investigator required env vars for the doc builds
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/nepthys/issues/80#issuecomment-1000429871

## Description

The investigators require some of the env vars.
https://github.com/thoth-station/investigator/blob/b6ca87a07ae38b6d8529a227fa4d7ab48c26f399/thoth/investigator/configuration.py#L52
https://github.com/thoth-station/investigator/blob/b6ca87a07ae38b6d8529a227fa4d7ab48c26f399/thoth/investigator/configuration.py#L53
https://github.com/thoth-station/investigator/blob/b6ca87a07ae38b6d8529a227fa4d7ab48c26f399/thoth/investigator/configuration.py#L55
