### PR TITLE
Update triage-party configuration with more views

### DIFF
--- a/triage-party/overlays/moc/config.yaml
+++ b/triage-party/overlays/moc/config.yaml
@@ -13,9 +13,11 @@ settings:
     - https://github.com/thoth-station/common
     - https://github.com/thoth-station/core
     - https://github.com/thoth-station/cve-update-job
+    - https://github.com/thoth-station/datasets
     - https://github.com/thoth-station/graph-backup-job
     - https://github.com/thoth-station/graph-refresh-job
     - https://github.com/thoth-station/graph-sync-job
+    - https://github.com/thoth-station/helm-charts
     - https://github.com/thoth-station/init-job
     - https://github.com/thoth-station/invectio
     - https://github.com/thoth-station/investigator
@@ -25,27 +27,30 @@ settings:
     - https://github.com/thoth-station/messaging
     - https://github.com/thoth-station/metrics-exporter
     - https://github.com/thoth-station/mi
-    - https://github.com/thoth-station/mi-scheduler
     - https://github.com/thoth-station/micropipenv
+    - https://github.com/thoth-station/mi-scheduler
     - https://github.com/thoth-station/package-extract
     - https://github.com/thoth-station/package-releases-job
+    - https://github.com/thoth-station/package-update-job
     - https://github.com/thoth-station/pipeline-helpers
-    - https://github.com/thoth-station/prescription-sync-job
     - https://github.com/thoth-station/prescriptions
+    - https://github.com/thoth-station/prescriptions-refresh-job
+    - https://github.com/thoth-station/prescription-sync-job
     - https://github.com/thoth-station/ps-cv
+    - https://github.com/thoth-station/ps-ip
     - https://github.com/thoth-station/ps-nlp
     - https://github.com/thoth-station/pulp-pypi-sync-job
     - https://github.com/thoth-station/purge-job
     - https://github.com/thoth-station/python
+    - https://github.com/thoth-station/reporter
     - https://github.com/thoth-station/report-processing
-    - https://github.com/thoth-station/reporter
-    - https://github.com/thoth-station/reporter
     - https://github.com/thoth-station/revsolver
     - https://github.com/thoth-station/s2i
     - https://github.com/thoth-station/s2i-generic-data-science-notebook
     - https://github.com/thoth-station/s2i-minimal-notebook
     - https://github.com/thoth-station/s2i-scipy-notebook
     - https://github.com/thoth-station/s2i-thoth
+    - https://github.com/thoth-station/search
     - https://github.com/thoth-station/slo-reporter
     - https://github.com/thoth-station/solver
     - https://github.com/thoth-station/solver-project-url-job
@@ -54,6 +59,8 @@ settings:
     - https://github.com/thoth-station/support
     - https://github.com/thoth-station/thamos
     - https://github.com/thoth-station/thoth-application
+    - https://github.com/thoth-station/thoth-ops-infra
+    - https://github.com/thoth-station/thoth-station.github.io
     - https://github.com/thoth-station/user-api
     - https://github.com/thoth-station/workflow-helpers
 

--- a/triage-party/overlays/moc/config.yaml
+++ b/triage-party/overlays/moc/config.yaml
@@ -137,6 +137,8 @@ collections:
       - bugs-recv
       - enhancement-recv
       - other-recv
+      - up-next
+      - active-assigned
 
   - id: important
     name: Important
@@ -157,6 +159,8 @@ collections:
     rules:
       - active-unassigned
       - long-active
+      - needs-triage-not
+      - help-important
 
   - id: similar
     name: Similar
@@ -485,23 +489,6 @@ rules:
     filters:
       - label: lifecycle/stale
 
-  # Inconsistencies
-  active-unassigned:
-    name: "Lifecyle Active without assignee"
-    resolution: "Assign the person working on it or fix lifecycle status"
-    type: issue
-    filters:
-      - label: "lifecycle/active"
-      - tag: "!assigned"
-
-  long-active:
-    name: "Lifecycle Active but not updated for long"
-    resolution: "Update the status"
-    type: issue
-    filters:
-      - label: "lifecycle/active"
-      - updated: +14d
-
   # Receive queue
   pickup-ready:
     name: "Issues waiting to be picked up"
@@ -547,6 +534,23 @@ rules:
       - label: "!.*bug"
       - label: ".*question"
 
+  up-next:
+    name: "critical-urgent issues not active yet (i.e. what's next)"
+    resolution: "Assign if needed, set lifecycle/active when work starts"
+    type: issue
+    filters:
+      - label: "!lifecycle/active"
+      - label: "priority/critical-urgent"
+
+  active-assigned:
+    name: "Active and assigned issues"
+    resolution: "This is FYI, meant to show what's currently being worked on. Just verify that's true."
+    type: issue
+    filters:
+      - label: "lifecycle/active"
+      - tag: assigned
+
+  # Important
   important-assignee-updated:
     name: "In Progress"
     type: issue
@@ -594,6 +598,39 @@ rules:
     resolution: Close as duplicate or give a better title
     filters:
       - tag: similar
+
+  # Inconsistencies
+  active-unassigned:
+    name: "Lifecyle Active without assignee"
+    resolution: "Assign the person working on it or fix lifecycle status"
+    type: issue
+    filters:
+      - label: "lifecycle/active"
+      - tag: "!assigned"
+
+  long-active:
+    name: "Lifecycle Active but not updated for long"
+    resolution: "Update the status"
+    type: issue
+    filters:
+      - label: "lifecycle/active"
+      - updated: +10d
+
+  needs-triage-not:
+    name: "needs-triage but has triage/*"
+    resolution: "Remove the conflicting label(s): needs-triage or triage/*"
+    type: issue
+    filters:
+      - label: needs-triage
+      - label: triage/.*
+
+  help-important:
+    name: "Help wanted and Important"
+    resolution: "Consider removing 'help wanted' with /remove-help"
+    type: issue
+    filters:
+      - label: "help wanted"
+      - label: "priority/(important.*|critical.*)"
 
   # for statistics generation
   open-issues:


### PR DESCRIPTION

This is to add the following additional boxes to triage-party:

 - inconsistencies: help+important, inconsistent triage
 - queue information: what's active, what's next

Also adding the helm-charts repo