### PR TITLE
Keep DM sync up-to-date which uses graph-sync image

### DIFF
--- a/amun/overlays/aws-prod/amun-api/argo-workflows/sync-template.yaml
+++ b/amun/overlays/aws-prod/amun-api/argo-workflows/sync-template.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: graph-sync
+  annotations:
+    operation: graph-sync
 spec:
   templates:
     - name: graph-sync

--- a/amun/overlays/aws-prod/amun-api/kustomization.yaml
+++ b/amun/overlays/aws-prod/amun-api/kustomization.yaml
@@ -157,6 +157,15 @@ patches:
       annotationSelector: "operation=messaging"
   - patch: |-
       - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/graph-sync-job:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=graph-sync"
+  - patch: |-
+      - op: replace
         path: /spec/templates/1/script/image
         value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/kubectl:latest
       - op: replace

--- a/amun/overlays/aws-prod/amun-inspection/kustomization.yaml
+++ b/amun/overlays/aws-prod/amun-inspection/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - metrics-exporter-reader.yaml
   - thoth-notification.yaml
   - https://raw.githubusercontent.com/thoth-station/thoth-application/master/adviser/overlays/aws-prod/imagestreamtag.yaml
+  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/graph-sync/overlays/aws-prod/common/imagestreamtag.yaml
 patches:
   - patch: |-
       - op: add
@@ -32,6 +33,16 @@ patches:
       version: v1
       kind: ImageStream
       name: adviser
+  - patch: |-
+      - op: add
+        path: /spec/lookupPolicy
+        value:
+          local: true
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: graph-sync-job
 
 # wf controller image patch
 images:

--- a/amun/overlays/moc-prod/amun-api/argo-workflows/sync-template.yaml
+++ b/amun/overlays/moc-prod/amun-api/argo-workflows/sync-template.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: graph-sync
+  annotations:
+    operation: graph-sync
 spec:
   templates:
     - name: graph-sync

--- a/amun/overlays/moc-prod/amun-api/kustomization.yaml
+++ b/amun/overlays/moc-prod/amun-api/kustomization.yaml
@@ -157,6 +157,15 @@ patches:
       annotationSelector: "operation=messaging"
   - patch: |-
       - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/graph-sync-job:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=graph-sync"
+  - patch: |-
+      - op: replace
         path: /spec/templates/1/script/image
         value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/kubectl:latest
       - op: replace

--- a/amun/overlays/moc-prod/amun-inspection/kustomization.yaml
+++ b/amun/overlays/moc-prod/amun-inspection/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - metrics-exporter-reader.yaml
   - thoth-notification.yaml
   - https://raw.githubusercontent.com/thoth-station/thoth-application/master/adviser/overlays/moc-prod/imagestreamtag.yaml
+  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/graph-sync/overlays/moc-prod/common/imagestreamtag.yaml
 patches:
   - patch: |-
       - op: add
@@ -32,7 +33,16 @@ patches:
       version: v1
       kind: ImageStream
       name: adviser
-
+  - patch: |-
+      - op: add
+        path: /spec/lookupPolicy
+        value:
+          local: true
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: graph-sync-job
 # wf controller image patch
 images:
   - name: argocli

--- a/amun/overlays/ocp4-stage/amun-api/argo-workflows/sync-template.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/argo-workflows/sync-template.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: graph-sync
+  annotations:
+    operation: graph-sync
 spec:
   templates:
     - name: graph-sync

--- a/amun/overlays/ocp4-stage/amun-api/kustomization.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/kustomization.yaml
@@ -154,6 +154,15 @@ patches:
       annotationSelector: "operation=messaging"
   - patch: |-
       - op: replace
+        path: /spec/templates/0/container/image
+        value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-prod/graph-sync-job:latest
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: WorkflowTemplate
+      annotationSelector: "operation=graph-sync"
+  - patch: |-
+      - op: replace
         path: /spec/templates/1/script/image
         value: image-registry.openshift-image-registry.svc:5000/thoth-amun-inspection-stage/kubectl:latest
       - op: replace

--- a/amun/overlays/ocp4-stage/amun-inspection/kustomization.yaml
+++ b/amun/overlays/ocp4-stage/amun-inspection/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - metrics-exporter-reader.yaml
   - thoth-notification.yaml
   - https://raw.githubusercontent.com/thoth-station/thoth-application/master/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+  - https://raw.githubusercontent.com/thoth-station/thoth-application/master/graph-sync/overlays/ocp4-stage/common/imagestreamtag.yaml
 patches:
   - patch: |-
       - op: add
@@ -31,6 +32,16 @@ patches:
       version: v1
       kind: ImageStream
       name: adviser
+  - patch: |-
+      - op: add
+        path: /spec/lookupPolicy
+        value:
+          local: true
+    target:
+      group: image.openshift.io
+      version: v1
+      kind: ImageStream
+      name: graph-sync-job
 # wf controller image patch
 images:
   - name: argocli


### PR DESCRIPTION
Keep DM sync up-to-date which uses graph-sync image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

![graph-error](https://user-images.githubusercontent.com/14028058/161261241-21ddf885-30f2-4891-9053-5431f4d95da0.png)

