### PR TITLE
Increase memory for prescriptions-refresh jobs to 1Gi to avoid OOM

### DIFF
--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-gh.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-gh.yaml
@@ -147,10 +147,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -224,10 +224,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -296,10 +296,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -366,10 +366,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -436,10 +436,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -506,10 +506,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -576,10 +576,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 256Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh

--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-image-analysis.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-image-analysis.yaml
@@ -155,10 +155,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh

--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-pypi.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-pypi.yaml
@@ -145,10 +145,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 512Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 512Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -288,10 +288,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 384Mi
+              memory: 1Gi
             requests:
               cpu: 500m
-              memory: 384Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh
@@ -357,10 +357,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh

--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-quay.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-quay.yaml
@@ -133,10 +133,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh

--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-scorecards.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-scorecards.yaml
@@ -128,10 +128,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
             requests:
               cpu: 250m
-              memory: 384Mi
+              memory: 1Gi
           volumeMounts:
             - name: ssh-config
               mountPath: /opt/app-root/src/.ssh


### PR DESCRIPTION
## Related Issues and Dependencies

Avoid OOM. We can further reduce memory allocation based on metrics.
