### PR TITLE
Bump graph metrics exporter to v0.6.1

### DIFF
--- a/graph-metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.0
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.1
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.0
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.1
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.0
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.1
       importPolicy: {}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

patch due to: https://github.com/thoth-station/graph-metrics-exporter/pull/73

image already available on quay: https://quay.io/repository/thoth-station/graph-metrics-exporter?tab=tags