### PR TITLE
feat: Disable branch protection on peribolos repo

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -157,6 +157,9 @@ branch-protection:
         required_pull_request_reviews:
           dismiss_stale_reviews: false
           required_approving_review_count: 1
+      repos:
+        peribolos-as-a-service:
+          protect: false
     os-climate:
           protect: true
           allow_force_pushes: false


### PR DESCRIPTION
Release workflow is being blocked by mandatory pre-commit context on push to master. Disabling this branch protect rule for now.