### PR TITLE
Bump user-api to v0.34.11 in stage

### DIFF
--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.10
+        name: quay.io/thoth-station/user-api:v0.34.11
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

/hold

... until available https://quay.io/repository/thoth-station/user-api?tab=tags