### PR TITLE
Fix the image patching of dm

### DIFF
--- a/adviser/base/argo-workflows/dependency-monkey.yaml
+++ b/adviser/base/argo-workflows/dependency-monkey.yaml
@@ -4,7 +4,7 @@ kind: WorkflowTemplate
 metadata:
   name: dm
   annotations:
-    operation: adviser
+    operation: dependency
     thoth-station.ninja/template-version: 0.0.1
   labels:
     app: thoth

--- a/adviser/base/argo-workflows/kebechet-run-results.yaml
+++ b/adviser/base/argo-workflows/kebechet-run-results.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: kebechet-run-results
+  annotations:
+    operation: kebechet
 spec:
   templates:
     - name: schedule-kebechet

--- a/adviser/overlays/aws-prod/kustomization.yaml
+++ b/adviser/overlays/aws-prod/kustomization.yaml
@@ -27,6 +27,26 @@ patches:
       version: v1alpha1
       kind: WorkflowTemplate
       annotationSelector: "operation=adviser"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=dependency"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"
   - patch: |-
       - op: replace
         path: /spec/templates/0/container/image

--- a/adviser/overlays/moc-prod/kustomization.yaml
+++ b/adviser/overlays/moc-prod/kustomization.yaml
@@ -27,6 +27,26 @@ patches:
       version: v1alpha1
       kind: WorkflowTemplate
       annotationSelector: "operation=adviser"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=dependency"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-prod/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"
   - patch: |-
       - op: replace
         path: /spec/templates/0/container/image

--- a/adviser/overlays/ocp4-stage/kustomization.yaml
+++ b/adviser/overlays/ocp4-stage/kustomization.yaml
@@ -27,6 +27,26 @@ patches:
       version: v1alpha1
       kind: WorkflowTemplate
       annotationSelector: "operation=adviser"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-stage/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=dependency"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-backend-stage/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"
   - patch: |-
       - op: replace
         path: /spec/templates/0/container/image

--- a/adviser/overlays/test/kustomization.yaml
+++ b/adviser/overlays/test/kustomization.yaml
@@ -19,6 +19,26 @@ patches:
       version: v1alpha1
       kind: WorkflowTemplate
       annotationSelector: "operation=adviser"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/adviser:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=dependency"
+  # wf template image patch
+  - patch: |-
+      - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-test-core/kebechet:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=kebechet"
   - patch: |-
       - op: replace
         path: /spec/templates/0/container/image


### PR DESCRIPTION
Fix the image patching of dm
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/integration-tests/issues/253#issuecomment-1061019264

## Description

As dependency monkey should run in `amun-inspection` namespace, the image is also to be patched in that namespace.