### PR TITLE
Bump user-api to v0.34.9 in stage environment

### DIFF
--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.8
+        name: quay.io/thoth-station/user-api:v0.34.9
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Related: https://github.com/thoth-station/user-api/pull/1694