### PR TITLE
Upgrade sefkhet-abwy image version to v0.23.2

### DIFF
--- a/sefkhet-abwy-chatbot/overlays/moc/imagestreamtag.yaml
+++ b/sefkhet-abwy-chatbot/overlays/moc/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.23.1
+        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.23.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/sefkhet-abwy/overlays/moc/imagestreamtag.yaml
+++ b/sefkhet-abwy/overlays/moc/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.23.1
+        name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.23.2
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/sefkhet-abwy/overlays/ocp/imagestreamtag.yaml
+++ b/sefkhet-abwy/overlays/ocp/imagestreamtag.yaml
@@ -6,7 +6,7 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.23.1
+      name: quay.io/thoth-station/sefkhet-abwy-webhook-receiver:v0.23.2
     importPolicy: {}
     name: latest
     referencePolicy:


### PR DESCRIPTION
Upgrade sefkhet-abwy image version to [v0.23.2](https://github.com/AICoE/sefkhet-abwy/pull/211).