### PR TITLE
Remove the required context as the presubmit are not run always

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -318,12 +318,6 @@ tide:
             required-contexts:
               - aicoe-ci/pre-commit-check
               - aicoe-ci/build-check
-      open-services-group:
-        repos:
-          community:
-            required-contexts:
-              - perobolos
-              - labels
       thoth-station:
         repos:
           adviser:


### PR DESCRIPTION
Remove the required context as the presubmit are not run always
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/open-services-group/community/pull/6#issuecomment-1010086775
