### PR TITLE
Bump Amun API to v0.10.3 in stage

### DIFF
--- a/amun/overlays/ocp4-stage/amun-api/imagestreamtag.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/amun-api:v0.10.2
+      name: quay.io/thoth-station/amun-api:v0.10.3
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Container image is available at [quay.io/thoth-station/amun-api:v0.10.3](https://quay.io/repository/thoth-station/amun-api?tab=tags&tag=latest)