### PR TITLE
Increase memory for document-sync-job

### DIFF
--- a/document-sync-job/base/cronjob.yaml
+++ b/document-sync-job/base/cronjob.yaml
@@ -82,10 +82,10 @@ spec:
                   readOnly: true
               resources:
                 requests:
-                  memory: "1Gi"
+                  memory: "2Gi"
                   cpu: "1"
                 limits:
-                  memory: "1.5Gi"
+                  memory: "2Gi"
                   cpu: "1"
               livenessProbe:
                 failureThreshold: 1


### PR DESCRIPTION
## Description

It looks like more memory is needed to sync some of the docs.
