### PR TITLE
Add a rule to triage-party to highlight issues without a SIG

### DIFF
--- a/triage-party/overlays/moc/config.yaml
+++ b/triage-party/overlays/moc/config.yaml
@@ -102,6 +102,7 @@ collections:
     rules:
       # Issues pending triage
       - issue-needs-triage
+      - issue-needs-sig
       # SLO
       - issue-near-soon-overdue
       - issue-near-longterm-overdue
@@ -293,6 +294,13 @@ rules:
       - label: "!priority/.*"
       - label: "!lifecycle/frozen"
       - label: "!help needed"
+
+  issue-needs-sig:
+    name: "Issues without SIG"
+    resolution: "Assign a sig/* label"
+    type: issue
+    filters:
+      - label: "!sig/.*"
 
   # SLO nearing
   issue-near-soon-overdue:

--- a/triage-party/overlays/moc/config.yaml
+++ b/triage-party/overlays/moc/config.yaml
@@ -5,8 +5,10 @@ settings:
   repos:
     - https://github.com/AICoE/elyra-aidevsecops-tutorial
     - https://github.com/AICoE/manage-dependencies-tutorial
+    - https://github.com/AICoE/meteor-operator
     - https://github.com/AICoE/overlays-for-ai-pipeline-tutorial
     - https://github.com/AICoE/recommend-base-image-tutorial
+    - https://github.com/open-services-group/byon
     - https://github.com/thoth-station/adviser
     - https://github.com/thoth-station/amun-api
     - https://github.com/thoth-station/amun-client
@@ -29,6 +31,7 @@ settings:
     - https://github.com/thoth-station/mi
     - https://github.com/thoth-station/micropipenv
     - https://github.com/thoth-station/mi-scheduler
+    - https://github.com/thoth-station/opendatahub-cnbi
     - https://github.com/thoth-station/package-extract
     - https://github.com/thoth-station/package-releases-job
     - https://github.com/thoth-station/package-update-job


### PR DESCRIPTION
This is to add a rule in the weekly triage view of triage-party to show any issues that do not yet have a SIG label.