### PR TITLE
Start the sync of the fedora35 python 3.10 solvers

### DIFF
--- a/core/overlays/aws-prod/common/configmaps.yaml
+++ b/core/overlays/aws-prod/common/configmaps.yaml
@@ -37,6 +37,7 @@ data:
   solvers: |
     solver-rhel-8-py38
     solver-fedora-34-py39
+    solver-fedora-35-py310
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/core/overlays/moc-prod/common/configmaps.yaml
+++ b/core/overlays/moc-prod/common/configmaps.yaml
@@ -37,6 +37,7 @@ data:
   solvers: |
     solver-rhel-8-py38
     solver-fedora-34-py39
+    solver-fedora-35-py310
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/core/overlays/ocp4-stage/common/configmaps.yaml
+++ b/core/overlays/ocp4-stage/common/configmaps.yaml
@@ -37,6 +37,7 @@ data:
   solvers: |
     solver-rhel-8-py38
     solver-fedora-34-py39
+    solver-fedora-35-py310
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -35,7 +35,7 @@ metadata:
   name: solvers
 data:
   solvers: |
-    solver-rhel-8-py38
+    solver-rhel-8-py36
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -35,7 +35,7 @@ metadata:
   name: solvers
 data:
   solvers: |
-    solver-rhel-8-py36
+    solver-rhel-8-py38
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/solver/overlays/aws-prod/imagestreamtag.yaml
+++ b/solver/overlays/aws-prod/imagestreamtag.yaml
@@ -40,3 +40,17 @@ spec:
       importPolicy: {}
       referencePolicy:
         type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: solver-fedora-35-py310
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/solver-fedora-35-py310:v1.12.0
+      importPolicy: {}
+      referencePolicy:
+        type: Source

--- a/solver/overlays/moc-prod/imagestreamtag.yaml
+++ b/solver/overlays/moc-prod/imagestreamtag.yaml
@@ -40,3 +40,17 @@ spec:
       importPolicy: {}
       referencePolicy:
         type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: solver-fedora-35-py310
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/solver-fedora-35-py310:v1.12.0
+      importPolicy: {}
+      referencePolicy:
+        type: Source

--- a/solver/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/solver/overlays/ocp4-stage/imagestreamtag.yaml
@@ -40,3 +40,17 @@ spec:
       importPolicy: {}
       referencePolicy:
         type: Local
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: solver-fedora-35-py310
+spec:
+  tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: quay.io/thoth-station/solver-fedora-35-py310:v1.12.0
+      importPolicy: {}
+      referencePolicy:
+        type: Source

--- a/solver/overlays/test/imagestreamtag.yaml
+++ b/solver/overlays/test/imagestreamtag.yaml
@@ -49,7 +49,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/solver-fedora-35-py310:v0.32.3
+        name: quay.io/thoth-station/solver-fedora-35-py310:v1.12.0
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
Start the sync of the fedora35 python 3.10 solvers
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/2479
Related-to: https://github.com/thoth-station/s2i-thoth/issues/231

## Description

start the solver execution for the f35-py3.10 based solvers.