### PR TITLE
:fire: switch insecure false for the agro-worflows

### DIFF
--- a/adviser/base/argo-workflows/advise.yaml
+++ b/adviser/base/argo-workflows/advise.yaml
@@ -80,7 +80,6 @@ spec:
                 adviser/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -99,7 +98,6 @@ spec:
                 adviser/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/adviser/base/argo-workflows/dependency-monkey.yaml
+++ b/adviser/base/argo-workflows/dependency-monkey.yaml
@@ -45,7 +45,6 @@ spec:
               dependency-monkey-requests/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -64,7 +63,6 @@ spec:
               dependency-monkey-reports/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/adviser/base/argo-workflows/provenance-check.yaml
+++ b/adviser/base/argo-workflows/provenance-check.yaml
@@ -34,7 +34,6 @@ spec:
               provenance-checker/{{inputs.parameters.THOTH_DOCUMENT_ID}}.request"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -53,7 +52,6 @@ spec:
               provenance-checker/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/buildlog-parser/base/argo-workflows/buildlog-parser.yaml
+++ b/buildlog-parser/base/argo-workflows/buildlog-parser.yaml
@@ -59,7 +59,6 @@ spec:
                 buildlogs/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -79,7 +78,6 @@ spec:
                 buildlogs-parsed/{{inputs.parameters.THOTH_OUTPUT_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/core/overlays/aws-prod/backend-prod/configmaps.yaml
+++ b/core/overlays/aws-prod/backend-prod/configmaps.yaml
@@ -40,7 +40,7 @@ data:
         bucket: "thoth-store"
         keyPrefix: "data/aws-prod/argo/artifacts/"
         endpoint: "s3.amazonaws.com"
-        insecure: true
+        insecure: false
         accessKeySecret:
           name: argo-artifact-repository-secrets
           key: accessKey

--- a/core/overlays/aws-prod/middletier-prod/configmaps.yaml
+++ b/core/overlays/aws-prod/middletier-prod/configmaps.yaml
@@ -40,7 +40,7 @@ data:
         bucket: "thoth-store"
         keyPrefix: "data/aws-prod/argo/artifacts/"
         endpoint: "s3.amazonaws.com"
-        insecure: true
+        insecure: false
         accessKeySecret:
           name: argo-artifact-repository-secrets
           key: accessKey

--- a/core/overlays/ocp4-stage/backend-stage/configmaps.yaml
+++ b/core/overlays/ocp4-stage/backend-stage/configmaps.yaml
@@ -40,7 +40,7 @@ data:
         bucket: "thoth"
         keyPrefix: "data/ocp4-stage/argo/artifacts/"
         endpoint: "s3.upshift.redhat.com"
-        insecure: true
+        insecure: false
         accessKeySecret:
           name: argo-artifact-repository-secrets
           key: accessKey

--- a/core/overlays/ocp4-stage/middletier-stage/configmaps.yaml
+++ b/core/overlays/ocp4-stage/middletier-stage/configmaps.yaml
@@ -30,7 +30,7 @@ data:
         bucket: "thoth"
         keyPrefix: "data/ocp4-stage/argo/artifacts/"
         endpoint: "s3.upshift.redhat.com"
-        insecure: true
+        insecure: false
         accessKeySecret:
           name: argo-artifact-repository-secrets
           key: accessKey

--- a/core/overlays/test/configmaps.yaml
+++ b/core/overlays/test/configmaps.yaml
@@ -77,7 +77,7 @@ data:
         bucket: "thoth"
         keyPrefix: "data/ocp4-test/argo/artifacts/"
         endpoint: "s3.upshift.redhat.com"
-        insecure: true
+        insecure: false
         accessKeySecret:
           name: argo-artifact-repository-secrets
           key: accessKey

--- a/package-extract/base/argo-workflows/package-extract.yaml
+++ b/package-extract/base/argo-workflows/package-extract.yaml
@@ -64,7 +64,6 @@ spec:
                 analysis/{{inputs.parameters.THOTH_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/revsolver/base/argo-workflows/revsolver-template.yaml
+++ b/revsolver/base/argo-workflows/revsolver-template.yaml
@@ -31,7 +31,6 @@ spec:
                 revsolver/{{inputs.parameters.THOTH_REVSOLVER_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/security-indicators/base/argo-workflows/aggregator-template.yaml
+++ b/security-indicators/base/argo-workflows/aggregator-template.yaml
@@ -62,7 +62,6 @@ spec:
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               key: >-
                 {{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/{{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/security-indicators/{{inputs.parameters.THOTH_DOCUMENT_ID}}/bandit
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -79,7 +78,6 @@ spec:
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               key: >-
                 {{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/{{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/security-indicators/{{inputs.parameters.THOTH_DOCUMENT_ID}}/cloc
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -96,7 +94,6 @@ spec:
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               key: >-
                 {{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/{{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/security-indicators/{{inputs.parameters.THOTH_DOCUMENT_ID}}/aggregated
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/security-indicators/base/argo-workflows/bandit-template.yaml
+++ b/security-indicators/base/argo-workflows/bandit-template.yaml
@@ -56,7 +56,6 @@ spec:
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               key: >-
                 {{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/{{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/si-bandit/{{inputs.parameters.THOTH_DOCUMENT_ID}}
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/security-indicators/base/argo-workflows/cloc-template.yaml
+++ b/security-indicators/base/argo-workflows/cloc-template.yaml
@@ -57,7 +57,6 @@ spec:
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               key: >-
                 {{inputs.parameters.THOTH_CEPH_BUCKET_PREFIX}}/{{inputs.parameters.THOTH_DEPLOYMENT_NAME}}/si-cloc/{{inputs.parameters.THOTH_DOCUMENT_ID}}
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/solver/base/argo-workflows/solver-template.yaml
+++ b/solver/base/argo-workflows/solver-template.yaml
@@ -64,7 +64,6 @@ spec:
                 solver/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -184,7 +183,6 @@ spec:
                 solver/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey

--- a/solver/overlays/test/argo-workflows/solver-template.yaml
+++ b/solver/overlays/test/argo-workflows/solver-template.yaml
@@ -66,7 +66,6 @@ spec:
                 solver/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey
@@ -180,7 +179,6 @@ spec:
                 solver/{{inputs.parameters.THOTH_SOLVER_DOCUMENT_ID}}"
               endpoint: "{{inputs.parameters.THOTH_S3_ENDPOINT_URL}}"
               bucket: "{{inputs.parameters.THOTH_CEPH_BUCKET_NAME}}"
-              insecure: true
               accessKeySecret:
                 name: argo-artifact-repository-secrets
                 key: accessKey


### PR DESCRIPTION
switch insecure false for the agro-worflows

- Removed insecure flag from worklfows

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #2642 

## Description

- The argo-workflow artifact overrides the workflow-controller configuration. 
so we have removed the insecure bit from workflow and are going to rely on the workflow controller configuration.