### PR TITLE
Disable insecure agro artifact submission

### DIFF
--- a/core/overlays/moc-prod/backend-prod/configmaps.yaml
+++ b/core/overlays/moc-prod/backend-prod/configmaps.yaml
@@ -40,7 +40,7 @@ data:
         bucket: "thoth"
         keyPrefix: "data/smaug-prod/argo/artifacts/"
         endpoint: "s3-openshift-storage.apps.smaug.na.operate-first.cloud"
-        insecure: true
+        insecure: false
         accessKeySecret:
           name: argo-artifact-repository-secrets
           key: accessKey

--- a/core/overlays/moc-prod/middletier-prod/configmaps.yaml
+++ b/core/overlays/moc-prod/middletier-prod/configmaps.yaml
@@ -40,7 +40,7 @@ data:
         bucket: "thoth"
         keyPrefix: "data/smaug-prod/argo/artifacts/"
         endpoint: "s3-openshift-storage.apps.smaug.na.operate-first.cloud"
-        insecure: true
+        insecure: false
         accessKeySecret:
           name: argo-artifact-repository-secrets
           key: accessKey


### PR DESCRIPTION
Disable insecure agro artifact submission
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

```
time="2022-01-10T16:30:06.512Z" level=info msg="Saving from /tmp/argo/outputs/logs/main.log to s3 (endpoint: s3-openshift-storage.apps.smaug.na.operate-first.cloud, bucket: thoth, key: data/smaug-prod/argo/artifacts/kebechet-job-220110162705-933ea1c42443f860/kebechet-job-220110162705-933ea1c42443f860-3370468600/main.log)"
time="2022-01-10T16:30:06.519Z" level=warning msg="Failed to put file: 503 Service Unavailable"
time="2022-01-10T16:30:06.519Z" level=error msg="executor error: timed out waiting for the condition"
```

## Description

Just hunch, that the endpoint insecure true is causing is the issue. 
