### PR TITLE
:fire: patch the prometheus url towards thanos querier

### DIFF
--- a/amun/overlays/aws-prod/amun-api/configmaps.yaml
+++ b/amun/overlays/aws-prod/amun-api/configmaps.yaml
@@ -25,6 +25,6 @@ apiVersion: v1
 metadata:
   name: prometheus
 data:
-  pushgateway-host: prometheus-portal-thoth-infra-prod.apps.balrog.aws.operate-first.cloud
+  pushgateway-host: thanos-querier-openshift-monitoring.apps.balrog.aws.operate-first.cloud
   pushgateway-port: "80"
-  pushgateway-url: prometheus-portal-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80
+  pushgateway-url: thanos-querier-openshift-monitoring.apps.balrog.aws.operate-first.cloud:80

--- a/amun/overlays/moc-prod/amun-api/configmaps.yaml
+++ b/amun/overlays/moc-prod/amun-api/configmaps.yaml
@@ -25,6 +25,6 @@ apiVersion: v1
 metadata:
   name: prometheus
 data:
-  pushgateway-host: prometheus-portal-thoth-infra-prod.apps.smaug.na.operate-first.cloud
+  pushgateway-host: thanos-querier-openshift-monitoring.apps.smaug.na.operate-first.cloud
   pushgateway-port: "80"
-  pushgateway-url: prometheus-portal-thoth-infra-prod.apps.smaug.na.operate-first.cloud:80
+  pushgateway-url: thanos-querier-openshift-monitoring.apps.smaug.na.operate-first.cloud:80

--- a/core/overlays/aws-prod/common/configmaps.yaml
+++ b/core/overlays/aws-prod/common/configmaps.yaml
@@ -54,7 +54,7 @@ apiVersion: v1
 metadata:
   name: prometheus
 data:
-  host-url: "http://prometheus-portal-thoth-infra-prod.apps.balrog.aws.operate-first.cloud"
+  host-url: "https://thanos-querier-openshift-monitoring.apps.balrog.aws.operate-first.cloud"
   user-api-url: "user-api-thoth-frontend-prod.apps.balrog.aws.operate-first.cloud:80"
   instance-metrics-exporter-infra: "metrics-exporter-thoth-infra-prod.apps.balrog.aws.operate-first.cloud:80"
   instance-metrics-management-api: "management-api-thoth-frontend-prod.apps.balrog.aws.operate-first.cloud:80"


### PR DESCRIPTION
patch the prometheus url towards thanos querier
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2357

## Description

The metrics-exporter was failing as it was looking for Prometheus instead of Thanos.