### PR TITLE
Increase document sync to 3 days

### DIFF
--- a/document-sync-job/base/cronjob.yaml
+++ b/document-sync-job/base/cronjob.yaml
@@ -89,7 +89,7 @@ spec:
                   cpu: "1"
               livenessProbe:
                 failureThreshold: 1
-                initialDelaySeconds: 43200
+                initialDelaySeconds: 259200
                 periodSeconds: 10
                 tcpSocket:
                   port: 80


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/thoth-application/pull/2323

## Description

The inial document sync failed on timeout. Let's increase the deadline (now 3 days) and trigger the sync again. We can make optimize the sync with https://github.com/thoth-station/thoth-application/pull/2323 once the initial sync is done.
