### PR TITLE
:sleeping: Hibernate the data-ingestion jobs on smaug cluster

### DIFF
--- a/advise-reporter/overlays/moc-prod/cronjob.yaml
+++ b/advise-reporter/overlays/moc-prod/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: advise-reporter
 spec:
   schedule: "0 2 * * *"
-  suspend: false
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4

--- a/cve-update/overlays/moc-prod/cronjob.yaml
+++ b/cve-update/overlays/moc-prod/cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     component: cve-update
 spec:
   schedule: "@daily"
-  suspend: false
+  suspend: true
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 4
   concurrencyPolicy: Forbid

--- a/integration-tests/overlays/moc-prod-ocp4-stage/cronjob.yaml
+++ b/integration-tests/overlays/moc-prod-ocp4-stage/cronjob.yaml
@@ -7,4 +7,4 @@ metadata:
     app: thoth
     component: integration-tests
 spec:
-  suspend: false
+  suspend: true

--- a/mi-scheduler/overlays/moc-prod/cronjob.yaml
+++ b/mi-scheduler/overlays/moc-prod/cronjob.yaml
@@ -4,18 +4,18 @@ apiVersion: batch/v1beta1
 metadata:
   name: mi-scheduler-gh
 spec:
-  suspend: false
+  suspend: true
 ---
 kind: CronJob
 apiVersion: batch/v1beta1
 metadata:
   name: mi-scheduler-kebechet-analyse
 spec:
-  suspend: false
+  suspend: true
 ---
 kind: CronJob
 apiVersion: batch/v1beta1
 metadata:
   name: mi-scheduler-kebechet-merge
 spec:
-  suspend: false
+  suspend: true

--- a/slo-reporter/overlays/moc-prod-ocp4-stage/cronjob.yaml
+++ b/slo-reporter/overlays/moc-prod-ocp4-stage/cronjob.yaml
@@ -5,4 +5,4 @@ metadata:
   name: slo-reporter
 spec:
   schedule: "0 6 * * *"
-  suspend: false
+  suspend: true


### PR DESCRIPTION
:sleeping: Hibernate the data-ingestion jobs on smaug cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description

As part of hibernation, only data-ingestion components in smaug
smaug would be used mainly for data services only.