### PR TITLE
[prow] project map: SIG User Experience instead of Kebechet

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -168,10 +168,10 @@ project_config:
   project_org_configs:
     thoth-station:
       org_default_column_map:
-        Kebechet: New
         SIG-DevSecOps: New
         SIG-Observability: New
         SIG-Stack-Guidance: New
+        SIG-User-Experience: New
 
       # get this via `curl -H "Authorization: token ????" "https://api.github.com/orgs/thoth-station/teams"`
       org_maintainers_team_id: 4924960


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

The [Kebechet GitHub project](https://github.com/orgs/thoth-station/projects/3) is not actively maintained according to recent feedback.

On the other hand, the [SIG User Experience project](https://github.com/orgs/thoth-station/projects/40) is ramping up.

This PR updates the prow plugin configuration for the `project` plugin to remove Kebechet and add SIG-User-Experience.