### PR TITLE
[prow] Add configuration for the projectmanager prow plugin

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -200,6 +200,39 @@ project_config:
       # get this via `curl -H "Authorization: token ????" "https://api.github.com/orgs/thoth-station/teams"`
       org_maintainers_team_id: 4924960
 
+project_manager:
+  orgsRepos:
+    thoth-station:
+      projects:
+        SIG-DevSecOps:
+          columns:
+            - name: New
+              labels:
+                - sig/devsecops
+              org: thoth-station
+              state: open
+        SIG-Observability:
+          columns:
+            - name: New
+              labels:
+                - sig/observability
+              org: thoth-station
+              state: open
+        SIG-Stack-Guidance:
+          columns:
+            - name: New
+              labels:
+                - sig/stack-guidance
+              org: thoth-station
+              state: open
+        SIG-User-Experience:
+          columns:
+            - name: New
+              labels:
+                - sig/user-experience
+              org: thoth-station
+              state: open
+
 plugins:
   b4mad:
     plugins:
@@ -289,6 +322,7 @@ plugins:
       - milestoneapplier
       - milestonestatus
       - project
+      - projectmanager
       - require-matching-label
       - shrug
       - size


### PR DESCRIPTION
This adds configuration for the prow [projectmanager plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/projectmanager).

The configuration is meant to manage automatic addition of issues to GitHub projects based on their labels.

Configuration is included for the 4 projects matching our current [SIGs](https://github.com/thoth-station/core/blob/master/community/sig-list.md). For example, an issue labeled with `sig/devsecops` would get automatically added to the *New* column of the [SIG-DevSecOps project](https://github.com/orgs/thoth-station/projects/16).

For reference, sample configuration for that plugin can be seen in [the documented plugins.yaml config](https://github.com/kubernetes/test-infra/blob/853555e6b2bc3052fb863fef12be5c1521f8d36a/prow/plugins/plugin-config-documented.yaml#L567)