### PR TITLE
Bump adviser to v0.56.0 in stage

### DIFF
--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.55.0
+        name: quay.io/thoth-station/adviser:v0.56.0
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
## Description

Built image is available at https://quay.io/repository/thoth-station/adviser?tab=tags&tag=v0.56.0
