### PR TITLE
Bump management-api to v0.18.5 in stage

### DIFF
--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.18.4
+      name: quay.io/thoth-station/management-api:v0.18.5
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
/hold
Until container image is available
