### PR TITLE
Set up document sync job for the thoth-station

### DIFF
--- a/document-sync-job/base/cronjob.yaml
+++ b/document-sync-job/base/cronjob.yaml
@@ -1,0 +1,101 @@
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: document-sync
+spec:
+  schedule: "@daily"
+  suspend: true
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - image: quay.io/thoth-station/document-sync-job:v0.1.0
+              name: document-sync-job
+              env:
+                - name: THOTH_DOCUMENT_SYNC_DST
+                  value: "s3://thoth-store/data/aws-prod"
+                - name: THOTH_DEPLOYMENT_NAME
+                  valueFrom:
+                    configMapKeyRef:
+                      key: deployment-name
+                      name: thoth
+                - name: THOTH_S3_ENDPOINT_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      key: host
+                      name: ceph
+                - name: THOTH_CEPH_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      key: bucket-name
+                      name: ceph
+                - name: THOTH_CEPH_BUCKET_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      key: bucket-prefix
+                      name: ceph
+                - name: THOTH_CEPH_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: ceph
+                      key: key-id
+                - name: THOTH_CEPH_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ceph
+                      key: secret-key
+                - name: RSYSLOG_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      key: rsyslog-host
+                      name: thoth
+                - name: RSYSLOG_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      key: rsyslog-port
+                      name: thoth
+                - name: PROMETHEUS_PUSHGATEWAY_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: prometheus
+                      key: pushgateway-url
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: thoth
+                      key: sentry-dsn
+                - name: THOTH_LOGGING_NO_JSON
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: logging-no-json
+              volumeMounts:
+                - name: dst-creds
+                  mountPath: /opt/app-root/src/.aws
+                  readOnly: true
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "1"
+                limits:
+                  memory: "1.5Gi"
+                  cpu: "1"
+              livenessProbe:
+                failureThreshold: 1
+                initialDelaySeconds: 7200
+                periodSeconds: 10
+                tcpSocket:
+                  port: 80
+          volumes:
+            - name: dst-creds
+              secret:
+                secretName: dst-ceph
+                items:
+                  - key: credentials
+                    path: credentials
+          restartPolicy: OnFailure

--- a/document-sync-job/base/imagestream.yaml
+++ b/document-sync-job/base/imagestream.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: thoth
+    component: document-sync
+  name: document-sync-job
+spec:
+  lookupPolicy:
+    local: true

--- a/document-sync-job/base/kustomization.yaml
+++ b/document-sync-job/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml
+  - imagestream.yaml
+commonLabels:
+  app: thoth
+  component: document-sync
+generators:
+  - secret-generator.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/document-sync-job/base/secret-generator.yaml
+++ b/document-sync-job/base/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: thoth-secret-generator
+files:
+  - ./secrets.enc.yaml

