### PR TITLE
Suspend scorecards handler and schedule refresh job monthly

### DIFF
--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-scorecards.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-scorecards.yaml
@@ -6,7 +6,7 @@ metadata:
     app: thoth
     component: prescriptions-refresh
 spec:
-  schedule: "@weekly"
+  schedule: "@monthly"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
   suspend: true

--- a/prescriptions-refresh-job/overlays/ocp4-stage/cronworkflow.yaml
+++ b/prescriptions-refresh-job/overlays/ocp4-stage/cronworkflow.yaml
@@ -39,4 +39,4 @@ kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-scorecards
 spec:
-  suspend: false
+  suspend: true


### PR DESCRIPTION
## Description

- Temporarily disable the prescriptions-refresh-job handler responsible for updating scorecards as it consumes too many resources
- Schedule this cronjob to be run monthly instead of weekly