### PR TITLE
Bump document-sync to v0.3.0 in stage environment

### DIFF
--- a/document-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/document-sync-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/document-sync-job:v0.2.0
+        name: quay.io/thoth-station/document-sync-job:v0.3.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/document-sync-job/issues/16
Related: https://github.com/thoth-station/thoth-application/pull/2323
