### PR TITLE
:recycle: Switch v1 rbac from v1beta1 as its deprecated

### DIFF
--- a/amun/overlays/aws-prod/amun-api/role_binding.yaml
+++ b/amun/overlays/aws-prod/amun-api/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api
@@ -13,7 +13,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-workflow
@@ -27,7 +27,7 @@ subjects:
     name: amun-api-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-prepare-workflow
@@ -41,7 +41,7 @@ subjects:
     name: amun-prepare-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo-admin

--- a/amun/overlays/moc-prod/amun-api/role_binding.yaml
+++ b/amun/overlays/moc-prod/amun-api/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api
@@ -13,7 +13,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-workflow
@@ -27,7 +27,7 @@ subjects:
     name: amun-api-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-prepare-workflow
@@ -41,7 +41,7 @@ subjects:
     name: amun-prepare-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo-admin

--- a/amun/overlays/ocp4-stage/amun-api/role_binding.yaml
+++ b/amun/overlays/ocp4-stage/amun-api/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api
@@ -13,7 +13,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-workflow
@@ -27,7 +27,7 @@ subjects:
     name: amun-api-workflow
     namespace: thoth-amun-inspection-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-prepare-workflow
@@ -41,7 +41,7 @@ subjects:
     name: amun-prepare-workflow
     namespace: thoth-amun-inspection-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo-admin

--- a/amun/overlays/power9/amun-api/role_binding.yaml
+++ b/amun/overlays/power9/amun-api/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api
@@ -13,7 +13,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-workflow
@@ -27,7 +27,7 @@ subjects:
     name: amun-api-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-prepare-workflow
@@ -41,7 +41,7 @@ subjects:
     name: amun-prepare-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo-admin

--- a/amun/overlays/prod/amun-api/role_binding.yaml
+++ b/amun/overlays/prod/amun-api/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api
@@ -13,7 +13,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-workflow
@@ -27,7 +27,7 @@ subjects:
     name: amun-api-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-prepare-workflow
@@ -41,7 +41,7 @@ subjects:
     name: amun-prepare-workflow
     namespace: thoth-amun-inspection-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: amun-api
     namespace: thoth-amun-api-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo-admin

--- a/amun/overlays/test/role_binding.yaml
+++ b/amun/overlays/test/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: amun-api
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-workflow
@@ -23,7 +23,7 @@ subjects:
   - kind: ServiceAccount
     name: amun-api-workflow
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-prepare-workflow
@@ -35,7 +35,7 @@ subjects:
   - kind: ServiceAccount
     name: amun-prepare-workflow
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo
@@ -47,7 +47,7 @@ subjects:
   - kind: ServiceAccount
     name: amun-api
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: amun-api-argo-admin

--- a/build-watcher/overlays/amun-api/role-binding.yaml
+++ b/build-watcher/overlays/amun-api/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: build-watcher

--- a/graph-refresh/overlays/aws-prod/rolebindings.yaml
+++ b/graph-refresh/overlays/aws-prod/rolebindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-infra
@@ -13,7 +13,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-middletier
@@ -27,7 +27,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo
@@ -41,7 +41,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo-admin

--- a/graph-refresh/overlays/moc-prod/rolebindings.yaml
+++ b/graph-refresh/overlays/moc-prod/rolebindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-infra
@@ -13,7 +13,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-middletier
@@ -27,7 +27,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo
@@ -41,7 +41,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo-admin

--- a/graph-refresh/overlays/ocp4-stage/rolebindings.yaml
+++ b/graph-refresh/overlays/ocp4-stage/rolebindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-infra
@@ -13,7 +13,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-middletier
@@ -27,7 +27,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo
@@ -41,7 +41,7 @@ subjects:
     name: graph-refresh-job
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo-admin

--- a/graph-refresh/overlays/test/rolebindings.yaml
+++ b/graph-refresh/overlays/test/rolebindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-template
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: graph-refresh-job
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-config
@@ -23,7 +23,7 @@ subjects:
   - kind: ServiceAccount
     name: graph-refresh-job
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo
@@ -35,7 +35,7 @@ subjects:
   - kind: ServiceAccount
     name: graph-refresh-job
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: graph-refresh-job-argo-admin

