### PR TITLE
Allow passing indexes where package dependencies should be looked up

### DIFF
--- a/solver/base/openshift-templates/solve_and_sync-template.yaml
+++ b/solver/base/openshift-templates/solve_and_sync-template.yaml
@@ -36,6 +36,9 @@ parameters:
   - name: THOTH_SOLVER_INDEXES
     description: "A comma separated list of indexes to scan during solver run"
     displayName: "Python Package Indexes"
+  - name: THOTH_SOLVER_DEPENDENCY_INDEXES
+    description: "A comma separated list of indexes to scan during solver to look up dependencies"
+    displayName: "Dependency Python Package Indexes"
   - name: THOTH_FORCE_SYNC
     description: Perform force sync - sync data even if they are reported to be existing
     displayName: Perform force sync
@@ -110,6 +113,8 @@ objects:
             value: "${THOTH_SOLVER_PACKAGES}"
           - name: "THOTH_SOLVER_INDEXES"
             value: "${THOTH_SOLVER_INDEXES}"
+          - name: "THOTH_SOLVER_DEPENDENCY_INDEXES"
+            value: "${THOTH_SOLVER_DEPENDENCY_INDEXES}"
           - name: "THOTH_FORCE_SYNC"
             value: "${THOTH_FORCE_SYNC}"
           - name: ceph_bucket_prefix
@@ -159,6 +164,8 @@ objects:
                       value: "{{workflow.parameters.THOTH_SOLVER_PACKAGES}}"
                     - name: "THOTH_SOLVER_INDEXES"
                       value: "{{workflow.parameters.THOTH_SOLVER_INDEXES}}"
+                    - name: "THOTH_SOLVER_DEPENDENCY_INDEXES"
+                      value: "{{workflow.parameters.THOTH_SOLVER_DEPENDENCY_INDEXES}}"
                     - name: "THOTH_S3_ENDPOINT_URL"
                       value: "{{workflow.parameters.ceph_host}}"
                     - name: "THOTH_CEPH_BUCKET_NAME"
@@ -247,6 +254,8 @@ objects:
                       value: "{{workflow.parameters.THOTH_SOLVER_PACKAGES}}"
                     - name: "THOTH_SOLVER_INDEXES"
                       value: "{{workflow.parameters.THOTH_SOLVER_INDEXES}}"
+                    - name: "THOTH_SOLVER_DEPENDENCY_INDEXES"
+                      value: "{{workflow.parameters.THOTH_SOLVER_DEPENDENCY_INDEXES}}"
                     - name: "THOTH_S3_ENDPOINT_URL"
                       value: "{{workflow.parameters.ceph_host}}"
                     - name: "THOTH_CEPH_BUCKET_NAME"

--- a/solver/overlays/test/argo-workflows/solver-template.yaml
+++ b/solver/overlays/test/argo-workflows/solver-template.yaml
@@ -49,6 +49,7 @@ spec:
           - name: "THOTH_SOLVER_NO_TRANSITIVE"
           - name: "THOTH_SOLVER_PACKAGES"
           - name: "THOTH_SOLVER_INDEXES"
+          - name: "THOTH_SOLVER_DEPENDENCY_INDEXES"
           - name: "THOTH_S3_ENDPOINT_URL"
           - name: "THOTH_CEPH_BUCKET_NAME"
           - name: "THOTH_CEPH_BUCKET_PREFIX"
@@ -92,6 +93,8 @@ spec:
             value: "/mnt/workdir/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
           - name: THOTH_SOLVER_INDEXES
             value: "{{inputs.parameters.THOTH_SOLVER_INDEXES}}"
+          - name: THOTH_SOLVER_DEPENDENCY_INDEXES
+            value: "{{inputs.parameters.THOTH_SOLVER_DEPENDENCY_INDEXES}}"
           - name: "THOTH_DOCUMENT_ID"
             value: "{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
           - name: THOTH_DEPLOYMENT_NAME


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/solver/issues/5111
Related: https://github.com/thoth-station/graph-refresh-job/issues/669
Related: https://github.com/thoth-station/thoth-application/issues/2272

## This introduces a breaking change

- [x] No

## Description

Allow passing new environment variable for solvers, which would check indexes for possible dependencies (cross-index resolution).
