### PR TITLE
:sleeping: Slow down the daily jobs to monthly on stage cluster

### DIFF
--- a/graph-backup-job/base/cronjob.yaml
+++ b/graph-backup-job/base/cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: thoth
     component: graph-backup
 spec:
-  schedule: "@daily"
+  schedule: "@monthly"
   suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1

--- a/graph-metrics-exporter/base/cronjob.yaml
+++ b/graph-metrics-exporter/base/cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: thoth
     component: graph-metrics-exporter
 spec:
-  schedule: "@hourly"
+  schedule: "@monthly"
   suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1

--- a/graph-refresh/base/cronjob.yaml
+++ b/graph-refresh/base/cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: thoth
     component: graph-refresh
 spec:
-  schedule: "*/40 * * * *"
+  schedule: "@hourly"
   suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2

--- a/integration-tests/base/cronjob.yaml
+++ b/integration-tests/base/cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: thoth
     component: integration-tests
 spec:
-  schedule: "@daily"
+  schedule: "@monthly"
   suspend: true
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 4


### PR DESCRIPTION
:sleeping: Slow down the daily jobs to monthly on-stage cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

- slow down the daily jobs to monthly 
- push back graph-refresh-job to hourly