### PR TITLE
set mi-scheduler-cm configmap for mi-scheduler cronjob

### DIFF
--- a/mi-scheduler/base/configmaps.yaml
+++ b/mi-scheduler/base/configmaps.yaml
@@ -8,3 +8,10 @@ data:
   repositories: "openshift/origin"
   organizations: "thoth-station,AICoE,aicoe-aiops,operate-first"
   parallel-workflows-limit: "1"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: mi-scheduler-cm
+data:
+  entities: "PullRequest,Issue"

--- a/mi-scheduler/base/cronjob.yaml
+++ b/mi-scheduler/base/cronjob.yaml
@@ -60,7 +60,7 @@ spec:
                 - name: MI_ENTITIES
                   valueFrom:
                     configMapKeyRef:
-                      name: mi-scheduler
+                      name: mi-scheduler-cm
                       key: entities
           restartPolicy: OnFailure
 ---


### PR DESCRIPTION
set mi-scheduler-cm configmap for mi-scheduler cronjob
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

we need this separation as the config map mi-scheduler lives in another namespace as thoth-common reads it and is used in workflows, so we need this as separate as it is directly being used in cronjob. 
https://github.com/thoth-station/thoth-application/blob/426358d5f6fad745e35a99ab74ee6cbf7067b2b6/mi-scheduler/base/cronjob.yaml#L63
https://github.com/thoth-station/thoth-application/blob/426358d5f6fad745e35a99ab74ee6cbf7067b2b6/mi-scheduler/overlays/moc-prod/kustomization.yaml#L24