### PR TITLE
Moved the logging-no-json env var to amun cm

### DIFF
--- a/amun/base/deploymentconfig.yaml
+++ b/amun/base/deploymentconfig.yaml
@@ -93,7 +93,7 @@ spec:
             - name: THOTH_LOGGING_NO_JSON
               valueFrom:
                 configMapKeyRef:
-                  name: thoth
+                  name: amun
                   key: logging-no-json
             - name: PROMETHEUS_PUSHGATEWAY_HOST
               valueFrom:

--- a/amun/overlays/aws-prod/amun-api/configmaps.yaml
+++ b/amun/overlays/aws-prod/amun-api/configmaps.yaml
@@ -8,6 +8,7 @@ data:
   deployment-name: aws-prod
   infra-namespace: thoth-amun-inspection-prod
   inspection-namespace: thoth-amun-inspection-prod
+  logging-no-json: "0"
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/amun/overlays/moc-prod/amun-api/configmaps.yaml
+++ b/amun/overlays/moc-prod/amun-api/configmaps.yaml
@@ -8,6 +8,7 @@ data:
   deployment-name: smaug-prod
   infra-namespace: thoth-amun-inspection-prod
   inspection-namespace: thoth-amun-inspection-prod
+  logging-no-json: "0"
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/amun/overlays/ocp4-stage/amun-api/configmaps.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/configmaps.yaml
@@ -8,6 +8,7 @@ data:
   deployment-name: ocp4-stage
   infra-namespace: thoth-amun-inspection-stage
   inspection-namespace: thoth-amun-inspection-stage
+  logging-no-json: "0"
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/amun/overlays/test/configmaps.yaml
+++ b/amun/overlays/test/configmaps.yaml
@@ -8,6 +8,7 @@ data:
   deployment-name: ocp-test
   infra-namespace: thoth-test-core
   inspection-namespace: thoth-test-core
+  logging-no-json: "0"
   artifactRepository: |-
     archiveLogs: false
     s3:


### PR DESCRIPTION
Moved the logging-no-json env var to amun cm
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

![amun-api](https://user-images.githubusercontent.com/14028058/149172879-6a0cc351-df6c-443b-9be0-6e11b624d534.png)

## Description

The amun deployment was missing the logging-no-json env var, moved it to amun configmap