### PR TITLE
Enable CVE update job in prod deployments

### DIFF
--- a/cve-update/overlays/aws-prod/cronjob.yaml
+++ b/cve-update/overlays/aws-prod/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: cve-update
 spec:
   schedule: "@daily"
-  suspend: true
+  suspend: false
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4
   concurrencyPolicy: Forbid

--- a/cve-update/overlays/moc-prod/cronjob.yaml
+++ b/cve-update/overlays/moc-prod/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: cve-update
 spec:
   schedule: "@daily"
-  suspend: true
+  suspend: false
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4
   concurrencyPolicy: Forbid


### PR DESCRIPTION
## Description

Let's enable cve-update job in prod deployments so that users get fresh CVE information. Otherwise we report a warning that the database has not been updated for quite some time:

```
  https://thoth-station.ninja/j/cve_timestamp                                      │ CVE database of known vulnerabilities for Python packages was updated at '2022-01-12T00:06:25.489150'                                 │ ⚠️ WARNING  
```
