### PR TITLE
Introduce image patch for the amun deploymentconfig

### DIFF
--- a/amun/overlays/aws-prod/amun-api/kustomization.yaml
+++ b/amun/overlays/aws-prod/amun-api/kustomization.yaml
@@ -13,6 +13,10 @@ generators:
   - secret-generator.yaml
 generatorOptions:
   disableNameSuffixHash: true
+images:
+  - name: amun-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-api-prod/amun-api
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
 patches:

--- a/amun/overlays/moc-prod/amun-api/kustomization.yaml
+++ b/amun/overlays/moc-prod/amun-api/kustomization.yaml
@@ -15,6 +15,10 @@ generators:
   - secret-generator.yaml
 generatorOptions:
   disableNameSuffixHash: true
+images:
+  - name: amun-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-api-prod/amun-api
+    newTag: latest
 patches:
   - patch: |-
       - op: add

--- a/amun/overlays/ocp4-stage/amun-api/kustomization.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/kustomization.yaml
@@ -12,6 +12,10 @@ patchesStrategicMerge:
   - imagestreamtag.yaml
 generators:
   - ./secret-generator.yaml
+images:
+  - name: amun-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-amun-api-stage/amun-api
+    newTag: latest
 patches:
   - patch: |-
       - op: add

--- a/amun/overlays/test/kustomization.yaml
+++ b/amun/overlays/test/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
   - thoth-notification.yaml
 generators:
   - ./secret-generator.yaml
+images:
+  - name: amun-api
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/amun-api
+    newTag: latest
 patchesStrategicMerge:
   - imagestreamtag.yaml
   - openshift-templates/inspection-workflow.yaml


### PR DESCRIPTION
Introduce image patch for the amun deploymentconfig
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/1996

## Description

The patch of deploymentconfig was missing.

![amun-api](https://user-images.githubusercontent.com/14028058/149155216-88320979-df8b-4687-93d9-67cc42a8919a.png)
