### PR TITLE
:chart_with_downwards_trend: Persist the grafana dashboard for stage cluster

### DIFF
--- a/grafana-dashboard/ocp4-stage/thoth-kafka-argo-metrics.json
+++ b/grafana-dashboard/ocp4-stage/thoth-kafka-argo-metrics.json
@@ -1,0 +1,1559 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 198,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 331,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 8,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_package_release_job_messages_sent_total{env=~\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{env}} | {{message_type}} message sent from package releases producer ({{version}})",
+                "refId": "B",
+                "step": 600
+              },
+              {
+                "expr": "thoth_graph_refresh_job_messages_sent_total{env=~\"$env\"}",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{env}} | {{message_type}} message sent from graph refresh producer ({{version}})",
+                "refId": "A",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kafka Messages sent by producers",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Producers",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 335,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 1,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_investigator_processed_total{instance=\"$instance_consumer\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{message_type}} message Processed",
+                "refId": "B",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kafka Messages processed by consumer",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 3,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_investigator_in_progress{instance=\"$instance_consumer\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{message_type}} message In progress ",
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kafka Messages In Progress in consumer",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 4,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_investigator_exceptions_total{instance=\"$instance_consumer\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{message_type}} message Exceptions",
+                "refId": "C",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kafka Messages Exceptions in consumer",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Consumer",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 383,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 9,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_investigator_paused_topics{instance=\"$instance_consumer\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "MESSAGE {{base_topic_name}} ",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kafka Message consumption paused status",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 10,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "message_count_by_version_total{instance=\"$instance_consumer_metrics\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "MESSAGE {{message_type}} ",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kafka message encountered per version",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 292,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 2,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_investigator_scheduled_workflows_total{instance=\"$instance_consumer\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "MESSAGE {{message_type}} SCHEDULED {{workflow_type}} WORKFLOW",
+                "refId": "A",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Workflows scheduled by consumer",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 394,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "A count of all workflows currently accessible by the controller by status",
+            "fill": 1,
+            "id": 6,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_count{instance='$instance_workflow_controller'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{status}}",
+                "refId": "A",
+                "step": 1200
+              },
+              {
+                "expr": "sum(argo_workflows_count{instance='$instance_workflow_controller'})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Total workflows",
+                "refId": "B",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Workflow status count",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "Percentage of workflows that has queue latency below a certain threshold",
+            "fill": 1,
+            "id": 7,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_queue_latency_bucket{instance='$instance_workflow_controller', queue_name=\"$queue_name\"} / ignoring(le) group_left argo_workflows_queue_latency_count{instance='$instance_workflow_controller', queue_name=\"$queue_name\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "queue_latency: {{le}} | queue_name: {{$queue_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Workflow queue latency [%]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 342,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 11,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_status_counter{status=\"Error\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{name}} : {{status}}",
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Argo workflows Error",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 12,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_status_counter{status=\"Succeeded\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{name}} : {{status}}",
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Argo workflows Succeeded",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 13,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": null,
+              "sortDesc": null,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_status_counter{status=\"Failed\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{name}} : {{status}}",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "increase(argo_workflows_status_counter{status=\"Failed\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "increase {{name}} : {{status}}",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "rate(argo_workflows_status_counter{status=\"Failed\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "rate {{name}} : {{status}}",
+                "refId": "C",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Argo workflows Failed",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 14,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_task_status_counter{status=\"Error\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{name}} : {{status}}",
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Argo workflows Task Error",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 15,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_task_status_counter{status=\"Succeeded\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{name}} : {{status}}",
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Argo workflows Task Succeeded",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 16,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_task_status_counter{status=\"Failed\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{name}} : {{status}}",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "increase(argo_workflows_task_status_counter{status=\"Failed\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Increase {{name}} : {{status}}",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "rate(argo_workflows_task_status_counter{status=\"Failed\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "rate {{name}} : {{status}}",
+                "refId": "C",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Argo workflows Task Failed",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "thoth",
+      "argo",
+      "kafka"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "investigator-faust-web-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "investigator-faust-web-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance_consumer",
+          "options": [
+            {
+              "selected": true,
+              "text": "investigator-faust-web-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "investigator-faust-web-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "investigator-faust-web-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance_workflow_controller",
+          "options": [
+            {
+              "selected": true,
+              "text": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": false,
+              "text": "workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80, workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "workflow_queue",
+            "value": "workflow_queue"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "queue_name",
+          "options": [
+            {
+              "selected": false,
+              "text": "cron_wf_queue",
+              "value": "cron_wf_queue"
+            },
+            {
+              "selected": false,
+              "text": "pod_queue",
+              "value": "pod_queue"
+            },
+            {
+              "selected": false,
+              "text": "wf_cron_queue",
+              "value": "wf_cron_queue"
+            },
+            {
+              "selected": true,
+              "text": "workflow_queue",
+              "value": "workflow_queue"
+            }
+          ],
+          "query": "cron_wf_queue,pod_queue,wf_cron_queue,workflow_queue",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "ocp4-stage",
+            "value": "ocp4-stage"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "env",
+          "options": [
+            {
+              "selected": false,
+              "text": "ocp4-test",
+              "value": "ocp4-test"
+            },
+            {
+              "selected": true,
+              "text": "ocp4-stage",
+              "value": "ocp4-stage"
+            }
+          ],
+          "query": "ocp4-test, ocp4-stage",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "1h",
+            "value": "1h"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "interval",
+          "options": [
+            {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": true,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "3h",
+              "value": "3h"
+            },
+            {
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            }
+          ],
+          "query": "1m, 10m, 30m, 1h, 3h, 6h, 12h, 1d, 7d",
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Thoth Kafka Consumers and Argo Workflows",
+    "version": 1
+  }

--- a/grafana-dashboard/ocp4-stage/thoth-knowledge-graph-content-metrics.json
+++ b/grafana-dashboard/ocp4-stage/thoth-knowledge-graph-content-metrics.json
@@ -1,0 +1,4531 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": 15,
+  "links": [],
+  "refresh": "30s",
+  "rows": [
+    {
+      "collapse": false,
+      "height": 88,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 81,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_adviser_count_per_source_type{thoth_integration=\"CLI\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Integration: CLI",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 88,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_adviser_count_per_source_type{thoth_integration=\"JUPYTER_NOTEBOOK\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Integration: JUPYTER TOOLS",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 89,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_adviser_count_per_source_type{thoth_integration=\"KEBECHET\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Integration: KEBECHET",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 90,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_adviser_count_per_source_type{thoth_integration=\"S2I\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Integration: S2I",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": -16,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 102,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_users_count_per_source_type{thoth_integration=\"CLI\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "CLI users",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 104,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_users_count_per_source_type{thoth_integration=\"JUPYTER_NOTEBOOK\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "JUPYTER TOOLS users",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 105,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_users_count_per_source_type{thoth_integration=\"KEBECHET\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "KEBECHET users",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 106,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_users_count_per_source_type{thoth_integration=\"S2I\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "S2I users",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 94,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#511749",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 95,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 12,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_kebechet_total_active_repo_count{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "GitHub repos with Kebechet active",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "max"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 92,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#0a50a1",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 73,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_pypi_stats{stats_type=\"packages\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "PyPI Python Packages",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#0a50a1",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 74,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_pypi_stats{stats_type=\"releases\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "PyPI Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": -884,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 49,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(thoth_graphdb_total_python_packages_per_indexes{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Python Packages",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 48,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 112,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_python_packages_per_indexes{instance=\"$instance\", job=\"Thoth Metrics\", index_url=\"https://pypi.org/simple\"} / ignoring(index_url, stats_type) group_right thoth_pypi_stats{stats_type=\"packages\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Python Packages respect to PyPI",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 113,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"} / ignoring(stats_type) group_right thoth_pypi_stats{stats_type=\"releases\", instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth Python Packages Releases respect to PyPI",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Python Packages Information Schema",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": -70,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 63,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 12,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_python_indexes{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Thoth registered indexes",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 107,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_solvers{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solvers (ConfigMap)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 38,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_solvers_database{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solvers (From Database)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": -725,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#967302",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 108,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-rhel-8-py36\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases rhel-8-py36",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#967302",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 109,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-rhel-8-py38\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases rhel-8-py38",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#967302",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 116,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-fedora-34-py39\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases solver-fedora-34-py39",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#967302",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 111,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\", solver_name=\"solver-fedora-35-py310\"} / ignoring(solver_name) group_left thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases solver-fedora-35-py310",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": -44,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#c15c17",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 37,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_unsolved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Unsolved Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#967302",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 72,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 6,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Solvers Knowledge",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": -268,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#3f6833",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 76,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(thoth_graphdb_total_python_packages_with_no_error{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases no error",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#890f02",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 77,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error{instance=\"$instance\", job=\"Thoth Metrics\"}) - sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases with error (general)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#890f02",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 93,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases (unsolvable)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#3f6833",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 100,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(thoth_graphdb_total_python_packages_with_no_error{instance=\"$instance\", job=\"Thoth Metrics\"}) / sum(thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases no error [%]",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#890f02",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 99,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "(sum(thoth_graphdb_total_python_packages_with_solver_error{instance=\"$instance\", job=\"Thoth Metrics\"}) - sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{instance=\"$instance\", job=\"Thoth Metrics\"})) / sum(thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases with error (general) [%]",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#890f02",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 101,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(thoth_graphdb_total_python_packages_with_solver_error_unsolvable{instance=\"$instance\", job=\"Thoth Metrics\"}) / sum(thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Solved Python Packages Releases with error (unsolvable) [%]",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": -78,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#052b51",
+            "#967302",
+            "#052b51"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 115,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 12,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_cve{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "Number of CVE",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#c15c17",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 80,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 5,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_si_unanalyzed_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "SI Unanalyzed Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#3f6833",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 79,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "SI Analyzed Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#890f02",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 96,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_si_not_analyzable_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "SI Not Analyzable Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Security Knowledge",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 94,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#3f6833",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 114,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 12,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"} / thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "SI Analyzed Python Packages Releases",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 300,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 86,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_adviser_count_per_source_type{instance=\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Thoth Integration use: {{thoth_integration}}",
+              "refId": "A",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Thoth Integration Use",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {
+            "Kebechet total active repos": "#cca300",
+            "Kebechet use increase respect to last week": "#0a50a1"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "id": 94,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_kebechet_total_active_repo_count{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Kebechet total active repos",
+              "refId": "A",
+              "step": 600
+            },
+            {
+              "expr": "delta(thoth_kebechet_total_active_repo_count{instance=\"$instance\", job=\"Thoth Metrics\"}[7d])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Kebechet use increase respect to last week",
+              "refId": "B",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Kebechet active repos",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 386,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 10,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_python_packages_per_indexes{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "PythonPackages: {{index_url}}",
+              "refId": "A",
+              "step": 600
+            },
+            {
+              "expr": "thoth_graphdb_sum_python_packages_per_indexes{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Tot Python Packages per Index",
+              "refId": "B",
+              "step": 600
+            },
+            {
+              "expr": "thoth_graphdb_number_python_package_versions{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Tot Python Packages Releases",
+              "refId": "C",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Python Packages per Indexes [TH-GPC-005]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 369,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 17,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_unsolved_python_packages_per_solver{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Unsolved Python Packages per: {{solver_name}}",
+              "refId": "A",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Unsolved Python Packages per solver [TH-GPC-027]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 71,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_solved_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Solved Python Packages Releases per: {{solver_name}}",
+              "refId": "A",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Solved Python Packages per solver [TH-GPC-027]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 393,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 97,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_python_packages_with_no_error{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Solved Python Packages with no error: {{solver_name}}",
+              "refId": "E",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Info about Solved Python Packages for all Solvers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": null,
+            "sortDesc": null,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_python_packages_with_solver_error{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Solved Python Packages with solver error (unsolvable=False, unparseable=False)): {{solver_name}}",
+              "refId": "A",
+              "step": 1200
+            },
+            {
+              "expr": "thoth_graphdb_total_python_packages_with_solver_error_unsolvable{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Solved Python Packages with solver error (unsolvable=TRUE): {{solver_name}}",
+              "refId": "C",
+              "step": 1200
+            },
+            {
+              "expr": "thoth_graphdb_total_python_packages_with_solver_error_unparseable{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Solved Python Packages with solver error (unparseable=TRUE): {{solver_name}}",
+              "refId": "B",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Info about Solved Python Packages for all Solvers with errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 253,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 92,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_si_unanalyzed_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "SI Unanalyzed Python Packages",
+              "refId": "A",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "SI Unanalzyed Python Packages",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 91,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_si_analyzed_python_packages{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "SI Analyzed Python Packages",
+              "refId": "A",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "SI Analyzed Python Packages",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Python Packages Information",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 306,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 16,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_number_of_pi_per_framework{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "FRAMEWORK: {{framework}} | PI: {{pi}}",
+              "refId": "D",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "PI Information [TH-GPC-009]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 21,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_performance_records{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{performance_table}}",
+              "refId": "A",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of Performance Indicators [TH-GPC-010]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Performance Indicators",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 87,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#511749",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 55,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_performance_records{instance=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_matmul\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "matmul Records",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#511749",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 57,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_performance_records{instance=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_conv2d\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "conv2d Records",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#511749",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 58,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 4,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_performance_records{instance=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_conv1d\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "conv1d Records",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "PI Schema",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 74,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": true,
+          "colorValue": false,
+          "colors": [
+            "#584477",
+            "#3f2b5b",
+            "#584477"
+          ],
+          "datasource": "Prometheus",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 66,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 12,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_performance_records{instance=\"$instance\", job=\"Thoth Metrics\", performance_table=\"pi_pybench\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 14400
+            }
+          ],
+          "thresholds": "",
+          "title": "pybench Records",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 306,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_user_software_stacks_records{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "External (User) Software Stacks",
+              "refId": "A",
+              "step": 600
+            },
+            {
+              "expr": "thoth_graphdb_total_user_run_software_environment{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Number of External Software Environment for Run",
+              "refId": "B",
+              "step": 600
+            },
+            {
+              "expr": "thoth_graphdb_total_main_records{instance=\"$instance\", job=\"Thoth Metrics\", main_table=~\"external_.*\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Number of {{main_table}}",
+              "refId": "C",
+              "step": 600
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "User Information [TH-GPC-011]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Users Information",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 294,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 15,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_total_run_software_environment{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Number of Software Environment for Run",
+              "refId": "A",
+              "step": 1200
+            },
+            {
+              "expr": "thoth_graphdb_total_build_software_environment{instance=\"$instance\", job=\"Thoth Metrics\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Number of Software Environment for Build",
+              "refId": "B",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "SoftwareEnvironment Information [TH-GPC-012]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "fill": 1,
+          "id": 98,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "thoth_graphdb_advised_software_stacks_records{instance=\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Number of advised software stacks",
+              "refId": "A",
+              "step": 1200
+            },
+            {
+              "expr": "thoth_graphdb_user_software_stacks_records{instance=\"$instance\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Number of user software stacks",
+              "refId": "B",
+              "step": 1200
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Python software stacks",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Software Environment (Build and Run) and Hardware",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [
+    "thoth",
+    "knowledge graph"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "value": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "instance",
+        "options": [
+          {
+            "selected": false,
+            "text": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          {
+            "selected": true,
+            "text": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+          }
+        ],
+        "query": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80, metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Thoth Knowledge Graph content metrics",
+  "version": 1
+}

--- a/grafana-dashboard/ocp4-stage/thoth-postgresql-metrics.json
+++ b/grafana-dashboard/ocp4-stage/thoth-postgresql-metrics.json
@@ -1,0 +1,2631 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 126,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 131,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": true,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "#508642",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "decimals": null,
+            "description": "PostgreSQL version",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 3,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "80%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 6,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_static{instance=\"$instance\"}",
+                "format": "time_series",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 2,
+                "legendFormat": "{{short_version}}",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Version",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "name"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the maximum number of concurrent connections.",
+            "format": "none",
+            "gauge": {
+              "maxValue": 250,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 1,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_max_connections{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Max Connections",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the number of shared memory buffers used by the server. [Units converted to bytes.]",
+            "format": "bytes",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 2,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_shared_buffers_bytes{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Shared Buffers",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the planner’s assumption about the size of the data cache. [Units converted to bytes.]",
+            "format": "bytes",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 4,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_effective_cache_size_bytes{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Effective Cache",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the maximum memory to be used for maintenance operations. [Units converted to bytes.]",
+            "format": "bytes",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 5,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_maintenance_work_mem_bytes{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Maintenance Work Mem",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the maximum memory to be used for query workspaces. [Units converted to bytes.]",
+            "format": "bytes",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 6,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_work_mem_bytes{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Work Mem",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the WAL size that triggers a checkpoint. [Units converted to bytes.]",
+            "format": "bytes",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 7,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_max_wal_size_bytes{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Max WAL Size",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the planner’s estimate of the cost of a nonsequentially fetched disk page.",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 8,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_random_page_cost{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Random Page Cost",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the planner’s estimate of the cost of a sequentially fetched disk page.",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 9,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_seq_page_cost{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Seq Page Cost",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Maximum number of concurrent worker processes.",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 10,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_max_worker_processes{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Max Worker Processes",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "description": "Sets the maximum number of parallel processes per executor node.",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 11,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 3,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "pg_settings_max_parallel_workers_per_gather{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Max Parallel Workers",
+            "transparent": false,
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 395,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 17,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "irate(pg_stat_database_tup_inserted{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "INSERT",
+                "refId": "A",
+                "step": 1200
+              },
+              {
+                "expr": "irate(pg_stat_database_tup_updated{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "UPDATE",
+                "refId": "B",
+                "step": 1200
+              },
+              {
+                "expr": "irate(pg_stat_database_tup_deleted{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "DELETE",
+                "refId": "C",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Change Stats",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 12,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "pg_stat_activity_count{instance=\"$instance\", datname=\"postgres\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{state}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Connections",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Connection / Transaction Statistics",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 374,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 13,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "irate(pg_stat_database_xact_commit{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "commits",
+                "refId": "A",
+                "step": 1200
+              },
+              {
+                "expr": "irate(pg_stat_database_xact_rollback{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "rollbacks",
+                "refId": "B",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Transactions",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 19,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "pg_stat_activity_max_tx_duration{instance=\"$instance\", datname=\"postgres\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "max_tx_duration [{{state}}]",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Longest Transaction",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "dtdurations",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "none",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 328,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 22,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "irate(pg_stat_database_conflicts{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "conflicts",
+                "refId": "A",
+                "step": 1200
+              },
+              {
+                "expr": "irate(pg_stat_database_deadlocks{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "deadlocks",
+                "refId": "B",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Conflicts/Deadlocks",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 18,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "irate(pg_stat_database_tup_fetched{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "SELECT (index scan)",
+                "refId": "A",
+                "step": 1200
+              },
+              {
+                "expr": "irate(pg_stat_database_tup_returned{instance=\"$instance\", datname=\"postgres\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "SELECT (table scan)",
+                "refId": "B",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Read Stats",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 428,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 20,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "pg_stat_database_blks_hit{instance=\"$instance\", datname=\"thoth\"} / (pg_stat_database_blks_read{instance=\"$instance\", datname=\"thoth\"} + pg_stat_database_blks_hit{instance=\"$instance\", datname=\"thoth\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Cache Hit Rate",
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Cache Hit Rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "none",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "Number of locks",
+            "fill": 1,
+            "id": 23,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 5,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "pg_locks_count{instance=\"$instance\", datname=\"thoth\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{mode}}",
+                "refId": "A",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Lock Tables",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": 0,
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "Total amount of data written to temporary files by queries in this database. All temporary files are counted, regardless of why the temporary file was created, and regardless of the log_temp_files setting.",
+            "fill": 1,
+            "id": 24,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "irate(pg_stat_database_temp_bytes{instance=\"$instance\", datname=\"thoth\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Temp Bytes",
+                "refId": "A",
+                "step": 2400
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Temp File",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 315,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "pg_stat_bgwriter_buffers_alloc (cumulative)\nNumber of buffers allocated, \n\npg_stat_bgwriter_buffers_backend (cumulative)\nNumber of buffers written directly by a backend, \n\npg_stat_bgwriter_buffers_backend_fsync (cumulative)\nNumber of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write),\n\npg_stat_bgwriter_buffers_checkpoint (cumulative)\nNumber of buffers written during checkpoints,\n\npg_stat_bgwriter_buffers_clean (cumulative)\nNumber of buffers written by the background writer",
+            "fill": 1,
+            "id": 21,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "irate(pg_stat_bgwriter_buffers_backend{instance=\"$instance\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "buffers_backend",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "irate(pg_stat_bgwriter_buffers_alloc{instance=\"$instance\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "buffers_alloc",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "irate(pg_stat_bgwriter_buffers_backend_fsync{instance=\"$instance\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "backend_fsync",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "irate(pg_stat_bgwriter_buffers_checkpoint{instance=\"$instance\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "buffers_checkpoint",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "irate(pg_stat_bgwriter_buffers_clean{instance=\"$instance\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "buffers_clean",
+                "refId": "E",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Buffers (bgwriter)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "pg_stat_bgwriter_checkpoint_sync_time (cumulative)\nTotal amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds,\n\npg_stat_bgwriter_checkpoint_write_time (cumulative)\nTotal amount of time that has been spent in the portion of checkpoint processing where files are written to disk, in milliseconds",
+            "fill": 1,
+            "id": 25,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 8,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "irate(pg_stat_bgwriter_checkpoint_write_time{instance=\"$instance\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "write_time - Total amount of time that has been spent in the portion of checkpoint processing where files are written to disk.",
+                "refId": "A",
+                "step": 1200
+              },
+              {
+                "expr": "irate(pg_stat_bgwriter_checkpoint_sync_time{instance=\"$instance\"}[5m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "sync_time - Total amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk.",
+                "refId": "B",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Checkpoint Stats",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 289,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 26,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graphdb_pct_bloat_data_table{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{table_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Table Bloat data (pct)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percent",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 27,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graphdb_mb_bloat_data_table{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{table_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Table Bloat data (mb)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decmbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 31,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graphdb_pct_index_bloat_data_table{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{table_name}}: {{index_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Index Bloat data (pct)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percent",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 32,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graphdb_mb_index_bloat_data_table{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{table_name}}: {{index_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Index Bloat data (mb)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decmbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 163,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 28,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 12,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "thoth_graphdb_is_corrupted{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "0.1,1",
+            "title": "Schema corruption (amcheck) [no 0, yes 1 -> alarm]",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 132,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "rgba(50, 172, 45, 0.97)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(245, 54, 54, 0.9)"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 29,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 12,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "thoth_graphdb_connection_issues{instance=\"$metrics_exporter_instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "0.1,1",
+            "title": "Database connection issue [no 0, yes 1,  -> alarm]",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 30,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graphdb_size{instance=\"$metrics_exporter_instance\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Thoth Database Size",
+                "refId": "A",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Thoth Database Size",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "thoth",
+      "ops-metrics",
+      "postgresql-metrics-exporter"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "postgres-metrics-exporter-thoth-graph-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "postgres-metrics-exporter-thoth-graph-stage.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance",
+          "options": [
+            {
+              "selected": false,
+              "text": "postgres-metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "postgres-metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": true,
+              "text": "postgres-metrics-exporter-thoth-graph-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "postgres-metrics-exporter-thoth-graph-stage.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "postgres-metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80,  postgres-metrics-exporter-thoth-graph-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "metrics_exporter_instance",
+          "options": [
+            {
+              "selected": true,
+              "text": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": false,
+              "text": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80, metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "ocp4-stage",
+            "value": "ocp4-stage"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "env",
+          "options": [
+            {
+              "selected": false,
+              "text": "ocp4-test",
+              "value": "ocp4-test"
+            },
+            {
+              "selected": true,
+              "text": "ocp4-stage",
+              "value": "ocp4-stage"
+            }
+          ],
+          "query": "ocp4-test,ocp4-stage",
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Thoth PostgreSQL metrics",
+    "version": 1
+  }

--- a/grafana-dashboard/ocp4-stage/thoth-report.json
+++ b/grafana-dashboard/ocp4-stage/thoth-report.json
@@ -1,0 +1,247 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 161,
+    "links": [],
+    "refresh": "1d",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 452,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 2,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_sli_weekly_stage",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Weekly update on SLI {{sli_type}} using METRIC: {{metric_name}}",
+                "refId": "A",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Thoth SLI/SLO weekly update",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 585,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 1,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_adviser_message_type_count{job=\"advise-type-analysis\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{info_type}} :{{message}}",
+                "refId": "A",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Advise Justifications and 'Errors'",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "thoth",
+      "reports"
+    ],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Thoth reports",
+    "version": 1
+  }

--- a/grafana-dashboard/ocp4-stage/thoth-service-metrics.json
+++ b/grafana-dashboard/ocp4-stage/thoth-service-metrics.json
@@ -1,0 +1,492 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 21,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 516,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 27,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "user_api_info{job=\"Thoth User API Metrics\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} | {{job}} | VERSION: {{version}}",
+                "refId": "A",
+                "step": 40
+              },
+              {
+                "expr": "thoth_metrics_exporter_info{job=\"Thoth Metrics\"}",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} |{{job}} | VERSION: {{version}}",
+                "refId": "B",
+                "step": 40
+              },
+              {
+                "expr": "management_api_info{job=\"Thoth Management API Metrics\"}",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} | {{job}} | VERSION: {{version}}",
+                "refId": "C",
+                "step": 40
+              },
+              {
+                "expr": "investigator_consumer_info{job=\"Thoth Investigator Consumer Metrics\"}",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{instance}} |{{job}} | VERSION: {{version}}",
+                "refId": "E",
+                "step": 40
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Thoth Components Versions",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Schema Status APIs",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 28,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_package_release_job_info",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{job}}  ({{env}})| VERSION: {{version}} ",
+                "refId": "F",
+                "step": 40
+              },
+              {
+                "expr": "thoth_graph_refresh_job_info",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "{{job}}  ({{env}})| VERSION: {{version}} ",
+                "refId": "G",
+                "step": 40
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Thoth Components Versions",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 512,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 29,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 7,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_database_schema_revision_script{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "REVISION SCRIPT component: {{component}} |revision head script: {{revision}} | instance {{instance}} | env {{env}}",
+                "refId": "D",
+                "step": 60
+              },
+              {
+                "expr": "thoth_database_schema_revision_table{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "REVISION TABLE component: {{component}} |revision head script: {{revision}} | instance {{instance}} | env {{env}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Database Schema revision for Thoth components",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 30,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 5,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graph_db_component_revision_check{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "COMPONENT: {{component}} | DEPLOYMENT: {{env}}",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Is component schema == database schema? [0 yes, 1 no -> alarm]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "thoth",
+      "service-metrics",
+      "metrics-exporter",
+      "dependencies-components"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "ocp4-stage",
+            "value": "ocp4-stage"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "env",
+          "options": [
+            {
+              "selected": false,
+              "text": "ocp4-test",
+              "value": "ocp4-test"
+            },
+            {
+              "selected": true,
+              "text": "ocp4-stage",
+              "value": "ocp4-stage"
+            }
+          ],
+          "query": "ocp4-test, ocp4-stage",
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-12h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Thoth Service metrics",
+    "version": 1
+  }

--- a/grafana-dashboard/ocp4-stage/thoth-service-user-api.json
+++ b/grafana-dashboard/ocp4-stage/thoth-service-user-api.json
@@ -1,0 +1,1868 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 194,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 397,
+        "panels": [
+          {
+            "aliasColors": {
+              "GET: HTTP 200": "#3f6833",
+              "GET: HTTP 308": "#f9934e",
+              "GET: HTTP 400": "#890f02",
+              "POST: HTTP 200": "#7eb26d",
+              "POST: HTTP 202": "#cffaff",
+              "POST: HTTP 400": "#bf1b00",
+              "POST: HTTP 401": "#58140c"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 17,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "increase(flask_http_request_total{instance=\"$instance\", method=\"GET\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "GET: HTTP {{ status }}",
+                "refId": "A",
+                "step": 240
+              },
+              {
+                "expr": "increase(flask_http_request_total{instance=\"$instance\", method=\"POST\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "POST: HTTP {{ status }}",
+                "refId": "F",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total requests per minute [TH-GP-0023]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "GET: HTTP 200": "#3f6833",
+              "GET: HTTP 308": "#f9934e",
+              "GET: HTTP 400": "#890f02",
+              "POST: HTTP 200": "#7eb26d",
+              "POST: HTTP 202": "#cffaff",
+              "POST: HTTP 400": "#bf1b00",
+              "POST: HTTP 401": "#58140c"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 45,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(thoth_user_api_adviser_authenticated_cache_hit_rate[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Cache hit adviser authenticated",
+                "refId": "A",
+                "step": 240
+              },
+              {
+                "expr": "rate(hoth_user_api_adviser_unauthenticated_cache_hit_rate[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Cache hit adviser unauthenticated",
+                "refId": "B",
+                "step": 240
+              },
+              {
+                "expr": "rate(thoth_user_api_provenance_checker_authenticated_cache_hit_rate[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Cache hit provenance checker authenticated",
+                "refId": "C",
+                "step": 240
+              },
+              {
+                "expr": "rate(thoth_user_api_provenance_checker_unauthenticated_cache_hit_rate[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Cache hit provenance checker unauthenticated",
+                "refId": "D",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Cache hit",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Total requests per minute [TH-GP-0023]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 466,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1./api/v1_openapi_json | METHOD: GET | STATUS : 200": "#890f02",
+              "ENDPOINT: /api/v1./api/v1_swagger_ui_index | METHOD: GET | STATUS : 200": "#890f02",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_advise_python_status | METHOD: GET | STATUS : 200": "#890f02",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_info | METHOD: GET | STATUS : 200": "#705da0",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_provenance_python_status | METHOD: GET | STATUS : 200": "#3f2b5b",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_advise_python | METHOD: GET | STATUS : 200": "#f9934e",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_buildlogs | METHOD: GET | STATUS : 200": "#962d82",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_python_package_indexes | METHOD: GET | STATUS : 200": "#1f78c1",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_build | METHOD: GET | STATUS : 200": "#0a437c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_run | METHOD: GET | STATUS : 200": "rgb(194, 200, 204)",
+              "ENDPOINT: api_liveness | METHOD: GET | STATUS : 200": "#890f02",
+              "ENDPOINT: api_readiness | METHOD: GET | STATUS : 200": "#890f02",
+              "ENDPOINT: api_v1 | METHOD: GET | STATUS : 200": "#890f02"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 43,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "flask_http_request_duration_seconds_count{instance=\"$instance\",  method=\"GET\", status=\"200\"} / ignoring(endpoint) group_left flask_http_request_total{instance=\"$instance\", method=\"GET\", status=\"200\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "A",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Percentage of endpoint hit (GET, 200) [TH-GP-0033]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Percentage of endpoints hit (GET, 200) [TH-GP-0033]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 346,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_parse_log | METHOD: POST | STATUS : 200": "#629e51",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_advise_python | METHOD: POST | STATUS : 202": "#eab839",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_analyze | METHOD: POST | STATUS : 202": "#967302",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_buildlog | METHOD: POST | STATUS : 202": "#58140c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_provenance_python | METHOD: POST | STATUS : 202": "rgb(25, 230, 26)"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 44,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "flask_http_request_duration_seconds_count{instance=\"$instance\", method=\"POST\", status=\"202\"} / ignoring(endpoint) group_left flask_http_request_total{instance=\"$instance\", method=\"POST\", status=\"202\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "A",
+                "step": 240
+              },
+              {
+                "expr": "flask_http_request_duration_seconds_count{instance=\"$instance\", method=\"POST\", status=\"200\"} / ignoring(endpoint) group_left flask_http_request_total{instance=\"$instance\", method=\"POST\", status=\"200\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "B",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Percentage of endpoint hit (POST, [200, 202]) [TH-GP-0033]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Percentage of endpoints hit (POST, 200, 202) [TH-GP-0033]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 262,
+        "panels": [
+          {
+            "aliasColors": {
+              "errors ": "#bf1b00"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 4,
+              "w": 6,
+              "x": 10,
+              "y": 0
+            },
+            "id": 9,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "errors"
+              }
+            ],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate(flask_http_request_duration_seconds_count{instance=\"$instance\", status!=\"200\"}[$interval]))",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "errors ",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Errors per second [TH-GP-0026]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "transparent": false,
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Errors per second [TH-GP-0026]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {
+              "mem": "#f9d9f9"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 13,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "process_resident_memory_bytes{instance=\"$instance\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "mem",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory usage [TH-GP-0024]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {
+              "cpu": "#f9e2d2"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 16,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(process_cpu_seconds_total{instance=\"$instance\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "cpu",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU usage [TH-GP-0025]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Memory usage [TH-GP-0024] and CPU usage [TH-GP-0025]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 549,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_info | METHOD: GET | STATUS : 200": "#705da0",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_provenance_python_status | METHOD: GET | STATUS : 200": "#3f2b5b",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_advise_python | METHOD: GET | STATUS : 200": "#f9934e",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_buildlogs | METHOD: GET | STATUS : 200": "#962d82",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_python_package_indexes | METHOD: GET | STATUS : 200": "#1f78c1",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_python_package_indexes | METHOD: GET | STATUS : 200PATH: path | METHOD: GET | STATUS : 200": "#1f78c1",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_build | METHOD: GET | STATUS : 200": "#0a437c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_run | METHOD: GET | STATUS : 200": "rgb(220, 217, 211)",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_parse_log | METHOD: POST | STATUS : 200": "#629e51",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_advise_python | METHOD: POST | STATUS : 202": "#eab839",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_analyze | METHOD: POST | STATUS : 202": "#967302",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_buildlog | METHOD: POST | STATUS : 202": "#58140c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_provenance_python | METHOD: POST | STATUS : 202": "rgb(77, 214, 25)",
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#e0752d",
+              "PATH: /api/v1/advise/python | METHOD: POST | STATUS : 202": "#eab839",
+              "PATH: /api/v1/analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "PATH: /api/v1/build-software-environment | METHOD: GET | STATUS : 200": "#0a437c",
+              "PATH: /api/v1/buildlog | METHOD: GET | STATUS : 200": "#962d82",
+              "PATH: /api/v1/buildlog | METHOD: POST | STATUS : 202": "#58140c",
+              "PATH: /api/v1/info | METHOD: GET | STATUS : 200": "#705da0",
+              "PATH: /api/v1/provenance/python | METHOD: POST | STATUS : 202": "rgb(47, 224, 8)",
+              "PATH: /api/v1/run-software-environment | METHOD: GET | STATUS : 200": "rgb(172, 168, 158)"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 27,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(flask_http_request_duration_seconds_sum{instance=\"$instance\", endpoint!=\"None\", endpoint!=\"base_url\", endpoint!=\"/api/v1./api/v1_openapi_json\", endpoint!=\"api_v1\", endpoint!=\"api_readiness\",endpoint!=\"/api/v1./api/v1_swagger_ui_static\", endpoint!=\"api_liveness\",endpoint!=\"/api/v1./api/v1_swagger_ui_index\", status=~\"200|202\"}[$interval])\n/\nrate(flask_http_request_duration_seconds_count{instance=\"$instance\",endpoint!=\"None\", endpoint!=\"base_url\", endpoint!=\"/api/v1./api/v1_openapi_json\", endpoint!=\"api_v1\", endpoint!=\"api_readiness\",endpoint!=\"/api/v1./api/v1_swagger_ui_static\", endpoint!=\"api_liveness\",endpoint!=\"/api/v1./api/v1_swagger_ui_index\", status=~\"200|202\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "B",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Average response time [30s] [TH-GP-0028]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "s",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Average response time [1m] [TH-GP-0028]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 637,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_info | METHOD: GET | STATUS : 200": "#705da0",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_provenance_python_status | METHOD: GET | STATUS : 200": "#3f2b5b",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_advise_python | METHOD: GET | STATUS : 200": "#f9934e",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_buildlogs | METHOD: GET | STATUS : 200": "#962d82",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_python_package_indexes | METHOD: GET | STATUS : 200": "#1f78c1",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_build | METHOD: GET | STATUS : 200": "#0a437c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_run | METHOD: GET | STATUS : 200": "rgb(203, 212, 200)",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_analyze | METHOD: POST | STATUS : 202": "#967302",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_buildlog | METHOD: POST | STATUS : 202": "#58140c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_provenance_python | METHOD: POST | STATUS : 202": "rgb(45, 204, 10)",
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: /api/v1/advise/python | METHOD: POST | STATUS : 202": "#eab839",
+              "PATH: /api/v1/analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "PATH: /api/v1/build-software-environment | METHOD: GET | STATUS : 200": "#0a437c",
+              "PATH: /api/v1/buildlog | METHOD: GET | STATUS : 200": "#962d82",
+              "PATH: /api/v1/buildlog | METHOD: POST | STATUS : 202": "#58140c",
+              "PATH: /api/v1/info | METHOD: GET | STATUS : 200": "#705da0",
+              "PATH: /api/v1/parse-log | METHOD: POST | STATUS : 200": "#629e51",
+              "PATH: /api/v1/provenance/python | METHOD: POST | STATUS : 202": "rgb(67, 216, 11)",
+              "PATH: /api/v1/python-package-index | METHOD: GET | STATUS : 200": "#1f78c1",
+              "PATH: /api/v1/run-software-environment | METHOD: GET | STATUS : 200": "rgb(180, 175, 162)"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 26,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "increase(flask_http_request_duration_seconds_bucket{instance=\"$instance\", endpoint!=\"None\", endpoint!=\"base_url\", endpoint!=\"/api/v1./api/v1_openapi_json\", endpoint!=\"api_v1\", endpoint!=\"api_readiness\",endpoint!=\"api_liveness\",endpoint!=\"/api/v1./api/v1_swagger_ui_static\", endpoint!=\"/api/v1./api/v1_swagger_ui_index\", le=\"0.25\", status=~\"200|202\"}[$interval]) \n/ ignoring (le) increase(flask_http_request_duration_seconds_count{instance=\"$instance\", endpoint!=\"None\", endpoint!=\"base_url\", endpoint!=\"/api/v1./api/v1_openapi_json\", endpoint!=\"api_v1\", endpoint!=\"api_readiness\",endpoint!=\"/api/v1./api/v1_swagger_ui_static\", endpoint!=\"api_liveness\",endpoint!=\"/api/v1./api/v1_swagger_ui_index\", status=~\"200|202\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "B",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Requests under 250ms [TH-GP-0029]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": "1",
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Requests under 250ms [TH-GP-0029]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 643,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_info | METHOD: GET | STATUS : 200": "#705da0",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_provenance_python_status | METHOD: GET | STATUS : 200": "#3f2b5b",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_advise_python | METHOD: GET | STATUS : 200": "#f9934e",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_buildlogs | METHOD: GET | STATUS : 200": "#962d82",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_python_package_indexes | METHOD: GET | STATUS : 200": "#1f78c1",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_build | METHOD: GET | STATUS : 200": "#0a437c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_run | METHOD: GET | STATUS : 200": "rgb(208, 218, 206)",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_analyze | METHOD: POST | STATUS : 202": "#967302",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_buildlog | METHOD: POST | STATUS : 202": "#58140c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_provenance_python | METHOD: POST | STATUS : 202": "rgb(37, 208, 11)",
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: /api/v1/advise/python | METHOD: POST | STATUS : 202": "#eab839",
+              "PATH: /api/v1/analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "PATH: /api/v1/build-software-environment | METHOD: GET | STATUS : 200": "#0a437c",
+              "PATH: /api/v1/buildlog | METHOD: GET | STATUS : 200": "#962d82",
+              "PATH: /api/v1/info | METHOD: GET | STATUS : 200": "#705da0",
+              "PATH: /api/v1/provenance/python | METHOD: POST | STATUS : 202": "rgb(62, 220, 15)",
+              "PATH: /api/v1/run-software-environment | METHOD: GET | STATUS : 200": "rgb(178, 174, 165)"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 12,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.5, rate(flask_http_request_duration_seconds_bucket{instance=\"$instance\",endpoint!=\"None\", endpoint!=\"base_url\", endpoint!=\"/api/v1./api/v1_openapi_json\", endpoint!=\"api_v1\", endpoint!=\"api_readiness\",endpoint!=\"api_liveness\",endpoint!=\"/api/v1./api/v1_swagger_ui_index\",endpoint!=\"/api/v1./api/v1_swagger_ui_static\",  status=~\"200|202\"}[60s]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "B",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Request duration - p50 [TH-GP-0030]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Request duration - p50 [TH-GP-0030]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 639,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_info | METHOD: GET | STATUS : 200": "#705da0",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_provenance_python_status | METHOD: GET | STATUS : 200": "#3f2b5b",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_advise_python | METHOD: GET | STATUS : 200": "#f9934e",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_buildlogs | METHOD: GET | STATUS : 200": "#962d82",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_python_package_indexes | METHOD: GET | STATUS : 200": "#1f78c1",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_build | METHOD: GET | STATUS : 200": "#0a437c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_software_environments_for_run | METHOD: GET | STATUS : 200": "rgb(183, 190, 181)",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_analyze | METHOD: POST | STATUS : 202": "#967302",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_buildlog | METHOD: POST | STATUS : 202": "#58140c",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_post_provenance_python | METHOD: POST | STATUS : 202": "rgb(30, 194, 15)",
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: /api/v1/advise/python | METHOD: POST | STATUS : 202": "#eab839",
+              "PATH: /api/v1/analyze | METHOD: GET | STATUS : 200": "#ea6460",
+              "PATH: /api/v1/build-software-environment | METHOD: GET | STATUS : 200": "#0a437c",
+              "PATH: /api/v1/buildlog | METHOD: GET | STATUS : 200": "#962d82",
+              "PATH: /api/v1/info | METHOD: GET | STATUS : 200": "#705da0",
+              "PATH: /api/v1/provenance/python | METHOD: POST | STATUS : 202": "rgb(95, 222, 4)",
+              "PATH: /api/v1/run-software-environment | METHOD: GET | STATUS : 200": "rgb(180, 174, 159)"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 15,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.9, rate(flask_http_request_duration_seconds_bucket{instance=\"$instance\",endpoint!=\"/api/v1./api/v1_openapi_json\", endpoint!=\"None\", endpoint!=\"base_url\", endpoint!=\"api_v1\", endpoint!=\"api_readiness\",endpoint!=\"api_liveness\",endpoint!=\"/api/v1./api/v1_swagger_ui_index\", endpoint!=\"/api/v1./api/v1_swagger_ui_static\", status=~\"200|202\"}[$interval]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "B",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Request duration - p90 [TH-GP-0031]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Request duration - p90 [TH-GP-0031]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 365,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_get_info | METHOD: GET | STATUS : 200": "#705da0",
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_python_package_indexes | METHOD: GET | STATUS : 200": "#1f78c1",
+              "PATH: /api/v1/info | METHOD: GET | STATUS : 200": "#705da0",
+              "PATH: /api/v1/python-package-index | METHOD: GET | STATUS : 200": "#1f78c1"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 4,
+              "w": 10,
+              "x": 0,
+              "y": 0
+            },
+            "id": 20,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(flask_http_request_duration_seconds_count{instance=\"$instance\", endpoint!=\"api_v1\", endpoint!=\"base_url\", status=\"200\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "B",
+                "step": 240
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Requests per second  [TH-GP-0026] (all endpoints)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Requests per second [TH-GP-0026]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 374,
+        "panels": [
+          {
+            "aliasColors": {
+              "ENDPOINT: /api/v1.thoth_user_api_api_v1_list_advise_python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: /api/v1/advise/python | METHOD: POST | STATUS : 202": "#eab839"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 11,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "rate(flask_http_request_duration_seconds_sum{instance=\"$instance\", endpoint!=\"api_v1\", endpoint!=\"base_url\", status=\"200\"}[$interval])\n/\nrate(flask_http_request_duration_seconds_count{instance=\"$instance\", endpoint!=\"api_v1\", endpoint!=\"base_url\", status=\"200\"}[$interval])",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Average response time  [TH-GP-0028] (All endpoints)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "s",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Average response time  [TH-GP-0028]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 450,
+        "panels": [
+          {
+            "aliasColors": {
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: path | METHOD: GET | STATUS : 200": "#f9934e"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 23,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "increase(flask_http_request_duration_seconds_bucket{instance=\"$instance\", endpoint!=\"api_v1\", endpoint!=\"base_url\", status=\"200\", le=\"0.25\"}[$interval]) \n/ ignoring (le) increase(flask_http_request_duration_seconds_count{instance=\"$instance\", endpoint!=\"api_v1\", endpoint!=\"base_url\", status=\"200\"}[$interval])",
+                "format": "time_series",
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Requests under 250ms [TH-GP-0029] (All endpoints)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "percent",
+                "label": null,
+                "logBase": 1,
+                "max": "1",
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Requests under 250ms [TH-GP-0029]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 504,
+        "panels": [
+          {
+            "aliasColors": {
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: path | METHOD: GET | STATUS : 200": "#f9934e"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 24,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.5, rate(flask_http_request_duration_seconds_bucket{instance=\"$instance\", endpoint!=\"api_v1\", endpoint!=\"base_url\", status=\"200\"}[$interval]))",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Request duration - p50 [TH-GP-0030] (All endpoints)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Request duration - p50 [TH-GP-0030]",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 425,
+        "panels": [
+          {
+            "aliasColors": {
+              "PATH: /api/v1/advise/python | METHOD: GET | STATUS : 200": "#f9934e",
+              "PATH: path | METHOD: GET | STATUS : 200": "#f9934e"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 25,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "rightSide": false,
+              "show": true,
+              "sort": "avg",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.9, rate(flask_http_request_duration_seconds_bucket{instance=\"$instance\", endpoint!=\"api_v1\", endpoint!=\"base_url\", status=\"200\"}[$interval]))",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "ENDPOINT: {{endpoint}} | METHOD: {{method}} | STATUS : {{status}}",
+                "refId": "A",
+                "step": 120
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Request duration - p90 [TH-GP-0031] (All endpoint)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Request duration - p90 [TH-GP-0031]",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "service-metrics",
+      "user-api",
+      "thoth"
+    ],
+    "templating": {
+      "list": [
+        {
+          "auto": true,
+          "auto_count": 30,
+          "auto_min": "10s",
+          "current": {
+            "text": "10m",
+            "value": "10m"
+          },
+          "hide": 0,
+          "label": null,
+          "name": "interval",
+          "options": [
+            {
+              "selected": false,
+              "text": "auto",
+              "value": "$__auto_interval"
+            },
+            {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": true,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            },
+            {
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "30d",
+              "value": "30d"
+            }
+          ],
+          "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+          "refresh": 2,
+          "type": "interval"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "user-api-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "user-api-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance",
+          "options": [
+            {
+              "selected": true,
+              "text": "user-api-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "user-api-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": false,
+              "text": "user-api-thoth-frontend-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "user-api-thoth-frontend-stage.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "user-api-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80, user-api-thoth-frontend-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-2d",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Thoth Service metrics user-api",
+    "version": 1
+  }

--- a/grafana-dashboard/ocp4-stage/thoth-sli-slo.json
+++ b/grafana-dashboard/ocp4-stage/thoth-sli-slo.json
@@ -1,0 +1,3468 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 134,
+    "links": [],
+    "refresh": "30s",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 305,
+        "panels": [
+          {
+            "aliasColors": {
+              "Thoth Learning rate SLO": "#bf1b00"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": 2,
+            "fill": 1,
+            "id": 64,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[$interval])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Thoth Solver Learning rate SLI (increase) | instance: {{instance}} | {{job}}",
+                "refId": "C",
+                "step": 600
+              },
+              {
+                "expr": "increase(thoth_graphdb_si_unanalyzed_python_package_versions_change_total{instance=\"$instance_metrics\"}[$interval])",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "Thoth SI Learning rate SLI (increase) | instance: {{instance}} | {{job}}",
+                "refId": "A",
+                "step": 600
+              },
+              {
+                "expr": "350",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "Thoth Learning rate SLO",
+                "refId": "B",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Learning Rates Python Packages",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Learning Rate",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 255,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 25,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graphdb_total_number_unsolved_python_packages{instance=\"$instance_metrics\"}",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "Thoth Number of unsolved packages",
+                "refId": "A",
+                "step": 600
+              },
+              {
+                "expr": "increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[$interval])",
+                "format": "time_series",
+                "hide": false,
+                "instant": false,
+                "intervalFactor": 2,
+                "legendFormat": "Thoth Unsolved Learning rate SLI (increase)",
+                "refId": "B",
+                "step": 600
+              },
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages{instance=\"$instance_metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated hours to solve all unsolved packages (1h inverval)",
+                "refId": "C",
+                "step": 600
+              },
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages{instance=\"$instance_metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days to solve all unsolved packages (1h inverval)",
+                "refId": "D",
+                "step": 600
+              },
+              {
+                "expr": "(thoth_graphdb_number_python_package_versions{instance=\"$instance_metrics\", job=\"Thoth Metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days to solve all packages adding a new solver (1h interval)",
+                "refId": "E",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Unsolved Python Packages, Learning Rate and Estimated time to solve all packages",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 69,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{instance=\"$instance_metrics\", job=\"Thoth Metrics\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days to solve (1h inverval): {{solver_name}}",
+                "refId": "E",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Estimated time to solve packages per solver [days]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 68,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{instance=\"$instance_metrics\", job=\"Thoth Metrics\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated hours to solve (1h inverval): {{solver_name}}",
+                "refId": "F",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Estimated time to solve packages per solver [hours]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Estimated time to solve (graphs)",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 89,
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "#967302",
+              "#967302",
+              "#967302"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 91,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 4,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "(thoth_graphdb_number_python_package_versions{instance=\"$instance_metrics\", job=\"Thoth Metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days (1h interval)",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Estimated days to solve all packages adding a new solver (current learning rate)",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "#967302",
+              "#967302",
+              "#967302"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 66,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 4,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages{instance=\"$instance_metrics\"} / increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days (1h interval)",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Estimated days to solve all unsolved packages",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "#967302",
+              "#967302",
+              "#967302"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 67,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 4,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{instance=\"$instance_metrics\", job=\"Thoth Metrics\", solver_name=\"solver-fedora-32-py38\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days (1h interval)",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Estimated days to solve all packages for solver-fedora-32-py38",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "#967302",
+              "#967302",
+              "#967302"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 70,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 4,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{instance=\"$instance_metrics\", job=\"Thoth Metrics\", solver_name=\"solver-rhel-8-py36\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days (1h interval)",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Estimated days to solve all packages for solver-rhel-8-py36",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": true,
+            "colorValue": false,
+            "colors": [
+              "#967302",
+              "#967302",
+              "#967302"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 71,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 4,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "(thoth_graphdb_total_number_unsolved_python_packages_per_solver{instance=\"$instance_metrics\", job=\"Thoth Metrics\", solver_name=\"solver-rhel-8-py38\"}  / ignoring(solver_name) group_left increase(thoth_graphdb_unsolved_python_package_versions_change_total{instance=\"$instance_metrics\"}[1h]))/24",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Estimated days (1h interval)",
+                "refId": "A",
+                "step": 14400
+              }
+            ],
+            "thresholds": "",
+            "title": "Estimated days to solve all packages for solver-rhel-8-py38",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Estimated time to solve (singlestats)",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 63,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_graphdb_total_number_si_unanalyzed_python_packages{instance=\"$instance_metrics\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Thoth Number of SI unanalyzed packages",
+                "refId": "A",
+                "step": 600
+              },
+              {
+                "expr": "increase(thoth_graphdb_si_unanalyzed_python_package_versions_change_total{instance=\"$instance_metrics\"}[$interval])",
+                "format": "time_series",
+                "instant": false,
+                "intervalFactor": 2,
+                "legendFormat": "Thoth SI Learning rate SLI (increase)",
+                "refId": "B",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "SI unanalyzed Python Packages",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "decimals": null,
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Estimated time to SI analyze (graphs)",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 267,
+        "panels": [
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 90,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "increase(argo_workflows_status_counter{instance=\"$instance\"}[$interval])",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "increase {{name}} : {{status}}",
+                "refId": "A",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Rate Workflow status",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "none",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 62,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=~\"solver_workflows_succeeded\", sli_type=\"component_quality\"}) / (sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_succeeded\", sli_type=\"component_quality\"}) + sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_failed\", sli_type=\"component_quality\"}) + sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_error\", sli_type=\"component_quality\"}))",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% solver workflows succeeded",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_failed\", sli_type=\"component_quality\"}) / (sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_succeeded\", sli_type=\"component_quality\"}) + sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_failed\", sli_type=\"component_quality\"}) + sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_error\", sli_type=\"component_quality\"}))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% solver workflows failed",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_error\", sli_type=\"component_quality\"}) / (sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_succeeded\", sli_type=\"component_quality\"}) + sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_failed\", sli_type=\"component_quality\"}) + sum(thoth_sli_weekly_stage{metric_name=\"solver_workflows_error\", sli_type=\"component_quality\"}))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% solver workflows error",
+                "refId": "H",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Solver Workflow quality",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 74,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=~\"adviser_workflows_succeeded\", sli_type=\"component_quality\", env=\"$env\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"adviser_workflows_.*\", sli_type=\"component_quality\", env=\"$env\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% adviser workflows succeeded",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"adviser_workflows_failed\", sli_type=\"component_quality\", env=\"$env\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"adviser_workflows_.*\", sli_type=\"component_quality\", env=\"$env\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% adviser workflows failed",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"adviser_workflows_error\", sli_type=\"component_quality\", env=\"$env\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"adviser_workflows_.*\", sli_type=\"component_quality\", env=\"$env\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% adviser workflows error",
+                "refId": "H",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Adviser Workflow quality",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 75,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=~\"provenance_checker_workflows_succeeded\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"provenance_checker_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% provenance checker workflows succeeded",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"provenance_checker_workflows_failed\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"provenance_checker_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% provenance checker workflows failed",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"provenance_checker_workflows_error\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"provenance_checker_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% provenance checker workflows error",
+                "refId": "H",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Provenance Checker Workflow quality",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 76,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=~\"security_workflows_succeeded\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"security_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows succeeded",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"security_workflows_failed\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"security_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows failed",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"security_workflows_error\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"security_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows error",
+                "refId": "H",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Security Workflow quality",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 77,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=~\"kebechet_workflows_succeeded\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"kebechet_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows succeeded",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"kebechet_workflows_failed\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"kebechet_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows failed",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"kebechet_workflows_error\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"kebechet_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows error",
+                "refId": "H",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kebechet Workflow quality",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 78,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=~\"package_extract_workflows_succeeded\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"package_extract_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows succeeded",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"package_extract_workflows_failed\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"package_extract_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows failed",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"package_extract_workflows_error\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"package_extract_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows error",
+                "refId": "H",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Package Extract Workflow quality",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 79,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=~\"revsolver_workflows_succeeded\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"revsolver_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows succeeded",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"revsolver_workflows_failed\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"revsolver_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows failed",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{metric_name=\"revsolver_workflows_error\", sli_type=\"component_quality\"}) / sum(thoth_sli_weekly_stage{metric_name=~\"revsolver_workflows_.*\", sli_type=\"component_quality\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "% security workflows error",
+                "refId": "H",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Revsolver Workflow quality",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Workflow Quality",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 281,
+        "panels": [
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 80,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_5\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 5s",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_10\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 10s",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_30\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 30s",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_60\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 60s",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_120\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 120s",
+                "refId": "E",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_180\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 180s",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_300\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 300s",
+                "refId": "G",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_600\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 600s",
+                "refId": "H",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_900\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"solver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 900s",
+                "refId": "I",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Solver Workflow latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 82,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_5\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 5s",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_10\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 10s",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_30\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 30s",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_60\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 60s",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_120\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 120s",
+                "refId": "E",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_180\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 180s",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_300\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 300s",
+                "refId": "G",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_600\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 600s",
+                "refId": "H",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_900\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"adviser_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 900s",
+                "refId": "I",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Adviser Workflow latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 83,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_5\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 5s",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_10\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 10s",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_30\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 30s",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_60\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 60s",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_120\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 120s",
+                "refId": "E",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_180\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 180s",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_300\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 300s",
+                "refId": "G",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_600\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 600s",
+                "refId": "H",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_900\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"provenance_checker_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 900s",
+                "refId": "I",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Provenance Checker Workflow latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 81,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_5\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 5s",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_10\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 10s",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_30\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 30s",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_60\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 60s",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_120\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 120s",
+                "refId": "E",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_180\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 180s",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_300\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 300s",
+                "refId": "G",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_600\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 600s",
+                "refId": "H",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_900\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 900s",
+                "refId": "I",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Security Workflow latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 84,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_5\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"security_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 5s",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_10\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 10s",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_30\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 30s",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_60\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 60s",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_120\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 120s",
+                "refId": "E",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_180\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 180s",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_300\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 300s",
+                "refId": "G",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_600\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 600s",
+                "refId": "H",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_900\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"kebechet_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 900s",
+                "refId": "I",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kebechet Workflow latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 86,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_5\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 5s",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_10\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 10s",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_30\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 30s",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_60\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 60s",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_120\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 120s",
+                "refId": "E",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_180\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 180s",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_300\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 300s",
+                "refId": "G",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_600\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 600s",
+                "refId": "H",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_900\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"package_extract_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 900s",
+                "refId": "I",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Package Extract Workflow latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Inspection Workflow Total": "#0a50a1",
+              "Inspection Workflow: Error State": "#c15c17",
+              "Inspection Workflow: Failed State": "#bf1b00",
+              "Inspection Workflow: Pending State": "rgb(96, 95, 95)",
+              "Inspection Workflow: Running State": "#64b0c8",
+              "Inspection Workflow: Skipped State": "#e5ac0e",
+              "Inspection Workflow: Succeeded State": "#3f6833",
+              "Workflow Error": "#c15c17",
+              "Workflow Failed": "#bf1b00",
+              "Workflow Pending": "rgb(91, 95, 96)",
+              "Workflow Running": "#64b0c8",
+              "Workflow Succeeded": "#3f6833"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 85,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": false,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_5\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 5s",
+                "refId": "A",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_10\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 10s",
+                "refId": "C",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_30\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 30s",
+                "refId": "B",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_60\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 60s",
+                "refId": "D",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_120\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 120s",
+                "refId": "E",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_180\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 180s",
+                "refId": "F",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_300\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 300s",
+                "refId": "G",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_600\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 600s",
+                "refId": "H",
+                "step": 1800
+              },
+              {
+                "expr": "sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_900\"}) / sum(thoth_sli_weekly_stage{sli_type=\"component_latency\", metric_name=\"revsolver_workflows_latency_bucket_+Inf\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "< 900s",
+                "refId": "I",
+                "step": 1800
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Revsolver Workflow latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 3,
+                "format": "percentunit",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Workflow Latency",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 73,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_reporter_requests_gauge{env=\"$env\"} - thoth_reporter_reports_gauge{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{component}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Number of requests vs number of documents created on Ceph",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 89,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_reporter_requests_gauge{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "requests for {{component}}",
+                "refId": "B",
+                "step": 1200
+              },
+              {
+                "expr": "thoth_reporter_reports_gauge{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "reports for {{component}}",
+                "refId": "C",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Number of requests and documents created on Ceph",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "User API services quality",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {
+              "Failed adviser runs": "#bf1b00",
+              "Successfull adviser runs": "#3f6833"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 87,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_reporter_success_adviser_gauge{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Successfull adviser runs {{adviser_version}}",
+                "refId": "A",
+                "step": 1200
+              },
+              {
+                "expr": "thoth_reporter_failed_adviser_gauge{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Failed adviser runs {{adviser_version}}",
+                "refId": "B",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Adviser Statistics",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percent",
+                "label": null,
+                "logBase": 1,
+                "max": "100",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "Failed adviser runs": "#bf1b00",
+              "Successfull adviser runs": "#3f6833"
+            },
+            "bars": true,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "fill": 1,
+            "id": 88,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "thoth_reporter_failed_adviser_justifications_gauge{env=\"$env\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "adviser {{adviser_version}} failures % due to {{justification}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Adviser Failures Analysis",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percent",
+                "label": null,
+                "logBase": 1,
+                "max": "100",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "SLO",
+      "SLI",
+      "thoth"
+    ],
+    "templating": {
+      "list": [
+        {
+          "auto": true,
+          "auto_count": 30,
+          "auto_min": "10s",
+          "current": {
+            "text": "1h",
+            "value": "1h"
+          },
+          "hide": 0,
+          "label": null,
+          "name": "interval",
+          "options": [
+            {
+              "selected": false,
+              "text": "auto",
+              "value": "$__auto_interval"
+            },
+            {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": true,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            },
+            {
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "30d",
+              "value": "30d"
+            }
+          ],
+          "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+          "refresh": 2,
+          "type": "interval"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance",
+          "options": [
+            {
+              "selected": true,
+              "text": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": false,
+              "text": "workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80, workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance_metrics",
+          "options": [
+            {
+              "selected": false,
+              "text": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": true,
+              "text": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "metrics-exporter-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80, metrics-exporter-thoth-infra-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "tags": [],
+            "text": "ocp4-stage",
+            "value": "ocp4-stage"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "env",
+          "options": [
+            {
+              "selected": false,
+              "text": "ocp4-test",
+              "value": "ocp4-test"
+            },
+            {
+              "selected": true,
+              "text": "ocp4-stage",
+              "value": "ocp4-stage"
+            }
+          ],
+          "query": "ocp4-test, ocp4-stage",
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Thoth SLI/SLO",
+    "version": 1
+  }

--- a/grafana-dashboard/ocp4-stage/thoth-workflow-controller.json
+++ b/grafana-dashboard/ocp4-stage/thoth-workflow-controller.json
@@ -1,0 +1,783 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": 196,
+    "links": [],
+    "refresh": "5m",
+    "rows": [
+      {
+        "collapse": false,
+        "height": 383,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "A count of all workflows currently accessible by the controller by status",
+            "fill": 1,
+            "id": 1,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_count{instance='$instance'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{status}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "count",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "A count of certain errors incurred by the controller",
+            "fill": 1,
+            "id": 5,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_error_count{instance='$instance'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{queue_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "error_count",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 292,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "The number of adds to the queue of workflows or cron workflows",
+            "fill": 1,
+            "id": 6,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_queue_adds_count{instance='$instance'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{queue_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "queue_adds_count",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "The depth of the queue of workflows or cron workflows to be processed by the controller",
+            "fill": 1,
+            "id": 8,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_queue_depth_count{instance='$instance'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{queue_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "queue_depth_count",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 343,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "Percentage of workflows that has queue latency below a certain threshold",
+            "fill": 1,
+            "id": 2,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "sort": null,
+              "sortDesc": null,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "argo_workflows_queue_latency_bucket{instance='$instance', queue_name=\"$queue_name\"} / ignoring(le) group_left argo_workflows_queue_latency_count{instance='$instance', queue_name=\"$queue_name\"}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "queue_latency: {{le}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Workflow queue latency [%]",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "cards": {
+              "cardPadding": null,
+              "cardRound": null
+            },
+            "color": {
+              "cardColor": "#b4ff00",
+              "colorScale": "sqrt",
+              "colorScheme": "interpolateYlOrRd",
+              "exponent": 0.5,
+              "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "datasource": "Prometheus",
+            "description": "A histogram of durations of operations",
+            "heatmap": {},
+            "highlightCards": true,
+            "id": 4,
+            "legend": {
+              "show": true
+            },
+            "links": [],
+            "span": 6,
+            "targets": [
+              {
+                "expr": "argo_workflows_operation_duration_seconds_bucket{instance='$instance'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{queue_name}}",
+                "refId": "A",
+                "step": 1200
+              }
+            ],
+            "title": "operation_duration_seconds",
+            "tooltip": {
+              "show": true,
+              "showHistogram": true
+            },
+            "type": "heatmap",
+            "xAxis": {
+              "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+              "decimals": null,
+              "format": "dtdurations",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true,
+              "splitFactor": null
+            },
+            "yBucketNumber": null,
+            "yBucketSize": null
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 330,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "description": "Total number of bytes currently allocated in go",
+            "fill": 1,
+            "id": 7,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": true,
+              "hideEmpty": false,
+              "max": true,
+              "min": true,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "go_memstats_alloc_bytes{instance='$instance'}",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Allocated Bytes",
+                "refId": "B",
+                "step": 600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Allocated Go Bytes",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "decbytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "argo",
+      "workflow-controller",
+      "thoth"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "tags": [],
+            "text": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80",
+            "value": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance",
+          "options": [
+            {
+              "selected": false,
+              "text": "workflow-controller-metrics-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "workflow-controller-metrics-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": true,
+              "text": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80"
+            },
+            {
+              "selected": false,
+              "text": "workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80",
+              "value": "workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80"
+            }
+          ],
+          "query": "workflow-controller-metrics-thoth-test-core.apps.ocp4.prod.psi.redhat.com:80,  workflow-controller-metrics-thoth-middletier-stage.apps.ocp4.prod.psi.redhat.com:80, workflow-controller-metrics-thoth-backend-stage.apps.ocp4.prod.psi.redhat.com:80",
+          "type": "custom"
+        },
+        {
+          "auto": true,
+          "auto_count": 30,
+          "auto_min": "10s",
+          "current": {
+            "text": "auto",
+            "value": "$__auto_interval"
+          },
+          "hide": 0,
+          "label": null,
+          "name": "interval",
+          "options": [
+            {
+              "selected": true,
+              "text": "auto",
+              "value": "$__auto_interval"
+            },
+            {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            },
+            {
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "30d",
+              "value": "30d"
+            }
+          ],
+          "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+          "refresh": 2,
+          "type": "interval"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": "workflow_queue",
+            "value": "workflow_queue"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "queue_name",
+          "options": [
+            {
+              "selected": false,
+              "text": "cron_wf_queue",
+              "value": "cron_wf_queue"
+            },
+            {
+              "selected": false,
+              "text": "pod_queue",
+              "value": "pod_queue"
+            },
+            {
+              "selected": false,
+              "text": "wf_cron_queue",
+              "value": "wf_cron_queue"
+            },
+            {
+              "selected": true,
+              "text": "workflow_queue",
+              "value": "workflow_queue"
+            }
+          ],
+          "query": "cron_wf_queue,pod_queue,wf_cron_queue,workflow_queue",
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Thoth Workflow Controllers",
+    "version": 1
+  }


### PR DESCRIPTION
Persist the grafana dashboard for stage cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2455

## Description

The grafana dashboard has already been uploaded to the grafana.
This is to persist the dashboard for the long term.