### PR TITLE
bump adviser to v0.52.3 in all environments

### DIFF
--- a/adviser/overlays/aws-prod/imagestreamtag.yaml
+++ b/adviser/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.52.2
+        name: quay.io/thoth-station/adviser:v0.52.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/moc-prod/imagestreamtag.yaml
+++ b/adviser/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.52.2
+        name: quay.io/thoth-station/adviser:v0.52.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.52.2
+        name: quay.io/thoth-station/adviser:v0.52.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/test/imagestreamtag.yaml
+++ b/adviser/overlays/test/imagestreamtag.yaml
@@ -6,7 +6,7 @@ spec:
   tags:
     - from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.52.2
+        name: quay.io/thoth-station/adviser:v0.52.3
       importPolicy: {}
       name: latest
       referencePolicy:


### PR DESCRIPTION
/hold until container image is delivered to https://quay.io/repository/thoth-station/adviser?tab=tags

Signed-off-by: Christoph Görn <goern@redhat.com>
