### PR TITLE
Increase document-sync deadline to 12 hours

### DIFF
--- a/document-sync-job/base/cronjob.yaml
+++ b/document-sync-job/base/cronjob.yaml
@@ -87,7 +87,7 @@ spec:
                   cpu: "1"
               livenessProbe:
                 failureThreshold: 1
-                initialDelaySeconds: 7200
+                initialDelaySeconds: 43200
                 periodSeconds: 10
                 tcpSocket:
                   port: 80


### PR DESCRIPTION
## Description

We have a lot of documents to sync, so let's increase the sync deadline and see how much time actually takes.
