### PR TITLE
patch the buildlog parser image

### DIFF
--- a/buildlog-parser/base/argo-workflows/buildlog-parser.yaml
+++ b/buildlog-parser/base/argo-workflows/buildlog-parser.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: parse-buildlog
+  annotations:
+    operation: buildlog-parser
 spec:
   templates:
     - name: parse-buildlog

--- a/buildlog-parser/overlays/moc-prod/kustomization.yaml
+++ b/buildlog-parser/overlays/moc-prod/kustomization.yaml
@@ -17,3 +17,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-prod/buildlog-parser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=buildlog-parser"

--- a/buildlog-parser/overlays/ocp4-stage/kustomization.yaml
+++ b/buildlog-parser/overlays/ocp4-stage/kustomization.yaml
@@ -17,3 +17,12 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-middletier-stage/buildlog-parser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=buildlog-parser"

--- a/buildlog-parser/overlays/test/kustomization.yaml
+++ b/buildlog-parser/overlays/test/kustomization.yaml
@@ -7,3 +7,13 @@ resources:
   - thoth-notification.yaml
 patchesStrategicMerge:
   - imagestreamtag.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/buildlog-parser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=buildlog-parser"


### PR DESCRIPTION
patch the buildlog parser image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

![buildlog-parser](https://user-images.githubusercontent.com/14028058/151745097-d8584f68-0132-4d94-bad9-70bb97042ed9.png)


Related-to: https://github.com/thoth-station/integration-tests/issues/225