### PR TITLE
make callback secret optional

### DIFF
--- a/adviser/base/openshift-templates/adviser.yaml
+++ b/adviser/base/openshift-templates/adviser.yaml
@@ -203,6 +203,7 @@ objects:
         - name: callback-secret
           secret:
             secretName: "callback-{{workflow.parameters.THOTH_DOCUMENT_ID}}"
+            optional: true
 
       templates:
         - name: "adviser"

--- a/core/base/argo-management.yaml
+++ b/core/base/argo-management.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: workflow-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - watch

--- a/core/base/kustomization.yaml
+++ b/core/base/kustomization.yaml
@@ -5,6 +5,7 @@ commonLabels:
   app.kubernetes.io/component: core
   app.kubernetes.io/managed-by: aicoe-thoth-devops
 resources:
+  - argo-management.yaml
   - configmaps.yaml
   - imagestreams.yaml
   - argo-workflows/send-message.yaml

--- a/core/base/send-webhooks-sa.yaml
+++ b/core/base/send-webhooks-sa.yaml
@@ -27,3 +27,15 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: send-webhooks
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: send-webhooks-argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflow-role
+subjects:
+  - kind: ServiceAccount
+    name: send-webhooks

--- a/core/overlays/ocp4-stage/backend-stage/argo-management.yaml
+++ b/core/overlays/ocp4-stage/backend-stage/argo-management.yaml
@@ -9,36 +9,6 @@ metadata:
   name: argo-server
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: workflow-role
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - watch
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods/log
-  verbs:
-  - get
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argo-binding-to-workflow-role

--- a/core/overlays/test/argo-management.yaml
+++ b/core/overlays/test/argo-management.yaml
@@ -14,36 +14,6 @@ metadata:
   name: workflow-controller-configmap
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: workflow-role
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - watch
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods/log
-  verbs:
-  - get
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: argo-binding-to-workflow-role


### PR DESCRIPTION
if no requests have been made with callback secret combine, then no secret will exist, by making the secret optional the volume that is mounted will be empty and still allow the step to run

Signed-off-by: Kevin <kpostlet@redhat.com>

## Related Issues and Dependencies

fixes: #2677 

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.
