### PR TITLE
Bump integration tests to v0.11.2 in stage

### DIFF
--- a/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.11.1
+        name: quay.io/thoth-station/integration-tests:v0.11.2
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/integration-tests/issues/313

/hold
Waiting for container image to be available at https://quay.io/repository/thoth-station/integration-tests?tab=tags
