### PR TITLE
Update mi to 2.12.0 and mi-scheduler to 1.7.7

### DIFF
--- a/mi-scheduler/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/mi:v2.10.6
+      name: quay.io/thoth-station/mi:v2.12.0
     importPolicy: {}
     referencePolicy:
       type: Local
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/mi-scheduler:v1.7.3
+      name: quay.io/thoth-station/mi-scheduler:v1.7.7
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/mi-scheduler/issues/249

## Does this require new deployment ?

- [x] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description

<!--- Describe your changes in detail -->
