### PR TITLE
[prow] remove some repos from needs-triage label management

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -81,43 +81,7 @@ require_matching_label:
       The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
   - missing_label: needs-triage
     org: thoth-station
-    repo: ps-cv
-    issues: true
-    prs: false
-    regexp: ^triage/accepted$
-    missing_comment: |
-      This issue is currently awaiting triage.
-      One of the @thoth-station/devs will take care of the issue, and will accept the issue by applying the
-      `triage/accepted` label and provide further guidance.
-
-      The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
-  - missing_label: needs-triage
-    org: thoth-station
-    repo: ps-nlp
-    issues: true
-    prs: false
-    regexp: ^triage/accepted$
-    missing_comment: |
-      This issue is currently awaiting triage.
-      One of the @thoth-station/devs will take care of the issue, and will accept the issue by applying the
-      `triage/accepted` label and provide further guidance.
-
-      The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
-  - missing_label: needs-triage
-    org: thoth-station
     repo: thoth-application
-    issues: true
-    prs: false
-    regexp: ^triage/accepted$
-    missing_comment: |
-      This issue is currently awaiting triage.
-      One of the @thoth-station/devsops will take care of the issue, and will accept the issue by applying the
-      `triage/accepted` label and provide further guidance.
-
-      The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
-  - missing_label: needs-triage
-    org: thoth-station
-    repo: kebechet
     issues: true
     prs: false
     regexp: ^triage/accepted$


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: #2359 
Related: https://github.com/thoth-station/core/pull/386

## Description

<!--- Describe your changes in detail -->

Make the list of repos for which the requires_matching_label plugin manages the `needs-triage` label match the [label configuration in the thot-station github org](https://github.com/thoth-station/core/blob/d1e76927ec9f46c668bd58999d55e16baa91641c/community/labels.yaml#L448).
