### PR TITLE
[prow] Fix typo in current milestone configuration

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -179,7 +179,7 @@ repo_milestone:
 
 milestone_applier:
   thoth-station/thoth-application:
-    master: 2022.05.00
+    master: 2022.05.09
     v2022.04.18: 2022.04.18
 
 project_config:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

The current sprint's milestone is [2022.05.09](https://github.com/thoth-station/thoth-application/milestone/29).

This PR fixes a typo in the prow milestone plugin configuration to match it.