### PR TITLE
Drop web concurrency for amun-api

### DIFF
--- a/amun/base/deploymentconfig.yaml
+++ b/amun/base/deploymentconfig.yaml
@@ -30,7 +30,7 @@ spec:
             - name: KUBERNETES_API_URL
               value: "https://kubernetes.default.svc.cluster.local"
             - name: WEB_CONCURRENCY
-              value: "2"
+              value: "1"
             - name: KUBERNETES_VERIFY_TLS
               value: "0"
             - name: AMUN_DEBUG


### PR DESCRIPTION
Drop web concurrency for amun-api
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #2464 

## Description

As we dropped the number of cores being used, dropping the web concurrency to be under limits. 