### PR TITLE
:ship: Bump up version of the updated component in release v2022.12.05

### DIFF
--- a/cve-update/overlays/moc-prod/imagestreamtag.yaml
+++ b/cve-update/overlays/moc-prod/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.5.5
+        name: quay.io/thoth-station/cve-update-job:v0.5.6
       importPolicy: {}

--- a/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
+++ b/cve-update/overlays/ocp4-stage/imagestreamtag.yaml
@@ -7,5 +7,5 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: quay.io/thoth-station/cve-update-job:v0.5.5
+        name: quay.io/thoth-station/cve-update-job:v0.5.6
       importPolicy: {}


### PR DESCRIPTION
Bump up version of the updated component in release v2022.12.05
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/2700
