### PR TITLE
Include the thoth-advise-metadata env to the kebechet-run-result

### DIFF
--- a/adviser/base/argo-workflows/kebechet-run-results.yaml
+++ b/adviser/base/argo-workflows/kebechet-run-results.yaml
@@ -71,6 +71,8 @@ spec:
             value: "{{inputs.parameters.git_service}}"
           - name: KEBECHET_ANALYSIS_ID
             value: "{{inputs.parameters.THOTH_DOCUMENT_ID}}"
+          - name: THOTH_ADVISER_METADATA
+            value: "{{inputs.parameters.THOTH_ADVISER_METADATA}}"
           - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Include the thoth-advise-metadata env to the kebechet-run-result
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/ps-nlp/issues/151#issuecomment-1179137642

