### PR TITLE
update pulp-pypi-sync-job image tag

### DIFF
--- a/pulp-pypi-sync-job/overlays/test/imagestreamtag.yaml
+++ b/pulp-pypi-sync-job/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/pulp-pypi-sync-job:v0.1.0
+        name: quay.io/thoth-station/pulp-pypi-sync-job:v0.1.1
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Related to [issue 33](https://github.com/thoth-station/pulp-pypi-sync-job/issues/33). 

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

Upping the tag of the Pulp-PYPI-sync-job in the `test` overlay to use the fix included in [Issue 33](https://github.com/thoth-station/pulp-pypi-sync-job/issues/33) stated above. 