### PR TITLE
Increase the parallel wf run limit and reduce ttl in stage for backend

### DIFF
--- a/core/overlays/aws-prod/backend-prod/configmaps.yaml
+++ b/core/overlays/aws-prod/backend-prod/configmaps.yaml
@@ -15,7 +15,7 @@ data:
           secondsAfterCompletion: 900
           secondsAfterSuccess: 900
           secondsAfterFailure: 900
-      parallelism: 2
+      parallelism: 5
 
     # metricsConfig controls the path and port for prometheus metrics
     metricsConfig:

--- a/core/overlays/ocp4-stage/backend-stage/configmaps.yaml
+++ b/core/overlays/ocp4-stage/backend-stage/configmaps.yaml
@@ -12,10 +12,10 @@ data:
     workflowDefaults:
       spec:
         ttlStrategy:
-          secondsAfterCompletion: 7200
-          secondsAfterSuccess: 7200
-          secondsAfterFailure: 7200
-      parallelism: 2
+          secondsAfterCompletion: 900
+          secondsAfterSuccess: 900
+          secondsAfterFailure: 900
+      parallelism: 5
 
     # metricsConfig controls the path and port for prometheus metrics
     metricsConfig:


### PR DESCRIPTION
Increase the parallel wf run limit and reduce ttl in stage for backend
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/integration-tests/issues/309
https://github.com/thoth-station/investigator/issues/637

## Description

As we have available resources, lets check with increase wf parallel execution limits.
![free-resources](https://user-images.githubusercontent.com/14028058/163167394-4d8c22ab-31b1-4c4c-8420-002a2ccc9e76.png)
