### PR TITLE
Supply configured solvers for document-sync to sync solvers

### DIFF
--- a/document-sync-job/base/cronjob.yaml
+++ b/document-sync-job/base/cronjob.yaml
@@ -24,6 +24,11 @@ spec:
                     configMapKeyRef:
                       key: deployment-name
                       name: thoth
+                - name: THOTH_DOCUMENT_SYNC_CONFIGURED_SOLVERS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: solvers
+                      key: solvers
                 - name: THOTH_DOCUMENT_SYNC_CONCURRENCY
                   value: "10"
                 - name: THOTH_S3_ENDPOINT_URL


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/document-sync-job/pull/21/
Related: https://github.com/thoth-station/document-sync-job/issues/20
Related: https://github.com/thoth-station/storages/pull/2586

## Description

Let's supply solvers that are configured in the deployment to make sure only these are properly synced to prod. Eventually with date filter applied.
