### PR TITLE
Upgrade workflow helper image version to v0.9.15

### DIFF
--- a/core/overlays/moc-prod/common/imagestreamtags.yaml
+++ b/core/overlays/moc-prod/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.14
+        name: quay.io/thoth-station/workflow-helpers:v0.9.15
       importPolicy: {}
       referencePolicy:
         type: Local

--- a/core/overlays/ocp4-stage/common/imagestreamtags.yaml
+++ b/core/overlays/ocp4-stage/common/imagestreamtags.yaml
@@ -21,7 +21,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/workflow-helpers:v0.9.14
+        name: quay.io/thoth-station/workflow-helpers:v0.9.15
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
Upgrade workflow helper image version to v0.9.15
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


## Related Issues and Dependencies

Required-for: #2702 
