### PR TITLE
creating aws-prod-ocp4-stage overlay for thoth-integration tests

### DIFF
--- a/integration-tests/overlays/aws-prod-ocp4-stage/README.rst
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/README.rst
@@ -1,0 +1,5 @@
+Integration tests for aws-prod
+------------------------------
+
+This overlay keeps manifests needed to run integration tests for aws-prod environment.
+Note integration tests are executed in ocp4-stage.

--- a/integration-tests/overlays/aws-prod-ocp4-stage/configmap.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/configmap.yaml
@@ -1,0 +1,11 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: integration-tests
+data:
+  deployment-name: "aws-prod"
+  user-api: "api.prod.thoth-station.ninja"
+  management-api: "management.prod.thoth-station.ninja"
+  amun-api: "amun.prod.thoth-station.ninja"
+  tags: "~@seizes_middletier_namespace,~@seizes_amun_inspection_namespace"

--- a/integration-tests/overlays/aws-prod-ocp4-stage/cronjob.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/cronjob.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: integration-tests
+  labels:
+    app: thoth
+    component: integration-tests
+spec:
+  suspend: false

--- a/integration-tests/overlays/aws-prod-ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/imagestreamtag.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: integration-tests
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/integration-tests:v0.11.0
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/integration-tests/overlays/aws-prod-ocp4-stage/kustomization.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - thoth-notification.yaml
+images:
+  - name: integration-tests
+    newName: image-registry.openshift-image-registry.svc:5000/aicoe-prod-bots/integration-tests
+    newTag: latest
+patchesStrategicMerge:
+  - configmap.yaml
+  - cronjob.yaml
+  - imagestreamtag.yaml
+generators:
+  - ./secret-generator.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: /metadata/namespace
+        value: "thoth-infra-stage"
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      annotationSelector: "operation=chat-notification"

--- a/integration-tests/overlays/aws-prod-ocp4-stage/secret-generator.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: thoth-secret-generator
+files:
+  - ./secrets.enc.yaml

