### PR TITLE
Bump pulp-pypi-sync-job to v0.1.1 in stage

### DIFF
--- a/pulp-pypi-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/pulp-pypi-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/pulp-pypi-sync-job:v0.1.0
+        name: quay.io/thoth-station/pulp-pypi-sync-job:v0.1.1
       importPolicy: {}


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/pulp-pypi-sync-job/issues/37
