### PR TITLE
Respect JSON logging configuration

### DIFF
--- a/pulp-pypi-sync-job/base/cronjob.yaml
+++ b/pulp-pypi-sync-job/base/cronjob.yaml
@@ -30,6 +30,11 @@ spec:
                     configMapKeyRef:
                       key: deployment-name
                       name: thoth
+                - name: THOTH_LOGGING_NO_JSON
+                  valueFrom:
+                    configMapKeyRef:
+                      name: thoth
+                      key: logging-no-json
                 - name: SENTRY_DSN
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Description

Checking the pod logs, we log JSON even if deployment is configured not to do so.
