### PR TITLE
:face_in_clouds: Remove unused env var in graph-sync job

### DIFF
--- a/graph-sync/base/argo-workflows/sync-template.yaml
+++ b/graph-sync/base/argo-workflows/sync-template.yaml
@@ -40,11 +40,6 @@ spec:
               configMapKeyRef:
                 name: thoth
                 key: logging-no-json
-          - name: AMUN_API_URL
-            valueFrom:
-              configMapKeyRef:
-                key: amun-api-url
-                name: thoth
           - name: THOTH_S3_ENDPOINT_URL
             valueFrom:
               configMapKeyRef:
@@ -145,11 +140,6 @@ spec:
               configMapKeyRef:
                 name: thoth
                 key: logging-no-json
-          - name: AMUN_API_URL
-            valueFrom:
-              configMapKeyRef:
-                key: amun-api-url
-                name: thoth
           - name: THOTH_S3_ENDPOINT_URL
             valueFrom:
               configMapKeyRef:

--- a/graph-sync/base/openshift-templates/syncJob-template.yaml
+++ b/graph-sync/base/openshift-templates/syncJob-template.yaml
@@ -120,11 +120,6 @@ objects:
                     configMapKeyRef:
                       name: thoth
                       key: logging-no-json
-                - name: AMUN_API_URL
-                  valueFrom:
-                    configMapKeyRef:
-                      key: amun-api-url
-                      name: thoth
                 - name: THOTH_S3_ENDPOINT_URL
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
Remove unused env var in graph-sync job
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/graph-sync-job/pull/678

