### PR TITLE
Adjust adviser's memory optimizer limit

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -123,7 +123,7 @@ spec:
           - name: THOTH_SENTRY_IGNORE_LOGGER
             value: "thoth.adviser.run"
           - name: THOTH_ADVISER_MEM_OPTIMIZER_LIMIT
-            value: "5000000"
+            value: "5750000"
           - name: THOTH_ADVISER_MEM_OPTIMIZER_ITERATION
             value: "100"
           - name: THOTH_ADVISER_MEM_OPTIMIZER_DROP_COUNT


### PR DESCRIPTION
## Description

It looks like we have still some memory available to fill. Activate the memory optimization later.

![image](https://user-images.githubusercontent.com/880687/156241567-fae785f7-63cd-456e-8fd6-d00c38ee9b25.png)

![image](https://user-images.githubusercontent.com/880687/156242758-e20d5710-f3e2-4de1-b7e8-1b61ef82b657.png)
