### PR TITLE
:ship: Bump up the images based on the version update v2022.02.28

### DIFF
--- a/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.20.2
+        name: quay.io/thoth-station/metrics-exporter:v0.21.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.20.2
+        name: quay.io/thoth-station/metrics-exporter:v0.21.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.20.2
+        name: quay.io/thoth-station/metrics-exporter:v0.21.0
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/user-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.4
+        name: quay.io/thoth-station/user-api:v0.34.8
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.4
+        name: quay.io/thoth-station/user-api:v0.34.8
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.7
+        name: quay.io/thoth-station/user-api:v0.34.8
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up the images based on the version update v2022.02.28
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2368

