### PR TITLE
Bump up user-api v0.34.10 to fix current openapi issue

### DIFF
--- a/user-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/user-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.8
+        name: quay.io/thoth-station/user-api:v0.34.10
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.8
+        name: quay.io/thoth-station/user-api:v0.34.10
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.9
+        name: quay.io/thoth-station/user-api:v0.34.10
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up user-api v0.34.10 to fix current openapi issue
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/user-api/issues/1696

## Description

Already tested this in test cluster