### PR TITLE
Revert "Do not send message by default after Amun inspections"

### DIFF
--- a/amun/base/openshift-templates/inspection-workflow.yaml
+++ b/amun/base/openshift-templates/inspection-workflow.yaml
@@ -174,7 +174,7 @@ parameters:
 - name: THOTH_SEND_MESSAGES
   description: indicates whether message should be sent upon inspection completion
   displayName: send messages
-  value: "0"  # Do not send message by default
+  value: "1"  # sends message by default
 
 - name: THOTH_FORCE_SYNC
   description: should inspection complete message cause graph sync job to be run with force sync


### PR DESCRIPTION
Reverts thoth-station/thoth-application#2418

The default behavior is encoded in sources:

https://github.com/thoth-station/common/blob/5c7452c5140a0105acfa6260ffa244d84c1f7431/thoth/common/openshift.py#L867-L869

We should make this configurable in templates https://github.com/thoth-station/common/pull/1231

As this change has no effect in the deployment, reverting. Let's fix sending messages step.