### PR TITLE
Bump adviser to v0.52.2 in prod environment

### DIFF
--- a/adviser/overlays/aws-prod/imagestreamtag.yaml
+++ b/adviser/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.51.0
+        name: quay.io/thoth-station/adviser:v0.52.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/moc-prod/imagestreamtag.yaml
+++ b/adviser/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.51.0
+        name: quay.io/thoth-station/adviser:v0.52.2
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Let's eventually bump adviser in prod to check the impact on the integration-test results.