### PR TITLE
Update mi-scheduler to 1.7.8

### DIFF
--- a/mi-scheduler/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/ocp4-stage/imagestreamtag.yaml
@@ -21,7 +21,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/mi-scheduler:v1.7.7
+      name: quay.io/thoth-station/mi-scheduler:v1.7.8
     importPolicy: {}
     referencePolicy:
       type: Local

--- a/mi-scheduler/overlays/test/imagestreamtag.yaml
+++ b/mi-scheduler/overlays/test/imagestreamtag.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/mi-scheduler:v1.7.7
+        name: quay.io/thoth-station/mi-scheduler:v1.7.8
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
## Related Issues and Dependencies
Related to https://github.com/thoth-station/mi-scheduler/issues/249

## Does this require new deployment ?

- [X] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description
SSIA
