### PR TITLE
:ship: Bump up the images based on the version update v2022.03.14

### DIFF
--- a/advise-reporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/advise-reporter/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.11.0
+      name: quay.io/thoth-station/advise-reporter:v0.11.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/advise-reporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/advise-reporter/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.11.0
+      name: quay.io/thoth-station/advise-reporter:v0.11.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/advise-reporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/advise-reporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/advise-reporter:v0.11.0
+      name: quay.io/thoth-station/advise-reporter:v0.11.1
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/adviser/overlays/aws-prod/imagestreamtag.yaml
+++ b/adviser/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.52.3
+        name: quay.io/thoth-station/adviser:v0.52.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/moc-prod/imagestreamtag.yaml
+++ b/adviser/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.52.3
+        name: quay.io/thoth-station/adviser:v0.52.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-releases/overlays/aws-prod/imagestreamtag.yaml
+++ b/package-releases/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.7
+        name: quay.io/thoth-station/package-releases-job:v0.11.8
       importPolicy: {}

--- a/package-releases/overlays/moc-prod/imagestreamtag.yaml
+++ b/package-releases/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.7
+        name: quay.io/thoth-station/package-releases-job:v0.11.8
       importPolicy: {}

--- a/solver/overlays/aws-prod/imagestreamtag.yaml
+++ b/solver/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.11.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.11.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.11.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.11.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -36,7 +36,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.11.1"
+        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.11.2"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/solver/overlays/moc-prod/imagestreamtag.yaml
+++ b/solver/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.11.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py36:v1.11.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -22,7 +22,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.11.1"
+        name: "quay.io/thoth-station/solver-rhel-8-py38:v1.11.2"
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -36,7 +36,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.11.1"
+        name: "quay.io/thoth-station/solver-fedora-34-py39:v1.11.2"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/user-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.10
+        name: quay.io/thoth-station/user-api:v0.34.12
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.34.10
+        name: quay.io/thoth-station/user-api:v0.34.12
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up the images based on the version update v2022.03.14
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2393

## Description

Sprint release updates.