### PR TITLE
Reduce CPU used by adviser on AWS prod

### DIFF
--- a/adviser/overlays/aws-prod/advise-resources-patch.yaml
+++ b/adviser/overlays/aws-prod/advise-resources-patch.yaml
@@ -3,7 +3,7 @@
   value:
     requests:
       memory: "6Gi"
-      cpu: "2.5"
+      cpu: "1.1"
     limits:
       memory: "6Gi"
-      cpu: "2.5"
+      cpu: "1.1"


### PR DESCRIPTION
## Description

Reduce CPU allocated per adviser run. Adviser uses 2 processes, one is CPU expensive, the other one is not that CPU expensive. 2.5 CPU look too much to allocate per an adviser run.
