### PR TITLE
Bump document-sync-job to v0.2.0 in stage environment

### DIFF
--- a/document-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/document-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/document-sync-job:v0.1.0
+        name: quay.io/thoth-station/document-sync-job:v0.2.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/document-sync-job/pull/11
