### PR TITLE
:ship: Bump up the images based on the version update v2022.02.14

### DIFF
--- a/adviser/overlays/aws-prod/imagestreamtag.yaml
+++ b/adviser/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.50.0
+        name: quay.io/thoth-station/adviser:v0.51.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/moc-prod/imagestreamtag.yaml
+++ b/adviser/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.50.0
+        name: quay.io/thoth-station/adviser:v0.51.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/aws-prod/common/imagestreamtags.yaml
+++ b/core/overlays/aws-prod/common/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.15.4
+      name: quay.io/thoth-station/investigator:v0.16.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/core/overlays/moc-prod/common/imagestreamtags.yaml
+++ b/core/overlays/moc-prod/common/imagestreamtags.yaml
@@ -35,7 +35,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/investigator:v0.15.4
+      name: quay.io/thoth-station/investigator:v0.16.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/graph-metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.5.8
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.0
       importPolicy: {}

--- a/management-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/management-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.16
+      name: quay.io/thoth-station/management-api:v0.18.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/management-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.17.16
+      name: quay.io/thoth-station/management-api:v0.18.0
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.20.1
+        name: quay.io/thoth-station/metrics-exporter:v0.20.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.20.1
+        name: quay.io/thoth-station/metrics-exporter:v0.20.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/solver/overlays/aws-prod/imagestreamtag.yaml
+++ b/solver/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.10.3"
+        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.11.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.10.3"
+        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.11.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -36,7 +36,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.10.3"
+        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.11.1"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/solver/overlays/moc-prod/imagestreamtag.yaml
+++ b/solver/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.10.3"
+        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.11.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.10.3"
+        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.11.1"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -36,7 +36,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.10.3"
+        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.11.1"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/user-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.3
+        name: quay.io/thoth-station/user-api:v0.34.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.3
+        name: quay.io/thoth-station/user-api:v0.34.4
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up the images based on the version update v2022.02.14
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2283

## Description

Sprint updates 