### PR TITLE
Increase adviser memory limit and requests

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -235,10 +235,10 @@ spec:
         resources:
           limits:
             cpu: 1.1
-            memory: 6Gi
+            memory: 10Gi
           requests:
             cpu: 1.1
-            memory: 6Gi
+            memory: 10Gi
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/issues/2272

## Description

Let's increase memory requests and limits. I'm not sure if this will help, but worth trying. I think we will need to do some optimization here (either adjusting heuristics or checking memory consumption of objects on adviser side). This is a very first attempt to check what's wrong.
