### PR TITLE
Bump user-api to v0.33.1 in prod

### DIFF
--- a/user-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/user-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.29.1
+        name: quay.io/thoth-station/user-api:v0.33.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.29.1
+        name: quay.io/thoth-station/user-api:v0.33.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Description

Performing version bump outside of the release cycle to have API ready for the demo.
