### PR TITLE
:ship: Bump up the amun-api image to v0.10.1

### DIFF
--- a/amun/overlays/aws-prod/amun-api/imagestreamtag.yaml
+++ b/amun/overlays/aws-prod/amun-api/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/amun-api:v0.9.5
+      name: quay.io/thoth-station/amun-api:v0.10.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/amun/overlays/moc-prod/amun-api/imagestreamtag.yaml
+++ b/amun/overlays/moc-prod/amun-api/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/amun-api:v0.9.5
+      name: quay.io/thoth-station/amun-api:v0.10.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/amun/overlays/ocp4-stage/amun-api/imagestreamtag.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/amun-api:v0.9.5
+      name: quay.io/thoth-station/amun-api:v0.10.1
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Bump up the amun-api image to v0.10.1
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/amun-api/issues/641

## Description

PR is in response of getting back amun-api in working condition. 
This is test and is successfully working 