### PR TITLE
Disable pulp index sync job for temporary fix

### DIFF
--- a/pulp-pypi-sync-job/overlays/ocp4-stage/cronjob.yaml
+++ b/pulp-pypi-sync-job/overlays/ocp4-stage/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: pulp-pypi-sync-job
 spec:
-  suspend: false
+  suspend: true


### PR DESCRIPTION
Disable pulp index sync job for temporary fix
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #2711 