--- a/init-job/base/role.yaml
+++ b/init-job/base/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: init-job

--- a/init-job/base/role_binding.yaml
+++ b/init-job/base/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: init-job
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: init-job
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: init-job-argo
@@ -23,7 +23,7 @@ subjects:
   - kind: ServiceAccount
     name: init-job
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: init-job-argo-admin

--- a/investigator/overlays/aws-prod/role_binding.yaml
+++ b/investigator/overlays/aws-prod/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -12,7 +12,7 @@ subjects:
   - kind: ServiceAccount
     name: investigator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -26,7 +26,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo
@@ -40,7 +40,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo-admin
@@ -54,7 +54,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -68,7 +68,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo
@@ -82,7 +82,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo-admin

--- a/investigator/overlays/moc-prod/role_binding.yaml
+++ b/investigator/overlays/moc-prod/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -12,7 +12,7 @@ subjects:
   - kind: ServiceAccount
     name: investigator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -26,7 +26,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo
@@ -40,7 +40,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo-admin
@@ -54,7 +54,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -68,7 +68,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo
@@ -82,7 +82,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo-admin

--- a/investigator/overlays/ocp4-stage/role_binding.yaml
+++ b/investigator/overlays/ocp4-stage/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -12,7 +12,7 @@ subjects:
   - kind: ServiceAccount
     name: investigator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -26,7 +26,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo
@@ -40,7 +40,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo-admin
@@ -54,7 +54,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -68,7 +68,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo
@@ -82,7 +82,7 @@ subjects:
     name: investigator
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo-admin

--- a/investigator/overlays/test/role_binding.yaml
+++ b/investigator/overlays/test/role_binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: investigator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo
@@ -23,7 +23,7 @@ subjects:
   - kind: ServiceAccount
     name: investigator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: investigator-argo-admin

--- a/management-api/overlays/aws-prod/role-binding.yaml
+++ b/management-api/overlays/aws-prod/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api
@@ -13,7 +13,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-pods-info
@@ -27,7 +27,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin
@@ -41,7 +41,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api
@@ -55,7 +55,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo
@@ -69,7 +69,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin
@@ -83,7 +83,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-pods-info
@@ -97,7 +97,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo
@@ -111,7 +111,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin

--- a/management-api/overlays/moc-prod/role-binding.yaml
+++ b/management-api/overlays/moc-prod/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api
@@ -13,7 +13,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-pods-info
@@ -27,7 +27,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin
@@ -41,7 +41,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api
@@ -55,7 +55,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo
@@ -69,7 +69,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin
@@ -83,7 +83,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-pods-info
@@ -97,7 +97,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo
@@ -111,7 +111,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin

--- a/management-api/overlays/ocp4-stage/role-binding.yaml
+++ b/management-api/overlays/ocp4-stage/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api
@@ -13,7 +13,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api
@@ -27,7 +27,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-pods-info
@@ -41,7 +41,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin
@@ -69,7 +69,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin
@@ -83,7 +83,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-pods-info
@@ -97,7 +97,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo
@@ -111,7 +111,7 @@ subjects:
     name: management-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin

--- a/management-api/overlays/test/role-binding.yaml
+++ b/management-api/overlays/test/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: management-api
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo
@@ -23,7 +23,7 @@ subjects:
   - kind: ServiceAccount
     name: management-api
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: management-api-argo-admin

--- a/metrics-exporter/base/rolebinding.yaml
+++ b/metrics-exporter/base/rolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter

--- a/metrics-exporter/overlays/aws-prod/role_bindings.yaml
+++ b/metrics-exporter/overlays/aws-prod/role_bindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -13,7 +13,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -27,7 +27,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -41,7 +41,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -55,7 +55,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -69,7 +69,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra

--- a/metrics-exporter/overlays/moc-prod/role_bindings.yaml
+++ b/metrics-exporter/overlays/moc-prod/role_bindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -13,7 +13,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -27,7 +27,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -41,7 +41,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -55,7 +55,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -69,7 +69,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra

