### PR TITLE
:ship: Bump up version of the updated component in release v2022.08.01

### DIFF
--- a/adviser/overlays/aws-prod/imagestreamtag.yaml
+++ b/adviser/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.56.0
+        name: quay.io/thoth-station/adviser:v0.56.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/moc-prod/imagestreamtag.yaml
+++ b/adviser/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.56.0
+        name: quay.io/thoth-station/adviser:v0.56.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.56.0
+        name: quay.io/thoth-station/adviser:v0.56.1
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/aws-prod/common/imagestreamtags.yaml
+++ b/core/overlays/aws-prod/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.10
+        name: quay.io/thoth-station/workflow-helpers:v0.9.11
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/moc-prod/common/imagestreamtags.yaml
+++ b/core/overlays/moc-prod/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.10
+        name: quay.io/thoth-station/workflow-helpers:v0.9.11
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.10
+        name: quay.io/thoth-station/workflow-helpers:v0.9.11
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/rick-test/imagestreamtags.yaml
+++ b/core/overlays/rick-test/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.4
+        name: quay.io/thoth-station/workflow-helpers:v0.9.11
       importPolicy: {}
       referencePolicy:
         type: Source

--- a/integration-tests/overlays/aws-prod-ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/aws-prod-ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.11.2
+        name: quay.io/thoth-station/integration-tests:v0.11.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/integration-tests/overlays/moc-prod-ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/moc-prod-ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.11.2
+        name: quay.io/thoth-station/integration-tests:v0.11.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/integration-tests/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/integration-tests:v0.11.2
+        name: quay.io/thoth-station/integration-tests:v0.11.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/prescriptions-refresh-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/prescriptions-refresh-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions-refresh-job:v0.7.2
+        name: quay.io/thoth-station/prescriptions-refresh-job:v0.7.3
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up version of the updated component in release v2022.08.01
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2598

