### PR TITLE
add create, and update permissions for secret resources 4 user-api

### DIFF
--- a/user-api/base/role.yaml
+++ b/user-api/base/role.yaml
@@ -8,7 +8,6 @@ rules:
       - ""
     resources:
       - configmaps
-      - secrets
     verbs:
       - get
       - list
@@ -27,6 +26,16 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - list
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
I gave user-api its own rule, removing it from the rule with
configmap permissions. I then duplicated the permissions that were
already present, and added "create" and "update" verbs to the rule.

## Related Issues and Dependencies

closes: https://github.com/thoth-station/thoth-application/issues/2556
