### PR TITLE
Upgrade DB pvc as it filled up

### DIFF
--- a/core/overlays/ocp4-stage/graph-stage/postgresql.yaml
+++ b/core/overlays/ocp4-stage/graph-stage/postgresql.yaml
@@ -28,7 +28,7 @@ items:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 96Gi
+          storage: 120Gi
       storageClassName: standard
       volumeMode: Filesystem
   - apiVersion: apps.openshift.io/v1


### PR DESCRIPTION
Upgrade DB pvc as it filled up

## Related Issues and Dependencies

![Screenshot from 2023-04-17 19-12-51](https://user-images.githubusercontent.com/14028058/232629778-d4dffbde-6ca7-4fe9-9847-66ba3fbbda8e.png)

The DB pods are in `crashlooping` stage, as the PVC is filled up and not connecting.

## Does this require new deployment ?

- [ ] Deployment for Test and Stage `AICoE/aicoe-cd` and Prod `operate-first/argocd-apps`.

## Description


This would increase the size of the PVC and fix the pod.