### PR TITLE
Upgrade management-api in prod to get storage v0.73.6 changes

### DIFF
--- a/management-api/overlays/moc-prod/imagestreamtag.yaml
+++ b/management-api/overlays/moc-prod/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/management-api:v0.18.9
+      name: quay.io/thoth-station/management-api:v0.18.10
     importPolicy: {}
     referencePolicy:
       type: Local


### PR DESCRIPTION
Upgrade management-api in prod to get storage v0.73.6 changes
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/management-api/commit/d2603b12324f6f9bb332bd49db9c819e9c390826

