### PR TITLE
Adjust sync concurrency based on urllib3 connection pool configured

### DIFF
--- a/document-sync-job/base/cronjob.yaml
+++ b/document-sync-job/base/cronjob.yaml
@@ -24,6 +24,8 @@ spec:
                     configMapKeyRef:
                       key: deployment-name
                       name: thoth
+                - name: THOTH_DOCUMENT_SYNC_CONCURRENCY
+                  value: "10"
                 - name: THOTH_S3_ENDPOINT_URL
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
## Description

Fixes warning produced by urllib3:

```
2022-02-04 15:30:13,351   1 WARNING  urllib3.connectionpool:305: Connection pool is full, discarding connection: s3.upshift.redhat.com. Connection pool size: 10
```