--- a/document-sync-job/base/secrets.enc.yaml
+++ b/document-sync-job/base/secrets.enc.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: dst-ceph
+type: Opaque
+stringData:
+    credentials: ENC[AES256_GCM,data:hDzc5bILpUtkSIzsfGsrGVPK5BP+m7Ff4ZRFplNCIMeLP6iCHqngl5GmrvSCT3xic3UD9MD8UiE9L++hnBzA79WXUoav+abosaw7bFcVelkFZurTC2Vx39rWVORriJHxy0fkYTmIYbqjptj31GLTbeTXqic=,iv:cZPylDAcUIw5qkLqxR/WB5y3iEllikAvl0VLR30vqSY=,tag:vzymNY7BAcULtAMVeUANXg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2022-01-27T21:27:20Z'
+    mac: ENC[AES256_GCM,data:6EQLFlLxgj2XANOKIVFATRdqTp9Sig8cfUwS0Fde54xZ1SvfrWA7/bkl1abqOnNsO4vlRfEMep/Tzy7dwB3TtsA5mtAlzlH++6wnkYjvInjvXz/lYWfPsK+LBXZx26HyUDp9MM/c+woWi2piv+OBascZBoOgVlYo7QX+DnnB6i8=,iv:9X4+s8FrFN0L/dDKKqBRfzN6DQauIrmCoVCMm6tsSpI=,tag:LvcW+L4dRy0XGl4f7jsosg==,type:str]
+    pgp:
+    -   created_at: '2022-01-27T21:27:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA1gbAjViyxWYAQ//ZpAF2rs2MQiJZH5upDJfqeQWiyc10oboCXPZCC9gQzX9
+            H8lpJMQUvpYCeCQHFVl0LfUYzyjnej8o5HTsgJBTr6bzKASNviZlWB9OqGTuybQf
+            CHb9uL4uhckSNiFtFGzVN0ou1KKfFNoHaAfOkeoAR38lc4x+nWhGbC7gPxhrYV3R
+            CjcmiZ+eelI3pPusarwz1cKrC+VfCVnguvBLoaeMVfAWNboFag28Pzv9kn0ezO64
+            yQg137P9pJclufUkBxdXMQnkL4btLZWAk5MDH7JTblM5AU7/MHENrtuO4N/GAQ5P
+            Ln+qvr6L87uYnVWx7t7rCVXceeyWyAGgApYcs+uzWYFGG3JEMLke9EC+37iedLdd
+            xS44of1AO3aThswkAUFVpog8YwAn36hZEgALk+1HGfhOgZ+wzDkeBjWwCxib6GO7
+            WAOx/9uh4YWlRF7S4q7nEIdxuaI0WeslSUFPhjNCJ/dPV6QnLkC9wmLeJBohvUc9
+            g0a2h8yYvhGUscnIQ928Gt4x762zEhlg5YApKJ6u429Dxu2ahkpthQmiKmtLNJkp
+            P4M8HLT1nLoXx8xTY1dJyhYvi8NW2fvYcpbp2hVyjSGINWEiV4MurdQI+AmkE5fX
+            aPAKG0FZ1Xsuuj3BkK7rR52QrH/9TsKs2yKHdt+GPO0rZBBSeHzf+5WMLwugjhzS
+            XgF1Wm6pjXsjS2CXR4UlrerL2quojRAKqrWW4uIrIHDSktUcWvJg5u90AyQ4j5tg
+            7hSjtHRSD6SzJ2gm4jtfAI8ZzLLVavVm5MM3+V+dCO32ikW08FWu8l9MI3Jen0U=
+            =UBP4
+            -----END PGP MESSAGE-----
+        fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
+    -   created_at: '2022-01-27T21:27:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA+/WpawS9RPbAQf/e7bM61VPc1B6eRKMqymyHJ0AMW0noc0Mv0GbBUYmEJgH
+            Fj08iYdziTkMalipdKqTnnC/kzZxT2r3ORjkswD7hIc+eUGvbh4Y1esgEKwBCSEH
+            9QBWcvsxnKjSMpeWSpXS/qI2N8VpvMuh38uaBziA+IbEnQ8eHkU5apVVeA1hU1X8
+            SeaFuZ3hChiB5r7S6vR2WcGOiSARpcw0HikAt0Zg7D77s4JVDnfVW3L1d/Ok8wru
+            f/GWOU4XPPpevY+yHaWKfvTmbtiCEQ3U7ySiP1MReZDaSLXlsFYWeXsBOACovsDX
+            GwWVm/OxSz/kERj4qKzcNVf1hHkGN0nFBpQjLCzH4tJeAfia8+uNpTfs2Hkuu9wk
+            yYk19QVIfjA7mCgp4pMPn4/gemkv9VJRlvV2J9wlj2FeWosNoh7V0aKhf2MndZf/
+            l9GI9C33nXQHQK2kS1RyJLtEBxrzN6zY8KxBnaoI2g==
+            =DoIZ
+            -----END PGP MESSAGE-----
+        fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
+    -   created_at: '2022-01-27T21:27:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQf/SYL+wkyH9FaQS7Ksy10Vwwmac+b8rs5yujeJdIQQvweP
+            nu+O477zk1+iEVLGUNN3Sa1J6BVrFv1o7YRYrR5wB5b82ewjY+X1Fy2TP8DVh7lE
+            PBUfEOXqAnCW+0/unt7+yHF0Ezj813nfdzQ6tkxMjdWfxxG5KKcRQbrN6K8daYkw
+            gMJzDEF/I5z5ZG5KzRfstWB8YMijYWZKeSDQ7KmC5yd5m+kjvqZOJQ9QsejtTd3V
+            /vH91zzNnQzdgZ01pHHKA5XHV3hJ2vkI/fXcv4hiwfKJWJuCg+WBfnwovbPbTR1k
+            6ZbSci+gBEwGQTmXdzUyjFsTI5EBVtb6Hxz+1mFYCdJeARLObEy75froSbzcBT4F
+            Zo+5beRVNfndwUlNEl7pT/yt9E2gTL+WRTfXFkv3YhGemVR9O266mA9CSzh9ca9V
+            MtzS1/yzyBt/hfVhbrnOHOZs4pPUHbwjQ4BmH9Yr9A==
+            =zt4j
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    -   created_at: '2022-01-27T21:27:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiAQ/+Me1ip1M+yAlb2ju7zC7jxaD66UUjM9+YEqgp+7ZuS7y6
+            jkiZGo0Rqq+B12xgQTx2kVs0e5CXy/vdXpdlbToqkrzZkdoOhZlSjayk+UZ3PUgN
+            WNwk909BKXv2AbjhD7/i6UIdwKMMbptCTKJZdxgSqgJ8T+TDwEHE5sFZmNqNi9Cz
+            RjYE/0zgDsXRCBF3Hc+a0oHeXuHBD9RcIF8TSzdTJRM2JEtU3fOhe1VkjrkNfqfm
+            CmDWQaT43t7VurO3Fc5mZhH4k1vbhoiFuhq++7qb8CO39l1Yp0GsY9EgNTDJhcVA
+            Ba9zMgmsUhZYQCConcudGgFEGOzAKqUJlC1jb1WNlhq/cBoRLhh46b2h621acxZ5
+            2TWcRHKbjMnf67IynJivQRFXO+mHUlqEV5eSpKbps/6xT/cgRRzz44d11Y6Xts96
+            JK0Hcg90Cmcm8ZCYOZcMvE58kyeU8eYGW9djCkgcl8kqOekITVh+qJplvPKrphLX
+            0HQIRVKZpvT+003YfniS0TZlZkr71Cc0ZrdUgxZuLAFI5JDAl+k1zcniU5iV07k+
+            6v1j4d9NdjbIiEnqq17F6j4yUQZSSJeTrxZOS85qUdqB4o357w4j3mIKuFU+Urw9
+            gf4VW1Dnst4t8gk9yVFnduMHqho0XZiGsdvA94y+csHhIxfGSZfLutvwOQSzutfS
+            XgGt5cfPKnSK7ktnuuqlHsKQD18d1hZMv03msABijc+C6rSV/JMvogOwATjxvvVd
+            X1L1rp5DmgwM3xEA7/BikTFQbzsA6sEDphzbMlbCYT5PyKMtze722xU5QxkCvPc=
+            =no3o
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    -   created_at: '2022-01-27T21:27:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIOA9LRbhPydJmLEAf/TcLJXYvGBLMatsRtoqA/YKjrkkhoDPr14uodjtM5tPwF
+            eAiBbQEXja6F6gPgc9IcLJdwAADGSLS7wXrvxeHXnWijPhUGIl/TAmVg6wWwvZny
+            VBboLow5pNw9uSkBGdDIFDCLud1s29ILOveQIXGknkqdoPqGFC43DzJVCwvhrr1x
+            0BBe+St5H5rEMZke4oEdQb8vDktT3U/9KbBtqvhGsGWcWXEg3j2NmrTN2Uop2aoR
+            NsNLHT+RlwIWaE3ZcEJdVg4JcB8FRMWNy2EF9TwQeIh0Bf/Ilg7XT3o69BlJKH3n
+            nJoX/QIsAQAitxmfkp5/ADFSb39C3s5uMqCRbvb4dgf/UDchOFF/TblLyTBxb2zj
+            YCqcrW2dZhvs2d7+uW4pEnuV6rJzI677vxn4fU+djDUAYo6ULmyaxf2RntQcCuoN
+            NwD0NYLywGtFMDzQ9GuO9QfRuGbYQ7qImFxhoieJtgY028Af1xjYN5cT5ecoUtUZ
+            1DqTtGXGqknv14zikbwKgmvFNtW8chwjDtyHySVoek6sAl3Ldgyml/OqrwQVdhnm
+            148NVeT8SWVEagfkXnsyW0mn/dF8/cEV/4oBRA5kDHR4qQyc5FJjcP9vldW3n8E4
+            J40vMsYt4W3VQXHEgElLr+5W2HoB/XLJt059SLWmArJsG1Zxl+EZQDLnuC7yg82/
+            39JeAR+00uwWXeYtr4baOE0kRlakITOZVrIchH+AUUMBxu9v5f7SKzWhvTAbulEL
+            VRoOwOj1InvxXAIp6dJsevE+bYaJ8ElmjrBdxw40b6v0VNhLzPV8zU9WAXVDUUkJ
+            Og==
+            =GEUa
+            -----END PGP MESSAGE-----
+        fp: 8D191B7544E9CCC3547B25A877E5A5B31D13A647
+    -   created_at: '2022-01-27T21:27:19Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9NBwWNwg7uAARAAvPh60Y0gCkw7bamk6RgMhWuaRv+Zk8IYCjlySdPzOTPs
+            zplED+Fxsp409KJSfJ+vNpWGFtoxrvh1FFT1DwdoH/AA2/UqvVOXCdi5RUfXgBv1
+            YMnuJyNRW/4jxlehypDQCXCIurmFVfBpy+qSAQ7GhYf86D2fiuHn7BaH80bYMjwI
+            N8nhtOd6hCE9BWPv2sg9B6gyEEsPtZihdRPDQIYCxGZuyqO2mn0luQViwS33zUpx
+            5073c1l4IiiPFxlx6QDpotwKhw4bC5LntVnLJUDhkgJD+8kYtXoI77rQz8fr+XXz
+            jj3ntoD4zkqDOwi8OLfbbU4CuotLhNV3zf9/gPj+w0dv4vhMBQ6MxpdKhiwhgP9j
+            2lgMXu1VKcO8nNGYFRBAP13RrB5tkuOpgb92KuaFQjeVp2SdIBmQuMp4Wtv4uQUf
+            A7+z7tyi2k+Wc4y6vNL81gVovi9vEN5oqSsGiY6/lzKBr1m4CINjIGCndpRzzOUX
+            Jvvc+pvJq0B5YbnUvFJs5Odh5ifGIzoGsaw7oTGILBmF1TTgKja3FqmCVGWUN51t
+            71j/v9wxFT7cSDKln7dzh1ZbXnyKkT/3ZyLh6p9cPmvE0EKUAON0tWC/gTFnsVQN
+            WQbsuHI73xkSQ3w4+Zx9DSlj/5bQz9r/kCpB9014QQXTDFMIB9Xxbd6htjszQRnS
+            XgFLKmgGKojj7XN63VL+ak5TuRKwfBc8eNhSFIhC2gI58pVaG5fwAJjEg6KJ5dBw
+            KctTevSoSfLC/XhV7T9mjpmxau3b09QU3SEwb3f+fxF7Oh2HZ23Ow5h4vxul2FY=
+            =l9Y5
+            -----END PGP MESSAGE-----
+        fp: A01778ACB7CC4D41B00FDD78CCBE624D8FF6D016
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.5.0

--- a/document-sync-job/overlays/ocp4-stage/cronjob.yaml
+++ b/document-sync-job/overlays/ocp4-stage/cronjob.yaml
@@ -1,0 +1,7 @@
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: document-sync
+spec:
+  suspend: true

--- a/document-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/document-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -1,0 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: thoth
+    component: document-sync
+  name: document-sync-job
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/document-sync-job:v0.1.0
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/document-sync-job/overlays/ocp4-stage/kustomization.yaml
+++ b/document-sync-job/overlays/ocp4-stage/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+images:
+  - name: document-sync-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-frontend-stage/document-sync-job
+    newTag: latest
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+  - cronjob.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: /metadata/namespace
+        value: "thoth-infra-stage"
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      annotationSelector: "operation=chat-notification"

--- a/document-sync-job/overlays/ocp4-stage/thoth-notification.yaml
+++ b/document-sync-job/overlays/ocp4-stage/thoth-notification.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: document-sync-chat-notification-success
+  annotations:
+    operation: chat-notification
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 5
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'Successfully synchronized *document-sync* to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/ocp4-stage-thoth-document-sync|ArgoCD UI> 🚚'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: document-sync-chat-notification-fail
+  annotations:
+    operation: chat-notification
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 5
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAILED* to sync *document-sync* to *OCP4-STAGE*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/ocp4-stage-thoth-document-sync|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never

--- a/document-sync-job/overlays/test/cronjob.yaml
+++ b/document-sync-job/overlays/test/cronjob.yaml
@@ -1,0 +1,7 @@
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: document-sync
+spec:
+  suspend: true

--- a/document-sync-job/overlays/test/imagestreamtag.yaml
+++ b/document-sync-job/overlays/test/imagestreamtag.yaml
@@ -1,0 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: thoth
+    component: document-sync
+  name: document-sync-job
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/document-sync-job:v0.1.0
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/document-sync-job/overlays/test/kustomization.yaml
+++ b/document-sync-job/overlays/test/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+images:
+  - name: document-sync-job
+    newName: image-registry.openshift-image-registry.svc:5000/thoth-test-core/document-sync-job
+    newTag: latest
+patchesStrategicMerge:
+  - imagestreamtag.yaml
+  - cronjob.yaml

--- a/document-sync-job/overlays/test/thoth-notification.yaml
+++ b/document-sync-job/overlays/test/thoth-notification.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: document-sync-chat-notification-success
+  annotations:
+    operation: chat-notification
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 5
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'Successfully synchronized *document-sync* to *OCP4-TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/test-thoth-document-sync|ArgoCD UI> 🚚'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: document-sync-chat-notification-fail
+  annotations:
+    operation: chat-notification
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 5
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAILED* to sync *document-sync* to *OCP4-TEST*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/test-thoth-document-sync|ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never


### PR DESCRIPTION
Set up document sync job for the thoth-station
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Successfully ran 1st alpha test.
[example-g2p7h-document-sync-job.log](https://github.com/thoth-station/thoth-application/files/7954154/example-g2p7h-document-sync-job.log)

This is sync ceph doc from the stage(ingestion) to prod(AWS)