### PR TITLE
Temporarily suspend prescriptions

### DIFF
--- a/prescriptions-refresh-job/overlays/ocp4-stage/cronworkflow.yaml
+++ b/prescriptions-refresh-job/overlays/ocp4-stage/cronworkflow.yaml
@@ -4,35 +4,35 @@ kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-gh
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-image-analysis
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-pg
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-pypi
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-quay
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow


### PR DESCRIPTION
## Description

Temporarily disable prescriptions because of an important increase in BigQuery API costs for some handlers.
