### PR TITLE
Fix cache expiration value

### DIFF
--- a/user-api/base/configmap.yaml
+++ b/user-api/base/configmap.yaml
@@ -6,5 +6,5 @@ metadata:
 data:
   api-https: "1"
   validate-responses: "0"
-  cache-expiration: "43200"  # 4 hours
+  cache-expiration: "14400"  # 4 hours
   report-exceptions: "0"


### PR DESCRIPTION
## Related Issues and Dependencies
It had been set to 12 hours in the configmap. 
The default value when this environment variable is not present for user api is 3 hours, but we can leave it as 4 hours here if needed.
