### PR TITLE
Increase `activeDeadlineSeconds` in backup solver workflow

### DIFF
--- a/solver/base/argo-workflows/solver-template.yaml
+++ b/solver/base/argo-workflows/solver-template.yaml
@@ -191,7 +191,7 @@ spec:
               secretKeySecret:
                 name: argo-artifact-repository-secrets
                 key: secretKey
-      activeDeadlineSeconds: 900
+      activeDeadlineSeconds: 1800
       container:
         name: solver
         image: "{{inputs.parameters.THOTH_SOLVER_NAME}}"


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/thoth-application/issues/2569

## Description

Increase the `activeDeadlineSeconds` in the solver workflow used when first workflow fails due to not enough resources allocated.
