### PR TITLE
Updated the kafka to version 3.1.0

### DIFF
--- a/kafka/base/thoth-kafka.yaml
+++ b/kafka/base/thoth-kafka.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kafka:
     replicas: 3
-    version: 3.0.0
+    version: 3.1.0
     logging:
       type: inline
       loggers:
@@ -36,11 +36,9 @@ spec:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
-      log.message.format.version: '3.0'
-      inter.broker.protocol.version: '3.0'
-      ssl.endpoint.identification.algorithm: ""
-      ssl.enabled.protocols: "TLSv1.2"
-      ssl.protocol: "TLSv1.2"
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      inter.broker.protocol.version: '3.1'
     metricsConfig:
       type: jmxPrometheusExporter
       valueFrom:


### PR DESCRIPTION
Updated the kafka to version 3.1.0
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2566

## Description

Update required as the operator was updated to 2.1.0 amq streams
Already updated in cluster and working.