### PR TITLE
Bump metrics-exporter to v0.20.0 for Kebechet monitoring dashboard

### DIFF
--- a/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.19.0
+        name: quay.io/thoth-station/metrics-exporter:v0.20.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.19.0
+        name: quay.io/thoth-station/metrics-exporter:v0.20.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.19.1
+        name: quay.io/thoth-station/metrics-exporter:v0.20.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

We inotruduced a new metric for Kebechet that is required in the dashboard.
