### PR TITLE
[prow] Add an additional 'epic' label

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -11,6 +11,7 @@ label:
     - deployment_name/ocp4-stage
     - deployment_name/ocp4-test
     - deployment_name/moc-prod
+    - epic
     - hacktoberfest
     - hacktoberfest-accepted
     - kind/cleanup


### PR DESCRIPTION
## Related Issues and Dependencies

Initially this is meant to be used by the OSG repos, see https://github.com/open-services-group/community/pull/179

## Description

<!--- Describe your changes in detail -->

This adds an additional label `epic` to be managed by prow's label plugin, so that anyone can comment on issues:

``` text
/label epic
/remove-label epic
```

without requiring write permissions in the target repository.