### PR TITLE
adding argo workflow and modifying template

### DIFF
--- a/sync-job/base/workflow-template.yaml
+++ b/sync-job/base/workflow-template.yaml
@@ -17,6 +17,12 @@ spec:
             - "package-extract"
             - "provenance-checker"
             - "security-indicator"
+        - name: THOTH_SYNC_FORCE
+          default: "0"
+        - name: THOTH_SYNC_GRACEFUL
+          default: "0"
+        - name: THOTH_SYNC_DEBUG
+          default: "0"
       container:
         image: "quay.io/thoth-station/sync-job:v0.2.4"
         env:

--- a/sync-job/base/workflow.yaml
+++ b/sync-job/base/workflow.yaml
@@ -1,0 +1,63 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: sync
+  annotations:
+    description: "Thoth: SyncJob"
+    openshift.io/display-name: "Thoth: SyncJob"
+    tags: thoth,sync
+    template.openshift.io/documentation-url: https://github.com/Thoth-Station/
+    template.openshift.io/long-description: >
+      This template defines the workflow to run the Sync-Job for our Ceph DB in OpenShift.
+    template.openshift.io/provider-display-name: "Red Hat, Inc."
+  labels:
+    app: thoth
+    template: sync
+    component: sync
+parameters:
+  - name: THOTH_SYNC_FORCE
+    required: false
+    description: Force run the sync job.
+    displayName: force
+  - name: THOTH_SYNC_GRACEFUL
+    required: false
+    description: Graceful sync for the sync job.
+    displayName: graceful
+  - name: THOTH_SYNC_DEBUG
+    required: true
+    description: Level of debugging to set for the sync job.
+    displayName: debug
+  - name: THOTH_DOCUMENT_TYPE
+    required: true
+    description: The document type to sync to ceph.
+    displayName: document_type
+objects:
+  - apiVersion: argoproj.io/v1alpha1
+    kind: Workflow
+    metadata:
+      name: sync-job
+    spec:
+      entrypoint: SyncDocuments
+      arguments:
+        parameters:
+        - name: THOTH_SYNC_FORCE
+        - name: THOTH_SYNC_GRACEFUL
+        - name: THOTH_SYNC_DEBUG
+        - name: THOTH_DOCUMENT_TYPE
+      templates:
+      - name: SyncDocuments
+        steps:
+        - - name: SyncDocuments
+            templateRef:
+              name: sync-job-wt
+              template: SyncDocumentType
+            arguments:
+              parameters:
+                - name: THOTH_SYNC_FORCE
+                  value: "{{workflow.parameters.THOTH_DOCUMENT_TYPE}}"
+                - name: THOTH_SYNC_GRACEFUL
+                  value: "{{workflow.parameters.THOTH_SYNC_GRACEFUL}}"
+                - name: THOTH_SYNC_DEBUG
+                  value: "{{workflow.parameters.THOTH_SYNC_DEBUG}}"
+                - name: THOTH_DOCUMENT_TYPE
+                  value: "{{workflow.parameters.THOTH_DOCUMENT_TYPE}}"


### PR DESCRIPTION
## Related Issues and Dependencies

Remake of https://github.com/thoth-station/sync-job/pull/67
Addresses Part 3 of https://github.com/thoth-station/management-api/issues/887
Related to:
    - https://github.com/thoth-station/management-api/pull/884/files
    - https://github.com/thoth-station/common/pull/1260

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Creating an Argo workflow that invokes an argo workflow template. Additionally openshift resources (job-template) have been moved to the openshift folder to match documentation and better organize the repo.

## Description

The sync job should be implemented as an argo workflow and workflow template so that it can be invoked by the management api with the `_schedule_workflow` function, and be more flexible in how we run it.

