### PR TITLE
Bump up the images based on the storgae v0.62.1 update

### DIFF
--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/workflow-helpers:v0.9.4
+      name: quay.io/thoth-station/workflow-helpers:v0.9.6
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.15.2
+      name: quay.io/thoth-station/investigator:v0.15.3
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.5.0
+        name: quay.io/thoth-station/cve-update-job:v0.5.1
       importPolicy: {}

--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.8.11
+        name: quay.io/thoth-station/graph-backup-job:v0.8.12
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.6
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.7
       importPolicy: {}

--- a/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.16
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.17
       importPolicy: {}

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.19.0
+        name: quay.io/thoth-station/metrics-exporter:v0.19.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.5
+        name: quay.io/thoth-station/package-releases-job:v0.11.6
       importPolicy: {}

--- a/package-releases/overlays/test/imagestreamtag.yaml
+++ b/package-releases/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.5
+        name: quay.io/thoth-station/package-releases-job:v0.11.6
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
Bump up the images based on the storgae v0.62.1 update
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

![check2update](https://user-images.githubusercontent.com/14028058/147427625-12259208-e5ea-4d68-96b3-2e94c3fcc8b2.png)

## Description

This is to fix the alerts. 