### PR TITLE
Keep DM up-to-date which uses adviser image

### DIFF
--- a/amun/overlays/aws-prod/amun-inspection/kustomization.yaml
+++ b/amun/overlays/aws-prod/amun-inspection/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - configmaps.yaml
   - metrics-exporter-reader.yaml
   - thoth-notification.yaml
+  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/adviser/overlays/aws-prod/imagestreamtag.yaml
 patches:
   - patch: |-
       - op: add
@@ -21,6 +22,17 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: add
+        path: /spec/lookupPolicy
+        value:
+          local: true
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: adviser
+
 # wf controller image patch
 images:
   - name: argocli

--- a/amun/overlays/moc-prod/amun-inspection/kustomization.yaml
+++ b/amun/overlays/moc-prod/amun-inspection/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - configmaps.yaml
   - metrics-exporter-reader.yaml
   - thoth-notification.yaml
+  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/adviser/overlays/moc-prod/imagestreamtag.yaml
 patches:
   - patch: |-
       - op: add
@@ -21,6 +22,17 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: add
+        path: /spec/lookupPolicy
+        value:
+          local: true
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: adviser
+
 # wf controller image patch
 images:
   - name: argocli

--- a/amun/overlays/ocp4-stage/amun-inspection/kustomization.yaml
+++ b/amun/overlays/ocp4-stage/amun-inspection/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - configmaps.yaml
   - metrics-exporter-reader.yaml
   - thoth-notification.yaml
+  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/adviser/overlays/ocp4-stage/imagestreamtag.yaml
 patches:
   - patch: |-
       - op: add
@@ -20,6 +21,16 @@ patches:
       version: v1
       kind: Job
       annotationSelector: "operation=chat-notification"
+  - patch: |-
+      - op: add
+        path: /spec/lookupPolicy
+        value:
+          local: true
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: adviser
 # wf controller image patch
 images:
   - name: argocli


### PR DESCRIPTION
Keep DM up-to-date which uses adviser image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

Dependency monkey uses adviser image, as we only apply adviser image in thoth-backend.
This is way to keep the adviser image up-to-date in thoth-amun-inspection namespace , where DM runs.