### PR TITLE
Bump graph-metrics-exporter to v0.6.0

### DIFF
--- a/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.8
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.0
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.8
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.0
       importPolicy: {}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To:  https://github.com/thoth-station/metrics-exporter/issues/821
