### PR TITLE
Provide port configuration to all deployment configs

### DIFF
--- a/amun/base/deploymentconfig.yaml
+++ b/amun/base/deploymentconfig.yaml
@@ -23,6 +23,8 @@ spec:
         - name: amun-api
           image: amun-api:latest
           env:
+            - name: PORT
+              value: "8080"
             - name: APP_MODULE
               value: "amun.entrypoint:app"
             - name: KUBERNETES_API_URL

--- a/build-watcher/base/deploymentconfig.yaml
+++ b/build-watcher/base/deploymentconfig.yaml
@@ -20,6 +20,8 @@ spec:
         - name: build-watcher
           image: build-watcher
           env:
+            - name: PORT
+              value: "8080"
             - name: KUBERNETES_API_URL
               value: 'https://kubernetes.default.svc.cluster.local'
             - name: KUBERNETES_VERIFY_TLS

--- a/investigator/base/deploymentconfig.yaml
+++ b/investigator/base/deploymentconfig.yaml
@@ -23,6 +23,8 @@ spec:
         - image: investigator:latest
           name: investigator-consumer
           env:
+            - name: PORT
+              value: "8080"
             - name: SUBCOMMAND
               value: "consumer"
             - name: DEBUG_LEVEL

--- a/investigator_message_metrics/base/deploymentconfig.yaml
+++ b/investigator_message_metrics/base/deploymentconfig.yaml
@@ -23,6 +23,8 @@ spec:
         - image: investigator
           name: message-metrics
           env:
+            - name: PORT
+              value: "8080"
             - name: SUBCOMMAND
               value: "consumer"
             - name: DEBUG_LEVEL

--- a/management-api/base/deploymentconfig.yaml
+++ b/management-api/base/deploymentconfig.yaml
@@ -23,6 +23,8 @@ spec:
         - name: management-api-openapi
           image: management-api:latest
           env:
+            - name: PORT
+              value: "8080"
             - name: APP_MODULE
               value: "thoth.management_api.openapi_server:app"
             - name: KUBERNETES_API_URL

--- a/metrics-exporter/base/deploymentconfig.yaml
+++ b/metrics-exporter/base/deploymentconfig.yaml
@@ -23,6 +23,8 @@ spec:
         - name: metrics-exporter
           image: metrics-exporter:latest
           env:
+            - name: PORT
+              value: "8080"
             - name: "THOTH_METRICS_EXPORTER_UPDATE_INTERVAL"
               valueFrom:
                 configMapKeyRef:

--- a/pulp-metrics-exporter/base/deploymentconfig.yaml
+++ b/pulp-metrics-exporter/base/deploymentconfig.yaml
@@ -22,6 +22,8 @@ spec:
         - name: pulp-metrics-exporter
           image: pulp-metrics-exporter:latest
           env:
+            - name: PORT
+              value: "8080"
             - name: PULP_METRICS_EXPORTER_UPDATE_INTERVAL
               valueFrom:
                 configMapKeyRef:

--- a/sefkhet-abwy-chatbot/base/deploymentconfig.yaml
+++ b/sefkhet-abwy-chatbot/base/deploymentconfig.yaml
@@ -22,6 +22,8 @@ spec:
         - env:
             - name: PYTHONPATH
               value: .
+            - name: PORT
+              value: "8080"
             - name: APP_SCRIPT
               value: chatbot
             - name: GITHUB_ACCESS_TOKEN

--- a/sefkhet-abwy/base/deploymentconfig.yaml
+++ b/sefkhet-abwy/base/deploymentconfig.yaml
@@ -26,6 +26,8 @@ spec:
             - containerPort: 8080
               protocol: TCP
           env:
+            - name: PORT
+              value: "8080"
             - name: GITHUB_SECRET
               valueFrom:
                 secretKeyRef:

--- a/user-api/base/deploymentconfig.yaml
+++ b/user-api/base/deploymentconfig.yaml
@@ -30,6 +30,8 @@ spec:
           image: user-api:latest
           imagePullPolicy: Always
           env:
+            - name: PORT
+              value: "8080"
             - name: APP_MODULE
               value: "thoth.user_api.openapi_server:app"
             - name: APP_CONFIG


### PR DESCRIPTION
## Related Issues and Dependencies

See https://github.com/thoth-station/user-api/issues/1645#issuecomment-1031857876

## Description

It looks like the base image no longer uses 8080 by default. Let's supply `PORT` environment variable to all deployment configs we have to make sure all web servers use 8080 without any regressions.
