### PR TITLE
feat(prow): OSG Peribolos needs Tide stop skipping checks

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -391,6 +391,10 @@ tide:
           workflow-helpers:
             required-contexts:
               - aicoe-ci/build-check
+      open-services-group:
+        repos:
+          peribolos-as-a-service:
+            skip-unknown-contexts: false
 
 periodics:
   - name: integration-tests-prod


### PR DESCRIPTION
Tide is skipping contexts not defined by Prow config (enabled in settings). Turn this off for Peribolos as a service repo. 