### PR TITLE
:ship: Bump up version of the updated component in release v2022.09.12

### DIFF
--- a/kebechet/overlays/aws-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/aws-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.10.3
+        name: quay.io/thoth-station/kebechet-job:v1.10.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/kebechet/overlays/moc-prod/imagestreamtag.yaml
+++ b/kebechet/overlays/moc-prod/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.10.3
+        name: quay.io/thoth-station/kebechet-job:v1.10.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/kebechet/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/kebechet-job:v1.10.3
+        name: quay.io/thoth-station/kebechet-job:v1.10.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/prescriptions-refresh-job/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/prescriptions-refresh-job/overlays/ocp4-stage/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/prescriptions-refresh-job:v0.7.3
+        name: quay.io/thoth-station/prescriptions-refresh-job:v0.7.4
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/aws-prod/imagestreamtag.yaml
+++ b/user-api/overlays/aws-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.35.5
+        name: quay.io/thoth-station/user-api:v0.35.6
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/user-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.35.5
+        name: quay.io/thoth-station/user-api:v0.35.6
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/user-api/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/user-api/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/user-api:v0.35.5
+        name: quay.io/thoth-station/user-api:v0.35.6
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Bump up version of the updated component in release v2022.09.12
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2628

