### PR TITLE
Turn off auto reviewers in operate-first

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -280,7 +280,6 @@ plugins:
       - approve
       - assign
       - blockade
-      - blunderbuss
       - help
       - hold
       - label


### PR DESCRIPTION
Turn off auto reviewers in operate-first
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


## Description

Operate-first team doesn't want to have auto reviewers in the github org.
