### PR TITLE
Adjust adviser's memory optimizer configuration

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -124,6 +124,10 @@ spec:
             value: "thoth.adviser.run"
           - name: THOTH_ADVISER_MEM_OPTIMIZER_LIMIT
             value: "5000000"
+          - name: THOTH_ADVISER_MEM_OPTIMIZER_ITERATION
+            value: "100"
+          - name: THOTH_ADVISER_MEM_OPTIMIZER_DROP_COUNT
+            value: "50"
           - name: THOTH_ADVISER_COUNT
             value: "{{inputs.parameters.THOTH_ADVISER_COUNT}}"
           - name: THOTH_ADVISER_LIMIT


### PR DESCRIPTION
## Description

Let's tweak the memory optimizer to make sure no OOMs are happening. We might interate on this configuration multiple times based on integration-tests results.
