### PR TITLE
Run graph-refresh every 40 mins, instead of every hour

### DIFF
--- a/graph-refresh/base/cronjob.yaml
+++ b/graph-refresh/base/cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: thoth
     component: graph-refresh
 spec:
-  schedule: "0 */1 * * *"
+  schedule: "*/40 * * * *"
   suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2


### PR DESCRIPTION
Run graph-refresh every 40 mins, instead of every hour
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

![gr](https://user-images.githubusercontent.com/14028058/158117598-ec0cb846-486f-415a-9902-5c1eb9734b15.png)
oE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

The workload is getting resolved by every 40 mins, and the metrics are alerting we have compute power unused.
so making the graph-refresh job run for every 40 mins in stage cluster.