### PR TITLE
:play_or_pause_button: Resume graph-refresh-job for data ingestion

### DIFF
--- a/graph-refresh/overlays/ocp4-stage/cronjob.yaml
+++ b/graph-refresh/overlays/ocp4-stage/cronjob.yaml
@@ -4,4 +4,4 @@ apiVersion: batch/v1beta1
 metadata:
   name: graph-refresh
 spec:
-  suspend: true
+  suspend: false


### PR DESCRIPTION
Resume graph-refresh-job for data ingestion
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #2720 

## Description

The unresolved message queue in kafka is now stable.
Resuming the graph-refresh-job would enable the functionality of populating the message queue again.