### PR TITLE
Downgrade amun api cpu limit for usability

### DIFF
--- a/amun/base/deploymentconfig.yaml
+++ b/amun/base/deploymentconfig.yaml
@@ -113,10 +113,10 @@ spec:
           resources:
             requests:
               memory: "384Mi"
-              cpu: "1"
+              cpu: "200m"
             limits:
               memory: "384Mi"
-              cpu: "1"
+              cpu: "200m"
           readinessProbe:
             httpGet:
               path: "/readiness"


### PR DESCRIPTION
Downgrade amun api CPU limit for usability
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

The Amun API is not used as the same as user-API , the CPU limit of the whole 1 core is not needed.
![amun-api](https://user-images.githubusercontent.com/14028058/160348209-ed7b6e17-dc48-425f-a174-096ea17ec501.png)
