### PR TITLE
Bump prescriptions-refresh-job to v0.7.1 in stage

### DIFF
--- a/prescriptions-refresh-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/prescriptions-refresh-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions-refresh-job:v0.7.0
+        name: quay.io/thoth-station/prescriptions-refresh-job:v0.7.1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Built image is available at https://quay.io/repository/thoth-station/prescriptions-refresh-job?tab=tags&tag=v0.7.1
