### PR TITLE
Document where to find container images used by Prow

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -6,3 +6,8 @@ This is a standalone ArgoCD Application for PROW. It is meant to be deployed int
 ## Validation/Compliance
 
 `kustomize build --enable_alpha_plugins overlays/thoth-station | conftest test --policy ../policy -`
+
+## How to know on which environment are tests running on Prow?
+
+The images used to run tests using Prow are listed in the [thoth-station/thoth-ops-infra](https://github.com/thoth-station/thoth-ops-infra) repository.
+For each repository where Prow is configured, the tests run by Prow and the base container image they use are available in the `.prow.yaml` file.


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes https://github.com/thoth-station/support/issues/151

## Description

Following the discussion in the issue, document where to find which container images Prow uses when running tests on a repo.
