### PR TITLE
Suspend prescription refresh execution

### DIFF
--- a/prescriptions-refresh-job/overlays/ocp4-stage/cronworkflow.yaml
+++ b/prescriptions-refresh-job/overlays/ocp4-stage/cronworkflow.yaml
@@ -4,39 +4,39 @@ kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-gh
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-image-analysis
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-pg
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-pypi
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-quay
 spec:
-  suspend: false
+  suspend: true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
   name: prescriptions-refresh-scorecards
 spec:
-  suspend: false
+  suspend: true


### PR DESCRIPTION
## Related Issues and Dependencies

Currently open PRs in the prescriptions repository

## Description

<!--- Describe your changes in detail -->

This is to temporarily stop the prescription refresh jobs.

While looking at the last execution of the job and the generated PRs I found out that current prescriptions seem to fail validation.

Pausing the job (meant to execute later today) until we clarify this.