### PR TITLE
fix: Use the cm integration-tests across whole cronjob

### DIFF
--- a/integration-tests/base/configmap.yaml
+++ b/integration-tests/base/configmap.yaml
@@ -7,3 +7,4 @@ data:
   mail-report: "1"
   generate-report: "1"
   tags: ""
+  logging-no-json: "1"

--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
                 - name: THOTH_LOGGING_NO_JSON
                   valueFrom:
                     configMapKeyRef:
-                      name: thoth
+                      name: integration-tests
                       key: logging-no-json
                 - name: THOTH_USER_API_HOST
                   valueFrom:


### PR DESCRIPTION
fix: Use the cm integration-tests across whole cronjob
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/2593