--- a/integration-tests/overlays/aws-prod-ocp4-stage/secrets.enc.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/secrets.enc.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+items:
+-   apiVersion: v1
+    data:
+        app-secret-key: ENC[AES256_GCM,data:C8WCOEQoKQx+RyPz8cwC/6q70Es=,iv:2zcpRUzVF+P+oGoRIuUIrFW8YGGhL1CTX8t+gGLVjMk=,tag:2j/CYew/bKPhLGQT1Iv8xA==,type:str]
+        management-api-token: ENC[AES256_GCM,data:zwDMmljjcAOgBJGG,iv:2ssZ8xH/MEQg8Dyq1yU/gDdniNG8YOiwmUEVJ+iNbsQ=,tag:s9QAI6v3m3wKIaWDGRIERA==,type:str]
+        user-api-token: ENC[AES256_GCM,data:K4X0b7nuPcwzZlgE,iv:HlDfwOG4jbapn4J8mpdgEu2FC2UnNgZI/+gw2GzzbGI=,tag:NY8J7yuCx9HN5iN6p2JJ+A==,type:str]
+    kind: Secret
+    metadata:
+        name: integration-tests
+    type: Opaque
+kind: List
+metadata:
+    resourceVersion: ""
+    selfLink: ""
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2021-04-12T20:51:44Z'
+    mac: ENC[AES256_GCM,data:dAUOsLlT097RBz0Wd5qYTyfxCSbBEMHCYgyOjilTsSSZa9G59oA2Ako3qXFvg0vICYNRSGn4DZO7Lo0CxvX4cc940FpHwM/gn6x2kIObFQfUCIJUN+wawQtA9M51Z79LqDFqtLx89xiYwTpjUZysTrwIKBtnwmQmV1G+uIyvLEw=,iv:b6AQyBSM1Px8vyRKwVhDWDiPBPhm/gDWOR7peI9z+qI=,tag:Aj9G+aeBEsEWnh2xme/5LQ==,type:str]
+    pgp:
+    -   created_at: '2021-04-12T20:51:44Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA1gbAjViyxWYAQ/+Opc7ub6kwbiUI0kWE4teb65M7dsppL0iEmQikJM2LOZA
+            NL7ZSz6IugRZNOemt5/wAvd2dxAUAaU0gBP5i6il4sH3ACMawINcWrzLNPaSPqBB
+            47Ga2lomUL7wcKtrGsk3Db2lporksaHR3WPUyvmdBjSwHmn4gallz6jvfN10Tppb
+            U6iAoElcw8k2+b+1fYZGWPWdh9ijWEbX93Zf4cDBhBJnVzdXiTFCuFlUQRFr1P5z
+            uQtoUtQCYdNCvakFww+v0mP+7dW8efWkABqurX5VuiHgB0ihzIvSpaJpWu0QCQsR
+            pP/fdXF17c1gqYxX93s3pOMshDC1npVQJWJRIsr++yPPr6iT2Rb2XOnGtOQYclVX
+            McXgM532TRH/oiyrewMF2+6Be26YDHwYtxyiTrJ561AvszUv7Qigda6/sPWtUMNy
+            e11hv86DteTIe3ddlnFUy5QrOspjNtOhobWx2I3SO4SNlYMpxrnkxpYvYyzYPOn1
+            XzlXMzlPTG2mnt0uLFHQZUhE6E5y1MYUecZ2rWE2syjBBRsCiRQhWf1Che9x8Y2n
+            eArhzp2rM80E7jC0ByIe8pkIqBCpEdki5aJxwR1e9g9gdOQiOhhzBjCAAXYM9504
+            VGkrHWHYg5ErEB8+KK7T0ZORrJqY/7YA3Crn5cVBsNExjRjJtNxpikORbf/cBj7S
+            XgE6DpSQ7fpWykLzWl01OB+GLI7UAGbN38C1SBEgRPKL1i6rjU4128JbkGHDsZ3Y
+            3E2INL4QsgnUaKHZUOyoqTb64QoAqbP7Slr50jHId3It+Q0DnsaamPZSpo3gG8s=
+            =7fea
+            -----END PGP MESSAGE-----
+        fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
+    -   created_at: '2021-04-12T20:51:44Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA+/WpawS9RPbAQf/X619GClCp0ypz6z0qy2puuqGpYlZTDxQLQWYhVXL8Swt
+            Ohn3EX6m6JQHooJfSPzJO9HyqkvdAZL77vS4WSkcUQE+s9Xfog0hVGCAxTgGNunF
+            Rkr9sweMhaHvpz7ZhCSEN32qUA08UG6ARCq5u0QU3Uvb9VziZ97ePZgqNTOXsxJ4
+            jVtRYfXJ/lVKFxAH7Z9/G8FVmLxw0S8e7sOrnSt57eMly4Xav+O/lhKcssHShXCY
+            YgVdLCoZ2+XN2afzsMSVRwimDHmBgc1Anx/8QUWDlzI3rpTG3msLUMGaVHB+md/A
+            t9NU5+gZ+Sp3MLwShSktiDI+61xYQvaTjCIuYQocctJeAR2OxVmurH8RH1m2l0/4
+            sAPz7o7Ruiqh7mA5ZBHPRAWuABQQaDyaH9ebxNOnZ/2tXTXPwT/y/Nf57ShNEndw
+            //rKZFDQ9aeKpG7FLl3IYxDFXBX/8QalKCy2QBZFoA==
+            =jYC3
+            -----END PGP MESSAGE-----
+        fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
+    -   created_at: '2021-04-12T20:51:44Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQf+KPtkN9qWPpCGbnBVT90U5RL2LgH1MyOqblZVcoYGOns6
+            bkuAAEfOhTxzD93QDvSd+uY6C2GE9gXWOo+U+bGqkDcNKAjgWpqkKqPJ6oIETqcs
+            TVTxGmaLZ+GWlhJMYmzF/IQ6/T7StmzWkOIVkTS74n3Gc7ZM0RCPf+3uSlpEEzfB
+            vwPGZP6z0jcN0fA1MOk8tmdP3ZfYz2/nPn76iEe7n2MVVwnA8C/BJjwPtBLpRiRT
+            Qhy0X3p95cUwbJgaIPrDV2lEwPraJNmhOSoViDvKW+J3rFlIvl9WWffJvFAR8sAx
+            aAuhQ2y7f0YFeh/mPIGpAmVwO0tmCQ6md96woQL1HNJeAb8rz3IuofPpZRHknTCS
+            3WdhOyNAB+9/j45N1AWpJKILIfYKEtkb0DG7VXxdW1VptjCJaxiIU6x0oP5QPK5l
+            NiAYy7Ur0nGUOwTsjjq5WOO/wJiWJRs8ZXUhd7Kj+w==
+            =bfjH
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    -   created_at: '2021-04-12T20:51:44Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiAQ/9FgWLyg7sMispGgba2VeVzdWkVRupwvuysulhSZ1OxGoh
+            Ww//dLgTSM0nfy56rb1542QgbidIKaviMCZCZa6bX8QUa1LmXcX+QXlMiKc2M/q/
+            IxxN7FOB4lkNTRWypR6XRv8LfS6bhLKJiv/ufZ2EkZBDvqR98QzkVcQH1eZlOU7/
+            6PRF1XquCGHNeVK27jXc/p7/CakIBsTSQ8TCRmbaczN/A7bpgXJhJurDRWuiOlcO
+            yRu7XJXLfSnTMhYFqmFKFjEkWRkLCSBMRPRI360e59r2fp6vXnCLS/vC4n/FF24M
+            P4P0W60wLHLxd7H/ygxYFj29Rc7Z9OVzC5A9NJ8hJaxEBnxQcwionw0yzSyq6PdC
+            zG/cTm97PunidNak85Ui7j/l1+90U7GdNQOfdFf/8Xdx1AU9F7g5qbseRgITq8YR
+            pi35qFDlApQRZCClDcvLjEvnNtMLsJ0lY8Y4v0c+leXdsrD2WEoWHdytIa8jOmaf
+            sCVTgEsLnrPNPh4JramkudBA0yMNLZryjDHMWJJCUd8HfFxRgFfe8kNzR5donokT
+            D0mQTTtAJ80pcqtm0buMTj25pY8uhheWCTO/7CrMf9nVRsZb5yqST6rg8IwyPrjS
+            1dZwtZ3ssTdEzmUp7GnV81ZFXd3MWuYKSI4xucUhZgwsDUfjJC7UuVh4451IqAPS
+            XgFtZx4LEuzbAxH3ySFSjJz0Hct3C5mGrnhCn8iNOKLkxJVlFwobYA7SqV1wbXDs
+            KM2LXf29TaCpXgVKpsmKpgUAmDhre/zv6zegun9DbtetgDFwHEHgEVdsyNcxg6o=
+            =Z1Df
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.5.0

