### PR TITLE
Revert to weekly scorecard prescriptions

### DIFF
--- a/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-scorecards.yaml
+++ b/prescriptions-refresh-job/base/argo-workflows/prescriptions-refresh-scorecards.yaml
@@ -6,7 +6,7 @@ metadata:
     app: thoth
     component: prescriptions-refresh
 spec:
-  schedule: "@monthly"
+  schedule: "@weekly"
   concurrencyPolicy: "Forbid"
   startingDeadlineSeconds: 0
   suspend: true


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/core/issues/440

## Description

Revert to a weekly computation of Scorecard prescriptions to aggregate info on each project revision. However, this implies an increase in cost for BigQuery we might want to consider, so we could also adapt the cron schedule to be run bi-weekly or keep it monthly.

cc @goern 
