### PR TITLE
:ship: Bump up version of the updated component in release v2022.08.22

### DIFF
--- a/adviser/overlays/aws-prod/imagestreamtag.yaml
+++ b/adviser/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.56.1
+        name: quay.io/thoth-station/adviser:v0.56.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/moc-prod/imagestreamtag.yaml
+++ b/adviser/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.56.1
+        name: quay.io/thoth-station/adviser:v0.56.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/adviser/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/adviser/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/adviser:v0.56.1
+        name: quay.io/thoth-station/adviser:v0.56.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/aws-prod/common/imagestreamtags.yaml
+++ b/core/overlays/aws-prod/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.11
+        name: quay.io/thoth-station/workflow-helpers:v0.9.12
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.16.2
+        name: quay.io/thoth-station/investigator:v0.16.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/moc-prod/common/imagestreamtags.yaml
+++ b/core/overlays/moc-prod/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.11
+        name: quay.io/thoth-station/workflow-helpers:v0.9.12
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.16.2
+        name: quay.io/thoth-station/investigator:v0.16.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.11
+        name: quay.io/thoth-station/workflow-helpers:v0.9.12
       importPolicy: {}
       referencePolicy:
         type: Local
@@ -35,7 +35,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/investigator:v0.16.2
+        name: quay.io/thoth-station/investigator:v0.16.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/cve-update/overlays/aws-prod/imagestreamtag.yaml
+++ b/cve-update/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.5.3
+        name: quay.io/thoth-station/cve-update-job:v0.5.4
       importPolicy: {}

--- a/cve-update/overlays/moc-prod/imagestreamtag.yaml
+++ b/cve-update/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.5.3
+        name: quay.io/thoth-station/cve-update-job:v0.5.4
       importPolicy: {}

--- a/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.5.3
+        name: quay.io/thoth-station/cve-update-job:v0.5.4
       importPolicy: {}

--- a/graph-backup-job/overlays/aws-prod/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.9.2
+        name: quay.io/thoth-station/graph-backup-job:v0.9.3
       importPolicy: {}

--- a/graph-backup-job/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.9.2
+        name: quay.io/thoth-station/graph-backup-job:v0.9.3
       importPolicy: {}

--- a/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-backup-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-backup-job:v0.9.2
+        name: quay.io/thoth-station/graph-backup-job:v0.9.3
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.2
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.3
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.2
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.3
       importPolicy: {}

--- a/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.2
+        name: quay.io/thoth-station/graph-metrics-exporter:v0.6.3
       importPolicy: {}

--- a/graph-refresh/overlays/aws-prod/imagestreamtag.yaml
+++ b/graph-refresh/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.19
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.20
       importPolicy: {}

--- a/graph-refresh/overlays/moc-prod/imagestreamtag.yaml
+++ b/graph-refresh/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.19
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.20
       importPolicy: {}

--- a/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/graph-refresh/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-refresh-job:v0.3.19
+        name: quay.io/thoth-station/graph-refresh-job:v0.3.20
       importPolicy: {}

--- a/graph-sync/overlays/aws-prod/common/imagestreamtag.yaml
+++ b/graph-sync/overlays/aws-prod/common/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.21
+        name: quay.io/thoth-station/graph-sync-job:v0.10.22
       importPolicy: {}

--- a/graph-sync/overlays/moc-prod/common/imagestreamtag.yaml
+++ b/graph-sync/overlays/moc-prod/common/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.21
+        name: quay.io/thoth-station/graph-sync-job:v0.10.22
       importPolicy: {}

--- a/graph-sync/overlays/ocp4-stage/common/imagestreamtag.yaml
+++ b/graph-sync/overlays/ocp4-stage/common/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/graph-sync-job:v0.10.21
+        name: quay.io/thoth-station/graph-sync-job:v0.10.22
       importPolicy: {}

--- a/management-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/management-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.18.5
+      name: quay.io/thoth-station/management-api:v0.18.6
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/management-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.18.5
+      name: quay.io/thoth-station/management-api:v0.18.6
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/management-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/management-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.18.5
+      name: quay.io/thoth-station/management-api:v0.18.6
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.21.1
+        name: quay.io/thoth-station/metrics-exporter:v0.21.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.21.1
+        name: quay.io/thoth-station/metrics-exporter:v0.21.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/metrics-exporter:v0.21.1
+        name: quay.io/thoth-station/metrics-exporter:v0.21.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-releases/overlays/aws-prod/imagestreamtag.yaml
+++ b/package-releases/overlays/aws-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.9
+        name: quay.io/thoth-station/package-releases-job:v0.11.10
       importPolicy: {}

--- a/package-releases/overlays/moc-prod/imagestreamtag.yaml
+++ b/package-releases/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.9
+        name: quay.io/thoth-station/package-releases-job:v0.11.10
       importPolicy: {}

--- a/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-releases/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-releases-job:v0.11.9
+        name: quay.io/thoth-station/package-releases-job:v0.11.10
       importPolicy: {}

--- a/package-update/overlays/aws-prod/imagestreamtag.yaml
+++ b/package-update/overlays/aws-prod/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.16
+        name: quay.io/thoth-station/package-update-job:v0.8.17
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-update/overlays/moc-prod/imagestreamtag.yaml
+++ b/package-update/overlays/moc-prod/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.16
+        name: quay.io/thoth-station/package-update-job:v0.8.17
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/package-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/package-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -10,7 +10,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/package-update-job:v0.8.16
+        name: quay.io/thoth-station/package-update-job:v0.8.17
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/revsolver/overlays/aws-prod/imagestreamtag.yaml
+++ b/revsolver/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/revsolver:v0.2.12"
+        name: "quay.io/thoth-station/revsolver:v0.2.13"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/revsolver/overlays/moc-prod/imagestreamtag.yaml
+++ b/revsolver/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/revsolver:v0.2.12"
+        name: "quay.io/thoth-station/revsolver:v0.2.13"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/revsolver/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/revsolver/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: "quay.io/thoth-station/revsolver:v0.2.12"
+        name: "quay.io/thoth-station/revsolver:v0.2.13"
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/slo-reporter/overlays/aws-prod-ocp4-stage/imagestreamtag.yaml
+++ b/slo-reporter/overlays/aws-prod-ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.19.2
+        name: quay.io/thoth-station/slo-reporter:v0.19.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/slo-reporter/overlays/moc-prod-ocp4-stage/imagestreamtag.yaml
+++ b/slo-reporter/overlays/moc-prod-ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.19.2
+        name: quay.io/thoth-station/slo-reporter:v0.19.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/slo-reporter/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/slo-reporter/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/slo-reporter:v0.19.2
+        name: quay.io/thoth-station/slo-reporter:v0.19.3
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/user-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.35.3
+        name: quay.io/thoth-station/user-api:v0.35.5
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.35.3
+        name: quay.io/thoth-station/user-api:v0.35.5
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.35.3
+        name: quay.io/thoth-station/user-api:v0.35.5
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up version of the updated component in release v2022.08.22
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2616
