### PR TITLE
[prow] Add branch cleaner plugin configuration

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -229,6 +229,30 @@ project_manager:
               org: thoth-station
               state: open
 
+branch_cleaner:
+  preserved_branches:
+    AICoE:
+      - main
+      - master
+    aicoe-aiops:
+      - main
+      - master
+    b4mad:
+      - main
+      - master
+    open-services-group:
+      - main
+      - master
+    operate-first:
+      - main
+      - master
+    os-climate:
+      - main
+      - master
+    thoth-station:
+      - main
+      - master
+
 plugins:
   b4mad:
     plugins:


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes thoth-station/prescriptions-refresh-job#172

## Does this require new deployment ?

Just a deployment of the updated prow config.

## Description

<!--- Describe your changes in detail -->

This configures the `branchcleaner` [prow plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/branchcleaner) so that source branches for merged PRs between two branches on the same repository are automatically deleted.

This can help with e.g. Kebechet PRs or prescription-refresh-job runs.