### PR TITLE
adding thoth solver f35-py310 image to imagestream in test overlay

### DIFF
--- a/solver/base/imagestreams.yaml
+++ b/solver/base/imagestreams.yaml
@@ -22,3 +22,11 @@ metadata:
 spec:
   lookupPolicy:
     local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: solver-fedora-35-py310
+spec:
+  lookupPolicy:
+    local: true

--- a/solver/overlays/test/imagestreamtag.yaml
+++ b/solver/overlays/test/imagestreamtag.yaml
@@ -39,3 +39,17 @@ spec:
     name: latest
     referencePolicy:
       type: Source
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: solver-fedora-35-py310
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/solver-fedora-35-py310:v0.32.3
+      importPolicy: {}
+      referencePolicy:
+        type: Source


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses: https://github.com/thoth-station/s2i-thoth/issues/231
Related to: https://github.com/thoth-station/s2i-thoth/pull/235
Depends on: https://github.com/thoth-station/solver/pull/5151

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

Adding an ImageStream resource to the solver test overlay `imagestream.yaml` to stream the new fedora35-py310 solver image coming in [solver pull 5151](https://github.com/thoth-station/solver/pull/5151). 