--- a/metrics-exporter/overlays/ocp4-stage/role_bindings.yaml
+++ b/metrics-exporter/overlays/ocp4-stage/role_bindings.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -13,7 +13,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -27,7 +27,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -41,7 +41,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -55,7 +55,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra
@@ -69,7 +69,7 @@ subjects:
     name: metrics-exporter
     namespace: thoth-infra-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metrics-exporter-from-infra

--- a/mi-scheduler/overlays/moc-prod/role-binding.yaml
+++ b/mi-scheduler/overlays/moc-prod/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mi-scheduler
@@ -13,7 +13,7 @@ subjects:
     name: mi-scheduler
     namespace: thoth-middletier-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mi-scheduler-argo-admin

--- a/mi-scheduler/overlays/ocp4-stage/role-binding.yaml
+++ b/mi-scheduler/overlays/ocp4-stage/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mi-scheduler
@@ -13,7 +13,7 @@ subjects:
     name: mi-scheduler
     namespace: thoth-middletier-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mi-scheduler-argo-admin

--- a/mi-scheduler/overlays/test/role-binding.yaml
+++ b/mi-scheduler/overlays/test/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mi-scheduler
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: mi-scheduler
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: mi-scheduler-argo-admin

--- a/revsolver/overlays/aws-prod/rolebinding.yaml
+++ b/revsolver/overlays/aws-prod/rolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver
@@ -13,7 +13,7 @@ subjects:
     name: revsolver
     namespace: thoth-middletier-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo
@@ -27,7 +27,7 @@ subjects:
     name: revsolver
     namespace: thoth-middletier-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo-admin

--- a/revsolver/overlays/moc-prod/rolebinding.yaml
+++ b/revsolver/overlays/moc-prod/rolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver
@@ -13,7 +13,7 @@ subjects:
     name: revsolver
     namespace: thoth-middletier-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo
@@ -27,7 +27,7 @@ subjects:
     name: revsolver
     namespace: thoth-middletier-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo-admin

--- a/revsolver/overlays/ocp4-stage/rolebinding.yaml
+++ b/revsolver/overlays/ocp4-stage/rolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver
@@ -13,7 +13,7 @@ subjects:
     name: revsolver
     namespace: thoth-middletier-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo
@@ -27,7 +27,7 @@ subjects:
     name: revsolver
     namespace: thoth-middletier-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo-admin

--- a/revsolver/overlays/test/rolebinding.yaml
+++ b/revsolver/overlays/test/rolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: revsolver
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo
@@ -23,7 +23,7 @@ subjects:
   - kind: ServiceAccount
     name: revsolver
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: revsolver-argo-admin

--- a/user-api/overlays/aws-prod/role-binding.yaml
+++ b/user-api/overlays/aws-prod/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api
@@ -13,7 +13,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-pods-info
@@ -27,7 +27,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-pods-info
@@ -41,7 +41,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo
@@ -69,7 +69,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo-admin
@@ -83,7 +83,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo-admin

--- a/user-api/overlays/moc-prod/role-binding.yaml
+++ b/user-api/overlays/moc-prod/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api
@@ -13,7 +13,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-pods-info
@@ -27,7 +27,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-pods-info
@@ -41,7 +41,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo
@@ -69,7 +69,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo-admin
@@ -83,7 +83,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-prod
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo-admin

--- a/user-api/overlays/ocp4-stage/role-binding.yaml
+++ b/user-api/overlays/ocp4-stage/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api
@@ -13,7 +13,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-pods-info
@@ -27,7 +27,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-pods-info
@@ -41,7 +41,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo
@@ -55,7 +55,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo
@@ -69,7 +69,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo-admin
@@ -83,7 +83,7 @@ subjects:
     name: user-api
     namespace: thoth-frontend-stage
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo-admin

--- a/user-api/overlays/test/role-binding.yaml
+++ b/user-api/overlays/test/role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api
@@ -11,7 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: user-api
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-pods-info
@@ -23,7 +23,7 @@ subjects:
   - kind: ServiceAccount
     name: user-api
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo
@@ -35,7 +35,7 @@ subjects:
   - kind: ServiceAccount
     name: user-api
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-api-argo-admin


### PR DESCRIPTION
Switch v1 rbac from v1beta1 as its deprecated
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122