--- a/integration-tests/overlays/aws-prod-ocp4-stage/thoth-notification.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/thoth-notification.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: integration-tests-chat-notification-success
+  annotations:
+    operation: chat-notification
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 5
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'Successfully synchronized *integration-tests* to *AWS-PROD*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/prod-thoth-integration-tests-aws|ArgoCD UI> 🚚'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: integration-tests-chat-notification-fail
+  annotations:
+    operation: chat-notification
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 5
+  backoffLimit: 2
+  template:
+    spec:
+      containers:
+        - name: chat-notification
+          image: registry.access.redhat.com/ubi8/ubi
+          command:
+            - "curl"
+            - "-X"
+            - "POST"
+            - "-H"
+            - "Content-Type: application/json; charset=UTF-8"
+            - "-d"
+            - "{'text':'🔥 *FAILED* to sync *integration-tests* to *AWS-PROD*, see <https://argocd-server-aicoe-argocd.apps.ocp4.prod.psi.redhat.com/applications/prod-thoth-integration-tests-aws |ArgoCD UI>'}"
+            - "$(THOTH_DEVOPS_WEBHOOK_URL)"
+          env:
+            - name: THOTH_DEVOPS_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: chat-notification
+                  key: thoth-devops
+      restartPolicy: Never


### PR DESCRIPTION
## Related Issues and Dependencies

Partially addresses: https://github.com/thoth-station/thoth-application/issues/2451

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

This will create a new overlay for aws-prod-ocp4-stage for the thoth-integration tests.

/cc @harshad16 
/cc @mayaCostantini 
